### PR TITLE
Enhance matching router with track and album endpoints

### DIFF
--- a/app/core/matching_engine.py
+++ b/app/core/matching_engine.py
@@ -2,31 +2,87 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from difflib import SequenceMatcher
-from typing import Iterable, Optional
+from typing import Dict, Iterable, Optional, Tuple
 
 from app.core.plex_client import PlexTrackInfo
-from app.core.spotify_client import Track
+from app.core.spotify_client import Album, Track
+
+
+MATCH_THRESHOLD = 0.7
+ALBUM_MATCH_THRESHOLD = 0.6
 
 
 @dataclass
 class MatchResult:
-    plex_track: PlexTrackInfo
-    score: float
+    plex_track: Optional[PlexTrackInfo]
+    confidence: float
+    match_type: str
+    is_match: bool
 
 
 class MusicMatchingEngine:
     """Naive matching engine comparing Spotify and Plex tracks."""
 
-    def score(self, spotify_track: Track, plex_track: PlexTrackInfo) -> float:
+    def _score_track(self, spotify_track: Track, plex_track: PlexTrackInfo) -> float:
         title_ratio = SequenceMatcher(None, spotify_track.title.lower(), plex_track.title.lower()).ratio()
         artist_ratio = SequenceMatcher(None, spotify_track.artist.lower(), plex_track.artist.lower()).ratio()
         album_ratio = SequenceMatcher(None, (spotify_track.album or "").lower(), (plex_track.album or "").lower()).ratio()
         return (title_ratio * 0.5) + (artist_ratio * 0.4) + (album_ratio * 0.1)
 
-    def find_best_match(self, spotify_track: Track, plex_candidates: Iterable[PlexTrackInfo]) -> Optional[MatchResult]:
-        best_result: Optional[MatchResult] = None
+    def _match_type(self, spotify_track: Track, plex_track: Optional[PlexTrackInfo], score: float) -> str:
+        if plex_track is None:
+            return "no_match"
+
+        if (
+            spotify_track.title.lower() == plex_track.title.lower()
+            and spotify_track.artist.lower() == plex_track.artist.lower()
+        ):
+            return "exact"
+
+        if spotify_track.artist.lower() == plex_track.artist.lower():
+            if spotify_track.album and plex_track.album and spotify_track.album.lower() == plex_track.album.lower():
+                return "artist_album"
+            return "artist"
+
+        if spotify_track.album and plex_track.album and spotify_track.album.lower() == plex_track.album.lower():
+            return "album"
+
+        return "fuzzy" if score >= MATCH_THRESHOLD else "low_confidence"
+
+    def find_best_match(self, spotify_track: Track, plex_candidates: Iterable[PlexTrackInfo]) -> MatchResult:
+        best_track: Optional[PlexTrackInfo] = None
+        best_score = 0.0
         for candidate in plex_candidates:
-            current_score = self.score(spotify_track, candidate)
-            if not best_result or current_score > best_result.score:
-                best_result = MatchResult(plex_track=candidate, score=current_score)
-        return best_result
+            current_score = self._score_track(spotify_track, candidate)
+            if current_score > best_score:
+                best_score = current_score
+                best_track = candidate
+
+        match_type = self._match_type(spotify_track, best_track, best_score)
+        return MatchResult(
+            plex_track=best_track,
+            confidence=best_score,
+            match_type=match_type,
+            is_match=best_track is not None and best_score >= MATCH_THRESHOLD,
+        )
+
+    def _score_album(self, spotify_album: Album, plex_album: Dict[str, object]) -> float:
+        title_ratio = SequenceMatcher(None, spotify_album.title.lower(), str(plex_album.get("title", "")).lower()).ratio()
+        artist_ratio = SequenceMatcher(None, spotify_album.artist.lower(), str(plex_album.get("artist", "")).lower()).ratio()
+        return (title_ratio * 0.6) + (artist_ratio * 0.4)
+
+    def find_best_album_match(
+        self, spotify_album: Album, plex_albums: Iterable[Dict[str, object]]
+    ) -> Tuple[Optional[Dict[str, object]], float]:
+        best_album: Optional[Dict[str, object]] = None
+        best_score = 0.0
+        for candidate in plex_albums:
+            current_score = self._score_album(spotify_album, candidate)
+            if current_score > best_score:
+                best_score = current_score
+                best_album = candidate
+
+        if best_score < ALBUM_MATCH_THRESHOLD:
+            return None, best_score
+
+        return best_album, best_score

