### PR TITLE
Add database-backed Spotify playlist endpoints

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -1,13 +1,54 @@
-from sqlalchemy import Column, Integer, String
+"""SQLAlchemy models used by the Harmony backend."""
+
+from sqlalchemy import Column, ForeignKey, Integer, String
+from sqlalchemy.orm import relationship
 
 from app.db import Base
 
 
 class Song(Base):
+    """Represents an individual song stored in the database."""
+
     __tablename__ = "songs"
 
     id = Column(Integer, primary_key=True, index=True)
-    title = Column(String, index=True)
-    artist = Column(String, index=True)
-    album = Column(String, index=True)
-    path = Column(String)
+    title = Column(String, index=True, nullable=False)
+    artist = Column(String, index=True, nullable=False)
+    album = Column(String, index=True, nullable=False)
+    duration = Column(Integer, nullable=True)
+    source = Column(String, index=True, nullable=False, default="local")
+    spotify_id = Column(String, unique=True, nullable=True)
+
+    playlist_items = relationship(
+        "PlaylistItem", back_populates="song", cascade="all, delete-orphan"
+    )
+
+
+class Playlist(Base):
+    """A collection of songs grouped under a user-defined playlist."""
+
+    __tablename__ = "playlists"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String, unique=True, nullable=False)
+
+    items = relationship(
+        "PlaylistItem",
+        back_populates="playlist",
+        cascade="all, delete-orphan",
+        order_by="PlaylistItem.order",
+    )
+
+
+class PlaylistItem(Base):
+    """Association table storing the order of songs within a playlist."""
+
+    __tablename__ = "playlist_items"
+
+    id = Column(Integer, primary_key=True, index=True)
+    playlist_id = Column(Integer, ForeignKey("playlists.id"), nullable=False)
+    song_id = Column(Integer, ForeignKey("songs.id"), nullable=False)
+    order = Column(Integer, nullable=False)
+
+    playlist = relationship("Playlist", back_populates="items")
+    song = relationship("Song", back_populates="playlist_items")

--- a/app/routers/spotify_router.py
+++ b/app/routers/spotify_router.py
@@ -104,7 +104,9 @@ def create_playlist(data: PlaylistCreate, db: Session = Depends(get_db)):
         )
 
         logger.info(
-            "Playlist '%s' created with %d songs", stored_playlist.name, len(data.tracks)
+            "Playlist '%s' mit %d Songs erstellt",
+            stored_playlist.name,
+            len(data.tracks),
         )
         return _playlist_to_schema(stored_playlist)
     except Exception as exc:  # pragma: no cover - defensive

--- a/app/routers/spotify_router.py
+++ b/app/routers/spotify_router.py
@@ -1,6 +1,15 @@
-from fastapi import APIRouter, HTTPException, Query
+"""Spotify API endpoints exposed by the Harmony backend."""
+
+from collections.abc import Sequence
+from typing import List
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel
+from sqlalchemy.orm import Session, selectinload
 
 from app.core.spotify_client import SpotifyClient
+from app.db import get_db
+from app.models import Playlist, PlaylistItem, Song
 from app.utils.logging_config import get_logger
 
 router = APIRouter()
@@ -8,8 +17,140 @@ logger = get_logger("spotify_router")
 client = SpotifyClient()
 
 
