### PR TITLE
Enhance Soulseek search response serialization

### DIFF
--- a/app/routers/soulseek_router.py
+++ b/app/routers/soulseek_router.py
@@ -1,25 +1,47 @@
+from dataclasses import asdict
+from typing import Any, Dict, List
+
 from fastapi import APIRouter, HTTPException, Query
 
-from app.core.soulseek_client import SoulseekClient
+from app.core.soulseek_client import SoulseekClient, TrackResult
 from app.utils.logging_config import get_logger
 
 
-router = APIRouter()
 logger = get_logger("soulseek_router")
+router = APIRouter()
 client = SoulseekClient()
+
+
+def _serialise_tracks(tracks: List[TrackResult]) -> List[Dict[str, Any]]:
+    """Convert dataclass track results into dictionaries for the API response."""
+
+    return [asdict(track) for track in tracks]
+
+
+async def _search_tracks_internal(query: str, timeout: int) -> Dict[str, Any]:
+    try:
+        tracks = await client.search(query, timeout=timeout)
+        serialised = _serialise_tracks(tracks)
+        return {"results": serialised, "count": len(serialised)}
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.error("Search failed: %s", exc)
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
 
 
 @router.get("/search")
 async def search_tracks(
     query: str = Query(..., description="Track or artist to search"),
     timeout: int = Query(30, ge=5, le=60, description="Search timeout in seconds"),
-) -> dict:
-    try:
-        tracks = await client.search(query, timeout=timeout)
-        return {"results": [track.__dict__ for track in tracks], "count": len(tracks)}
-    except Exception as exc:  # pragma: no cover - defensive
-        logger.error("Search failed: %s", exc)
-        raise HTTPException(status_code=500, detail=str(exc)) from exc
+) -> Dict[str, Any]:
+    return await _search_tracks_internal(query, timeout)
+
+
+@router.get("/search/tracks")
+async def search_tracks_explicit(
+    query: str = Query(..., description="Track or artist to search"),
+    timeout: int = Query(30, ge=5, le=60, description="Search timeout in seconds"),
+) -> Dict[str, Any]:
+    return await _search_tracks_internal(query, timeout)
 
 
 @router.post("/download")
@@ -28,7 +50,7 @@ async def download(username: str, filename: str, size: int = 0) -> dict:
         started = await client.download(username, filename, size)
         if not started:
             raise HTTPException(status_code=502, detail="Failed to schedule download")
-        return {"status": "started"}
+        return {"status": "started", "filename": filename}
     except HTTPException:
         raise
     except Exception as exc:  # pragma: no cover - defensive


### PR DESCRIPTION
## Summary
- share Soulseek search serialization through a helper to avoid duplicating dataclass to dict conversion
- expose both /search and /search/tracks endpoints via the shared helper while enriching the download response with the requested filename

## Testing
- PYTHONPATH=. pytest tests/test_beets_router.py

------
https://chatgpt.com/codex/tasks/task_e_68d09cd12674832191e407a0442a12d3