--- a/app/core/plex_client.py
+++ b/app/core/plex_client.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import List
+from typing import Dict, List, Tuple
 
 
 @dataclass
@@ -10,21 +10,89 @@ class PlexTrackInfo:
     artist: str
     album: str
     rating_key: str
+    duration: int | None = None
+    year: int | None = None
+
+
+@dataclass
+class PlexAlbumInfo:
+    title: str
+    artist: str
+    year: int | None
+    track_count: int
 
 
 class PlexClient:
     """Simplified Plex client using in-memory data."""
 
     def __init__(self) -> None:
+        self._connected = True
+        self._libraries: List[str] = ["Music"]
         self._tracks: List[PlexTrackInfo] = [
-            PlexTrackInfo(title="Song One", artist="Artist A", album="Album X", rating_key="t1"),
-            PlexTrackInfo(title="Song Two", artist="Artist B", album="Album Y", rating_key="t2"),
-            PlexTrackInfo(title="Unrelated", artist="Different", album="Other", rating_key="t3"),
+            PlexTrackInfo(
+                title="Song One",
+                artist="Artist A",
+                album="Album X",
+                rating_key="t1",
+                duration=210,
+                year=2020,
+            ),
+            PlexTrackInfo(
+                title="Song Two",
+                artist="Artist B",
+                album="Album Y",
+                rating_key="t2",
+                duration=198,
+                year=2019,
+            ),
+            PlexTrackInfo(
+                title="Unrelated",
+                artist="Different",
+                album="Other",
+                rating_key="t3",
+                duration=250,
+                year=None,
+            ),
         ]
+
+        album_map: Dict[Tuple[str, str], PlexAlbumInfo] = {}
+        for track in self._tracks:
+            key = (track.album, track.artist)
+            album = album_map.get(key)
+            if album is None:
+                album_map[key] = PlexAlbumInfo(
+                    title=track.album,
+                    artist=track.artist,
+                    year=track.year,
+                    track_count=1,
+                )
+            else:
+                album.track_count += 1
+                if album.year is None and track.year is not None:
+                    album.year = track.year
+        self._albums: List[PlexAlbumInfo] = list(album_map.values())
+
+    def is_connected(self) -> bool:
+        return self._connected
+
+    def list_libraries(self) -> List[str]:
+        return list(self._libraries)
 
     def get_all_artists(self) -> List[str]:
         return sorted({track.artist for track in self._tracks})
 
     def search_tracks(self, query: str) -> List[PlexTrackInfo]:
         normalized = query.lower()
-        return [track for track in self._tracks if normalized in track.title.lower()]
+        return [
+            track
+            for track in self._tracks
+            if normalized in track.title.lower() or normalized in track.artist.lower()
+        ]
+
+    def search_albums(self, query: str) -> List[PlexAlbumInfo]:
+        normalized = query.lower()
+        return [
+            album
+            for album in self._albums
+            if normalized in album.title.lower() or normalized in album.artist.lower()
+        ]

--- a/app/core/spotify_client.py
+++ b/app/core/spotify_client.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Iterable, List
+from typing import Iterable, List, Optional
 
 
 @dataclass
@@ -15,6 +15,26 @@ class Album:
     id: str
     title: str
     artist: str
+    year: Optional[int] = None
+
+    @classmethod
+    def from_spotify_album(cls, data: dict) -> "Album":
+        album_info = data.get("album", {})
+        album_name = album_info.get("name") if isinstance(album_info, dict) else data.get("name", "")
+        artists = data.get("artists", [])
+        if artists and isinstance(artists[0], dict):
+            artist_name = artists[0].get("name", "")
+        elif artists:
+            artist_name = artists[0]
+        else:
+            artist_name = data.get("artist", "")
+
+        return cls(
+            id=data.get("id", ""),
+            title=album_name,
+            artist=artist_name,
+            year=data.get("release_year"),
+        )
 
 
 @dataclass
@@ -24,15 +44,38 @@ class Track:
     artist: str
     album: str
     duration_ms: int
+    album_id: Optional[str] = None
 
     @classmethod
     def from_spotify_track(cls, data: dict) -> "Track":