-@router.get("/playlists")
-async def get_playlists() -> dict:
+# ---------------------------------------------------------------------------
+# Pydantic Schemas
+# ---------------------------------------------------------------------------
+
+
+class SongCreate(BaseModel):
+    """Payload schema for songs provided when creating a playlist."""
+
+    title: str
+    artist: str
+    album: str
+    duration: int | None = None
+    spotify_id: str | None = None
+
+
+class SongOut(BaseModel):
+    """Represents a song returned to the client."""
+
+    id: int
+    title: str
+    artist: str
+    album: str
+    duration: int | None
+    source: str
+
+    class Config:
+        orm_mode = True
+
+
+class PlaylistCreate(BaseModel):
+    """Payload schema for creating playlists including their tracks."""
+
+    name: str
+    tracks: List[SongCreate]
+
+
+class PlaylistOut(BaseModel):
+    """Playlist representation returned to API consumers."""
+
+    id: int
+    name: str
+    songs: List[SongOut]
+
+    class Config:
+        orm_mode = True
+
+
+# ---------------------------------------------------------------------------
+# Database-backed endpoints
+# ---------------------------------------------------------------------------
+
+
+def _playlist_to_schema(playlist: Playlist) -> PlaylistOut:
+    return PlaylistOut(
+        id=playlist.id,
+        name=playlist.name,
+        songs=[SongOut.from_orm(item.song) for item in playlist.items],
+    )
+
+
+@router.post("/playlist", response_model=PlaylistOut)
+def create_playlist(data: PlaylistCreate, db: Session = Depends(get_db)):
+    """Create a Spotify playlist in the database including all songs."""
+
+    try:
+        playlist = Playlist(name=data.name)
+
+        for index, track in enumerate(data.tracks, start=1):
+            song = Song(
+                title=track.title,
+                artist=track.artist,
+                album=track.album,
+                duration=track.duration,
+                source="spotify",
+                spotify_id=track.spotify_id,
+            )
+            playlist.items.append(PlaylistItem(song=song, order=index))
+
+        db.add(playlist)
+        db.commit()
+
+        stored_playlist = (
+            db.query(Playlist)
+            .options(selectinload(Playlist.items).selectinload(PlaylistItem.song))
+            .filter(Playlist.id == playlist.id)
+            .one()
+        )
+
+        logger.info(
+            "Playlist '%s' created with %d songs", stored_playlist.name, len(data.tracks)
+        )
+        return _playlist_to_schema(stored_playlist)
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.error("Failed to create playlist: %s", exc)
+        db.rollback()
+        raise HTTPException(
+            status_code=500, detail="Fehler beim Anlegen der Playlist"
+        ) from exc
+
+
+@router.get("/playlists", response_model=List[PlaylistOut])
+def list_playlists(db: Session = Depends(get_db)):
+    """Return all stored playlists with their songs."""
+
+    playlists: Sequence[Playlist] = (
+        db.query(Playlist)
+        .options(selectinload(Playlist.items).selectinload(PlaylistItem.song))
+        .all()
+    )
+    return [_playlist_to_schema(pl) for pl in playlists]
+
+
+@router.get("/songs", response_model=List[SongOut])
+def list_songs(db: Session = Depends(get_db)):
+    """Return all songs imported from Spotify."""
+
+    songs: Sequence[Song] = (
+        db.query(Song)
+        .filter(Song.source == "spotify")
+        .order_by(Song.id)
+        .all()
+    )
+    return [SongOut.from_orm(song) for song in songs]
+
+
+# ---------------------------------------------------------------------------
+# Spotify client passthrough endpoints used by the prototype UI
+# ---------------------------------------------------------------------------
+
+
+@router.get("/playlists/metadata")
+async def get_playlists_metadata() -> dict:
+    """Return static playlist metadata from the in-memory Spotify client."""
+
     try:
         playlists = client.get_user_playlists_metadata_only()
         return {"playlists": [playlist.__dict__ for playlist in playlists]}
@@ -20,6 +161,8 @@ async def get_playlists() -> dict:
 
 @router.get("/search")
 async def search_tracks(query: str = Query(...)) -> dict:
+    """Search the in-memory Spotify client for tracks matching the query."""
+
     try:
         results = client.search_tracks(query)
         return {"tracks": [track.__dict__ for track in results]}


### PR DESCRIPTION
## Summary
- expand the SQLAlchemy models to include playlists, playlist items, and extended song metadata
- add CRUD-style Spotify playlist endpoints backed by the database while keeping existing search support
- expose helper schemas for playlist creation and retrieval responses

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d092c75ee08321aeaf47d65435bf25