+        album_data = data.get("album") or data.get("album_name", "")
+        if isinstance(album_data, dict):
+            album_name = album_data.get("name", "")
+            album_id = album_data.get("id")
+        else:
+            album_name = album_data or ""
+            album_id = None
+
+        artists = data.get("artists")
+        if isinstance(artists, list):
+            if artists and isinstance(artists[0], dict):
+                artist_name = artists[0].get("name", "")
+            elif artists:
+                artist_name = artists[0]
+            else:
+                artist_name = ""
+        elif isinstance(artists, dict):
+            artist_name = artists.get("name", "")
+        else:
+            artist_name = data.get("artist", "")
+
         return cls(
             id=data.get("id", ""),
             title=data.get("title") or data.get("name", ""),
-            artist=data.get("artist") or data.get("artists", [{}])[0].get("name", ""),
-            album=data.get("album") or data.get("album_name", ""),
+            artist=artist_name,
+            album=album_name,
             duration_ms=int(data.get("duration_ms", 0)),
+            album_id=album_id,
         )
 
 
@@ -47,15 +90,56 @@ class SpotifyClient:
     """Simple in-memory Spotify client used for prototyping."""
 
     def __init__(self) -> None:
-        self._tracks: List[Track] = [
-            Track(id="1", title="Song One", artist="Artist A", album="Album X", duration_ms=210_000),
-            Track(id="2", title="Song Two", artist="Artist B", album="Album Y", duration_ms=180_000),
-            Track(id="3", title="Another Song", artist="Artist A", album="Album Z", duration_ms=200_000),
+        self._authenticated = True
+        self._albums: List[dict] = [
+            {
+                "id": "alb1",
+                "name": "Album X",
+                "artists": [{"id": "artist-a", "name": "Artist A"}],
+                "release_year": 2020,
+            },
+            {
+                "id": "alb2",
+                "name": "Album Y",
+                "artists": [{"id": "artist-b", "name": "Artist B"}],
+                "release_year": 2019,
+            },
         ]
+        self._album_index = {album["id"]: album for album in self._albums}
+        self._tracks: List[Track] = [
+            Track(
+                id="1",
+                title="Song One",
+                artist="Artist A",
+                album="Album X",
+                duration_ms=210_000,
+                album_id="alb1",
+            ),
+            Track(
+                id="2",
+                title="Song Two",
+                artist="Artist B",
+                album="Album Y",
+                duration_ms=180_000,
+                album_id="alb2",
+            ),
+            Track(
+                id="3",
+                title="Another Song",
+                artist="Artist A",
+                album="Album X",
+                duration_ms=200_000,
+                album_id="alb1",
+            ),
+        ]
+        self._track_index = {track.id: track for track in self._tracks}
         self._playlists: List[Playlist] = [
             Playlist(id="p1", name="Favorites", track_count=15),
             Playlist(id="p2", name="Chill", track_count=24),
         ]
+
+    def is_authenticated(self) -> bool:
+        return self._authenticated
 
     def get_user_playlists_metadata_only(self) -> List[Playlist]:
         return list(self._playlists)
@@ -68,3 +152,35 @@ class SpotifyClient:
         normalized = artist_name.lower()
         albums = {track.album for track in self._tracks if track.artist.lower() == normalized}
         return [Album(id=f"album-{i}", title=title, artist=artist_name) for i, title in enumerate(albums)]
+
+    def get_track_details(self, track_id: str) -> Optional[dict]:
+        track = self._track_index.get(track_id)
+        if track is None:
+            return None
+
+        album_data = self._album_index.get(track.album_id, {})
+        raw_data = {
+            "id": track.id,
+            "name": track.title,
+            "artists": [{"name": track.artist}],
+            "album": {
+                "id": album_data.get("id"),
+                "name": album_data.get("name", track.album),
+            },
+            "duration_ms": track.duration_ms,
+        }
+
+        return {
+            "id": track.id,
+            "name": track.title,
+            "artists": [track.artist],
+            "album": track.album,
+            "duration_ms": track.duration_ms,
+            "raw_data": raw_data,
+        }
+
+    def get_album(self, album_id: str) -> Optional[dict]:
+        album = self._album_index.get(album_id)
+        if album is None:
+            return None
+        return album.copy()

--- a/app/routers/matching_router.py
+++ b/app/routers/matching_router.py
@@ -1,25 +1,110 @@
 from typing import List
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Query
+from pydantic import BaseModel
 
-from app.core.matching_engine import MusicMatchingEngine
+from app.core.matching_engine import MatchResult, MusicMatchingEngine
+from app.core.plex_client import PlexClient
+from app.core.spotify_client import Album, SpotifyClient, Track
 from app.utils.logging_config import get_logger
 
-router = APIRouter()
 logger = get_logger("matching_router")
+router = APIRouter()
 engine = MusicMatchingEngine()
+spotify_client = SpotifyClient()
+plex_client = PlexClient()
 
 
-@router.post("/match")
-async def match_track(spotify_track: dict, plex_candidates: List[dict]) -> dict:
+class TrackMatch(BaseModel):
+    spotify_title: str
+    spotify_artists: List[str]
+    plex_title: str
+    plex_artist: str
+    confidence: float
+    match_type: str
+    is_match: bool
+
+
+class AlbumMatch(BaseModel):
+    spotify_album: str
+    spotify_artist: str
+    plex_album: str
+    plex_artist: str
+    confidence: float
+
+
+@router.get("/track", response_model=TrackMatch)
+async def match_track(spotify_track_id: str = Query(..., min_length=5)) -> TrackMatch:
+    """Match a Spotify track to the best Plex library candidate."""
+
     try:
-        from app.core.spotify_client import Track
-        from app.core.plex_client import PlexTrackInfo
+        if not spotify_client.is_authenticated():
+            raise HTTPException(status_code=401, detail="Spotify not authenticated")
 
-        spotify_obj = Track.from_spotify_track(spotify_track)
-        plex_objs = [PlexTrackInfo(**candidate) for candidate in plex_candidates]
-        match = engine.find_best_match(spotify_obj, plex_objs)
-        return {"match": match.__dict__ if match else None}
+        spotify_track = spotify_client.get_track_details(spotify_track_id)
+        if not spotify_track:
+            raise HTTPException(status_code=404, detail="Spotify track not found")
+
+        candidates = plex_client.search_tracks(spotify_track["name"])
+        if not candidates:
+            raise HTTPException(status_code=404, detail="No Plex candidates found")
+
+        result: MatchResult = engine.find_best_match(
+            Track.from_spotify_track(spotify_track["raw_data"]),
+            candidates,
+        )
+
+        return TrackMatch(
+            spotify_title=spotify_track["name"],
+            spotify_artists=spotify_track["artists"],
+            plex_title=result.plex_track.title if result.plex_track else "",
+            plex_artist=result.plex_track.artist if result.plex_track else "",
+            confidence=result.confidence,
+            match_type=result.match_type,
+            is_match=result.is_match,
+        )
+
+    except HTTPException:
+        raise
     except Exception as exc:  # pragma: no cover - defensive
-        logger.error("Matching failed: %s", exc)
+        logger.error("Track matching failed: %s", exc, exc_info=exc)
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+
+@router.get("/album", response_model=AlbumMatch)
+async def match_album(spotify_album_id: str = Query(..., min_length=5)) -> AlbumMatch:
+    """Match a Spotify album to Plex album metadata."""
+
+    try:
+        if not spotify_client.is_authenticated():
+            raise HTTPException(status_code=401, detail="Spotify not authenticated")
+
+        spotify_album = spotify_client.get_album(spotify_album_id)
+        if not spotify_album:
+            raise HTTPException(status_code=404, detail="Spotify album not found")
+
+        plex_albums = plex_client.search_albums(spotify_album["name"])
+        if not plex_albums:
+            raise HTTPException(status_code=404, detail="No Plex albums found")
+
+        best_match, confidence = engine.find_best_album_match(
+            Album.from_spotify_album(spotify_album),
+            [album.__dict__ for album in plex_albums],
+        )
+
+        if not best_match:
+            raise HTTPException(status_code=404, detail="No confident match found")
+
+        return AlbumMatch(
+            spotify_album=spotify_album["name"],
+            spotify_artist=spotify_album["artists"][0]["name"],
+            plex_album=str(best_match.get("title", "")),
+            plex_artist=str(best_match.get("artist", "")),
+            confidence=confidence,
+        )
+
+    except HTTPException:
+        raise
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.error("Album matching failed: %s", exc, exc_info=exc)
         raise HTTPException(status_code=500, detail=str(exc)) from exc

--- a/app/routers/plex_router.py
+++ b/app/routers/plex_router.py
@@ -1,17 +1,108 @@
-from fastapi import APIRouter, HTTPException
+from typing import List, Optional
+
+from fastapi import APIRouter, HTTPException, Query
+from pydantic import BaseModel
 
 from app.core.plex_client import PlexClient
 from app.utils.logging_config import get_logger
 
 router = APIRouter()
 logger = get_logger("plex_router")
-client = PlexClient()
+plex_client = PlexClient()
+
+
+class PlexLibraryResponse(BaseModel):
+    libraries: List[str]
+
+
+class PlexTrack(BaseModel):
+    title: str
+    artist: str
+    album: Optional[str]
+    duration: Optional[int]
+
+
+class PlexTrackResponse(BaseModel):
+    tracks: List[PlexTrack]
+
+
+class PlexAlbum(BaseModel):
+    title: str
+    artist: str
+    year: Optional[int]
+    track_count: int
+
+
+class PlexAlbumResponse(BaseModel):
+    albums: List[PlexAlbum]
+
+
+@router.get("/status")
+async def status() -> dict:
+    """Check if Plex client is connected and music library is available."""
+    try:
+        ok = plex_client.is_connected()
+        return {"plex_connected": ok}
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.error("Plex status check failed: %s", exc)
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+
+@router.get("/libraries", response_model=PlexLibraryResponse)
+async def list_libraries() -> PlexLibraryResponse:
+    """List available Plex libraries."""
+    try:
+        libs = plex_client.list_libraries()
+        return PlexLibraryResponse(libraries=libs)
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.error("Error fetching Plex libraries: %s", exc)
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+
+@router.get("/search/tracks", response_model=PlexTrackResponse)
+async def search_tracks(query: str = Query(..., min_length=2)) -> PlexTrackResponse:
+    """Search tracks in Plex music library."""
+    try:
+        results = plex_client.search_tracks(query)
+        tracks = [
+            PlexTrack(
+                title=result.title,
+                artist=result.artist,
+                album=getattr(result, "album", None),
+                duration=getattr(result, "duration", None),
+            )
+            for result in results
+        ]
+        return PlexTrackResponse(tracks=tracks)
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.error("Error searching Plex tracks: %s", exc)
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+
+@router.get("/search/albums", response_model=PlexAlbumResponse)
+async def search_albums(query: str = Query(..., min_length=2)) -> PlexAlbumResponse:
+    """Search albums in Plex music library."""
+    try:
+        results = plex_client.search_albums(query)
+        albums = [
+            PlexAlbum(
+                title=result.title,
+                artist=result.artist,
+                year=getattr(result, "year", None),
+                track_count=getattr(result, "track_count", 0),
+            )
+            for result in results
+        ]
+        return PlexAlbumResponse(albums=albums)
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.error("Error searching Plex albums: %s", exc)
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
 
 
 @router.get("/artists")
 async def get_artists() -> dict:
     try:
-        return {"artists": client.get_all_artists()}
+        return {"artists": plex_client.get_all_artists()}
     except Exception as exc:  # pragma: no cover - defensive
         logger.error("Failed to fetch artists: %s", exc)
         raise HTTPException(status_code=500, detail=str(exc)) from exc

--- a/app/routers/settings_router.py
+++ b/app/routers/settings_router.py
@@ -1,8 +1,75 @@
-from fastapi import APIRouter
+from __future__ import annotations
 
+import json
+import os
+from typing import Any, Dict
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+
+from app.utils.logging_config import get_logger
+
+logger = get_logger("settings_router")
 router = APIRouter()
 
+CONFIG_FILE = "config/config.json"
 
-@router.get("/ping")
-async def ping() -> dict:
-    return {"status": "ok", "message": "Settings router alive"}
+
+class SettingsUpdate(BaseModel):
+    key: str
+    value: Any
+
+
+def load_config() -> Dict[str, Any]:
+    """Load configuration from file."""
+    try:
+        if not os.path.exists(CONFIG_FILE):
+            logger.warning("Config file not found, creating default")
+            return {}
+        with open(CONFIG_FILE, "r", encoding="utf-8") as f:
+            return json.load(f)
+    except Exception as exc:  # pragma: no cover - defensive logging
+        logger.error("Failed to load config: %s", exc)
+        raise HTTPException(status_code=500, detail="Failed to load config") from exc
+
+
+def save_config(config: Dict[str, Any]) -> None:
+    """Save configuration to file."""
+    try:
+        os.makedirs(os.path.dirname(CONFIG_FILE), exist_ok=True)
+        with open(CONFIG_FILE, "w", encoding="utf-8") as f:
+            json.dump(config, f, indent=4)
+        logger.info("Configuration saved successfully")
+    except Exception as exc:  # pragma: no cover - defensive logging
+        logger.error("Failed to save config: %s", exc)
+        raise HTTPException(status_code=500, detail="Failed to save config") from exc
+
+
+@router.get("/config")
+def get_settings() -> Dict[str, Any]:
+    """Return the current configuration."""
+    config = load_config()
+    logger.info("System configuration retrieved")
+    return {"status": "success", "config": config}
+
+
+@router.post("/config")
+def update_settings(update: SettingsUpdate) -> Dict[str, Any]:
+    """Update a specific config key/value."""
+    config = load_config()
+    config[update.key] = update.value
+    save_config(config)
+    logger.info("Updated config: %s = %s", update.key, update.value)
+    return {"status": "success", "updated": {update.key: update.value}}
+
+
+@router.delete("/config/{key}")
+def delete_setting(key: str) -> Dict[str, Any]:
+    """Delete a config key from the configuration."""
+    config = load_config()
+    if key not in config:
+        raise HTTPException(status_code=404, detail=f"Config key '{key}' not found")
+    removed_value = config.pop(key)
+    save_config(config)
+    logger.info("Deleted config key: %s", key)
+    return {"status": "success", "removed": {key: removed_value}}

--- a/fastapi/__init__.py
+++ b/fastapi/__init__.py
@@ -14,6 +14,13 @@ class APIRouter:
     def __init__(self) -> None:
         self.routes: List[Tuple[str, str, Callable[..., Any]]] = []
 
+    def delete(self, path: str, **_kwargs: Any) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+        def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+            self.routes.append(("DELETE", path, func))
+            return func
+
+        return decorator
+
     def post(self, path: str, **_kwargs: Any) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
         def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
             self.routes.append(("POST", path, func))

--- a/tests/test_matching_router.py
+++ b/tests/test_matching_router.py
@@ -1,0 +1,285 @@
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+
+from app.core.matching_engine import MatchResult
+from app.routers import matching_router
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def test_match_track_success(monkeypatch):
+    match = MatchResult(
+        plex_track=SimpleNamespace(title="Song One", artist="Artist A", album="Album X"),
+        confidence=0.92,
+        match_type="exact",
+        is_match=True,
+    )
+
+    monkeypatch.setattr(
+        matching_router,
+        "spotify_client",
+        SimpleNamespace(
+            is_authenticated=lambda: True,
+            get_track_details=lambda _track_id: {
+                "id": "1",
+                "name": "Song One",
+                "artists": ["Artist A"],
+                "album": "Album X",
+                "raw_data": {
+                    "id": "1",
+                    "name": "Song One",
+                    "artists": [{"name": "Artist A"}],
+                    "album": {"id": "alb1", "name": "Album X"},
+                    "duration_ms": 210_000,
+                },
+            },
+        ),
+    )
+    monkeypatch.setattr(
+        matching_router,
+        "plex_client",
+        SimpleNamespace(search_tracks=lambda _query: [SimpleNamespace(title="Song One", artist="Artist A", album="Album X")]),
+    )
+    monkeypatch.setattr(
+        matching_router,
+        "engine",
+        SimpleNamespace(find_best_match=lambda _spotify, _candidates: match),
+    )
+
+    result = _run(matching_router.match_track("track1"))
+
+    assert result.spotify_title == "Song One"
+    assert result.plex_title == "Song One"
+    assert result.match_type == "exact"
+    assert result.is_match is True
+
+
+def test_match_track_not_authenticated(monkeypatch):
+    monkeypatch.setattr(
+        matching_router,
+        "spotify_client",
+        SimpleNamespace(is_authenticated=lambda: False),
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        _run(matching_router.match_track("track1"))
+
+    assert exc_info.value.status_code == 401
+
+
+def test_match_track_not_found(monkeypatch):
+    monkeypatch.setattr(
+        matching_router,
+        "spotify_client",
+        SimpleNamespace(is_authenticated=lambda: True, get_track_details=lambda _track_id: None),
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        _run(matching_router.match_track("track1"))
+
+    assert exc_info.value.status_code == 404
+    assert exc_info.value.detail == "Spotify track not found"
+
+
+def test_match_track_no_candidates(monkeypatch):
+    spotify = SimpleNamespace(
+        is_authenticated=lambda: True,
+        get_track_details=lambda _track_id: {
+            "id": "1",
+            "name": "Song One",
+            "artists": ["Artist A"],
+            "album": "Album X",
+            "raw_data": {
+                "id": "1",
+                "name": "Song One",
+                "artists": [{"name": "Artist A"}],
+                "album": {"id": "alb1", "name": "Album X"},
+                "duration_ms": 210_000,
+            },
+        },
+    )
+
+    monkeypatch.setattr(matching_router, "spotify_client", spotify)
+    monkeypatch.setattr(matching_router, "plex_client", SimpleNamespace(search_tracks=lambda _query: []))
+
+    with pytest.raises(HTTPException) as exc_info:
+        _run(matching_router.match_track("track1"))
+
+    assert exc_info.value.status_code == 404
+    assert exc_info.value.detail == "No Plex candidates found"
+
+
+def test_match_track_generic_error(monkeypatch):
+    spotify = SimpleNamespace(
+        is_authenticated=lambda: True,
+        get_track_details=lambda _track_id: {
+            "id": "1",
+            "name": "Song One",
+            "artists": ["Artist A"],
+            "album": "Album X",
+            "raw_data": {
+                "id": "1",
+                "name": "Song One",
+                "artists": [{"name": "Artist A"}],
+                "album": {"id": "alb1", "name": "Album X"},
+                "duration_ms": 210_000,
+            },
+        },
+    )
+    monkeypatch.setattr(matching_router, "spotify_client", spotify)
+    monkeypatch.setattr(
+        matching_router,
+        "plex_client",
+        SimpleNamespace(search_tracks=lambda _query: [SimpleNamespace(title="Song One", artist="Artist A", album="Album X")]),
+    )
+    monkeypatch.setattr(
+        matching_router,
+        "engine",
+        SimpleNamespace(find_best_match=lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("boom"))),
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        _run(matching_router.match_track("track1"))
+
+    assert exc_info.value.status_code == 500
+    assert exc_info.value.detail == "boom"
+
+
+def test_match_album_success(monkeypatch):
+    spotify_album = {
+        "id": "alb1",
+        "name": "Album X",
+        "artists": [{"name": "Artist A"}],
+        "release_year": 2020,
+    }
+    monkeypatch.setattr(
+        matching_router,
+        "spotify_client",
+        SimpleNamespace(is_authenticated=lambda: True, get_album=lambda _album_id: spotify_album),
+    )
+    monkeypatch.setattr(
+        matching_router,
+        "plex_client",
+        SimpleNamespace(search_albums=lambda _query: [SimpleNamespace(title="Album X", artist="Artist A")]),
+    )
+    monkeypatch.setattr(
+        matching_router,
+        "engine",
+        SimpleNamespace(find_best_album_match=lambda *_args, **_kwargs: ({"title": "Album X", "artist": "Artist A"}, 0.88)),
+    )
+
+    result = _run(matching_router.match_album("album1"))
+
+    assert result.spotify_album == "Album X"
+    assert result.plex_album == "Album X"
+    assert result.confidence == pytest.approx(0.88)
+
+
+def test_match_album_not_authenticated(monkeypatch):
+    monkeypatch.setattr(
+        matching_router,
+        "spotify_client",
+        SimpleNamespace(is_authenticated=lambda: False),
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        _run(matching_router.match_album("album1"))
+
+    assert exc_info.value.status_code == 401
+
+
+def test_match_album_not_found(monkeypatch):
+    monkeypatch.setattr(
+        matching_router,
+        "spotify_client",
+        SimpleNamespace(is_authenticated=lambda: True, get_album=lambda _album_id: None),
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        _run(matching_router.match_album("album1"))
+
+    assert exc_info.value.status_code == 404
+    assert exc_info.value.detail == "Spotify album not found"
+
+
+def test_match_album_no_plex_results(monkeypatch):
+    spotify_album = {
+        "id": "alb1",
+        "name": "Album X",
+        "artists": [{"name": "Artist A"}],
+    }
+    monkeypatch.setattr(
+        matching_router,
+        "spotify_client",
+        SimpleNamespace(is_authenticated=lambda: True, get_album=lambda _album_id: spotify_album),
+    )
+    monkeypatch.setattr(matching_router, "plex_client", SimpleNamespace(search_albums=lambda _query: []))
+
+    with pytest.raises(HTTPException) as exc_info:
+        _run(matching_router.match_album("album1"))
+
+    assert exc_info.value.status_code == 404
+    assert exc_info.value.detail == "No Plex albums found"
+
+
+def test_match_album_no_confident_match(monkeypatch):
+    spotify_album = {
+        "id": "alb1",
+        "name": "Album X",
+        "artists": [{"name": "Artist A"}],
+    }
+    monkeypatch.setattr(
+        matching_router,
+        "spotify_client",
+        SimpleNamespace(is_authenticated=lambda: True, get_album=lambda _album_id: spotify_album),
+    )
+    monkeypatch.setattr(
+        matching_router,
+        "plex_client",
+        SimpleNamespace(search_albums=lambda _query: [SimpleNamespace(title="Album X", artist="Artist A")]),
+    )
+    monkeypatch.setattr(
+        matching_router,
+        "engine",
+        SimpleNamespace(find_best_album_match=lambda *_args, **_kwargs: (None, 0.3)),
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        _run(matching_router.match_album("album1"))
+
+    assert exc_info.value.status_code == 404
+    assert exc_info.value.detail == "No confident match found"
+
+
+def test_match_album_generic_error(monkeypatch):
+    spotify_album = {
+        "id": "alb1",
+        "name": "Album X",
+        "artists": [{"name": "Artist A"}],
+    }
+    monkeypatch.setattr(
+        matching_router,
+        "spotify_client",
+        SimpleNamespace(is_authenticated=lambda: True, get_album=lambda _album_id: spotify_album),
+    )
+    monkeypatch.setattr(
+        matching_router,
+        "plex_client",
+        SimpleNamespace(search_albums=lambda _query: [SimpleNamespace(title="Album X", artist="Artist A")]),
+    )
+    monkeypatch.setattr(
+        matching_router,
+        "engine",
+        SimpleNamespace(find_best_album_match=lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("kaboom"))),
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        _run(matching_router.match_album("album1"))
+
+    assert exc_info.value.status_code == 500
+    assert exc_info.value.detail == "kaboom"

--- a/tests/test_plex_router.py
+++ b/tests/test_plex_router.py
@@ -1,0 +1,63 @@
+import asyncio
+
+from app.routers import plex_router
+
+
+def test_status_endpoint_reports_connection():
+    async def runner():
+        response = await plex_router.status()
+        assert response == {"plex_connected": True}
+
+    asyncio.run(runner())
+
+
+def test_list_libraries_returns_stub_data():
+    async def runner():
+        response = await plex_router.list_libraries()
+        assert response.model_dump() == {"libraries": ["Music"]}
+
+    asyncio.run(runner())
+
+
+def test_search_tracks_returns_matching_tracks():
+    async def runner():
+        response = await plex_router.search_tracks(query="song")
+        assert response.model_dump() == {
+            "tracks": [
+                {
+                    "title": "Song One",
+                    "artist": "Artist A",
+                    "album": "Album X",
+                    "duration": 210,
+                },
+                {
+                    "title": "Song Two",
+                    "artist": "Artist B",
+                    "album": "Album Y",
+                    "duration": 198,
+                },
+            ]
+        }
+
+    asyncio.run(runner())
+
+
+def test_search_albums_returns_matching_albums():
+    async def runner():
+        response = await plex_router.search_albums(query="album")
+        assert response.model_dump() == {
+            "albums": [
+                {"title": "Album X", "artist": "Artist A", "year": 2020, "track_count": 1},
+                {"title": "Album Y", "artist": "Artist B", "year": 2019, "track_count": 1},
+            ]
+        }
+
+    asyncio.run(runner())
+
+
+def test_get_artists_endpoint():
+    async def runner():
+        response = await plex_router.get_artists()
+        assert response == {"artists": ["Artist A", "Artist B", "Different"]}
+
+    asyncio.run(runner())


### PR DESCRIPTION
## Summary
- extend the in-memory Spotify client with authentication state plus rich track and album lookup helpers
- enhance the matching engine to return richer match metadata and support album comparisons
- expose dedicated track and album matching endpoints and cover them with unit tests
- add a configurable settings router with endpoints to load, update, and remove persisted configuration values

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d0a14c74488321951f7da7fc97a1ca