### PR TITLE
Add Spotify integration with matching engine and worker

### DIFF
--- a/app/config/settings.py
+++ b/app/config/settings.py
@@ -80,6 +80,66 @@ class ConfigManager:
 
             return dict(self._cache[cache_key])
 
+    def get_plex_config(self) -> Dict[str, str]:
+        """Return Plex connection details merged from environment and config file."""
+
+        with self._lock:
+            cache_key = "plex"
+            if cache_key not in self._cache:
+                config: Dict[str, str] = {}
+
+                file_config = self._load_config_section("plex")
+                if isinstance(file_config, dict):
+                    for key in ("base_url", "token", "library"):
+                        value = file_config.get(key)
+                        if isinstance(value, str) and value:
+                            config[key] = value
+
+                overrides = {
+                    "base_url": os.getenv("PLEX_BASE_URL") or os.getenv("PLEX_URL"),
+                    "token": os.getenv("PLEX_TOKEN"),
+                    "library": os.getenv("PLEX_LIBRARY"),
+                }
+
+                for key, value in overrides.items():
+                    if isinstance(value, str) and value:
+                        config[key] = value
+
+                self._cache[cache_key] = config
+
+            return dict(self._cache[cache_key])
+
+
+    def get_spotify_config(self) -> Dict[str, str]:
+        """Return Spotify OAuth configuration from environment and config file."""
+
+        with self._lock:
+            cache_key = "spotify"
+            if cache_key not in self._cache:
+                config: Dict[str, str] = {}
+
+                file_config = self._load_config_section("spotify")
+                if isinstance(file_config, dict):
+                    for key in ("client_id", "client_secret", "redirect_uri", "scope"):
+                        value = file_config.get(key)
+                        if isinstance(value, str) and value:
+                            config[key] = value
+
+                overrides = {
+                    "client_id": os.getenv("SPOTIFY_CLIENT_ID"),
+                    "client_secret": os.getenv("SPOTIFY_CLIENT_SECRET"),
+                    "redirect_uri": os.getenv("SPOTIFY_REDIRECT_URI"),
+                    "scope": os.getenv("SPOTIFY_SCOPE"),
+                }
+
+                for key, value in overrides.items():
+                    if isinstance(value, str) and value:
+                        config[key] = value
+
+                self._cache[cache_key] = config
+
+            return dict(self._cache[cache_key])
+
 
 config_manager = ConfigManager()
 

--- a/app/db.py
+++ b/app/db.py
@@ -1,40 +1,12 @@
-from collections.abc import Generator
+"""Compatibility wrapper exposing the database helpers."""
 
-from sqlalchemy import create_engine
-from sqlalchemy.orm import Session, declarative_base, sessionmaker
-from sqlalchemy.pool import StaticPool
+from backend.app.db import Base, DATABASE_URL, SessionLocal, engine, get_db, init_db
 
-from app.utils.logging_config import get_logger
-
-logger = get_logger("db")
-
-DATABASE_URL = "sqlite:///./harmony.db"
-
-engine_kwargs: dict[str, object] = {}
-
-if DATABASE_URL.startswith("sqlite"):
-    engine_kwargs["connect_args"] = {"check_same_thread": False}
-
-    # Für In-Memory-SQLite muss ein StaticPool verwendet werden, damit alle
-    # Sessions dieselbe Verbindung nutzen und Daten/Tables geteilt werden.
-    if DATABASE_URL in {"sqlite://", "sqlite:///:memory:"}:
-        engine_kwargs["poolclass"] = StaticPool
-
-engine = create_engine(DATABASE_URL, **engine_kwargs)
-SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
-Base = declarative_base()
-
-
-def init_db() -> None:
-    import app.models  # noqa: F401 - ensures models are registered
-
-    Base.metadata.create_all(bind=engine)
-    logger.info("Database initialized")
-
-
-def get_db() -> Generator[Session, None, None]:
-    db = SessionLocal()
-    try:
-        yield db
-    finally:
-        db.close()
+__all__ = [
+    "Base",
+    "DATABASE_URL",
+    "SessionLocal",
+    "engine",
+    "get_db",
+    "init_db",
+]

--- a/app/main.py
+++ b/app/main.py
@@ -7,6 +7,7 @@ from app.routers import (
     settings_router,
     soulseek_router,
     spotify_router,
+    sync_router,
 )
 from app.utils.logging_config import get_logger
 from app.db import init_db
@@ -22,6 +23,7 @@ app.include_router(matching_router.router, prefix="/matching", tags=["Matching"]
 app.include_router(settings_router.router, prefix="/settings", tags=["Settings"])
 app.include_router(spotify_router.router, prefix="/spotify", tags=["Spotify"])
 app.include_router(plex_router.router, prefix="/plex", tags=["Plex"])
+app.include_router(sync_router.router)
 
 
 @app.on_event("startup")

--- a/app/routers/__init__.py
+++ b/app/routers/__init__.py
@@ -1,4 +1,5 @@
-from app.routers import beets_router, matching_router, plex_router, settings_router, soulseek_router, spotify_router
+from . import beets_router, matching_router, settings_router, soulseek_router, spotify_router
+from backend.app.routers import plex_router, sync_router
 
 __all__ = [
     "beets_router",
@@ -7,4 +8,5 @@ __all__ = [
     "settings_router",
     "soulseek_router",
     "spotify_router",
+    "sync_router",
 ]

--- a/backend/app/core/__init__.py
+++ b/backend/app/core/__init__.py
@@ -1,0 +1,21 @@
+"""Core service integrations for the backend package."""
+
+from backend.app.core.matching_engine import (
+    MusicMatchingEngine,
+    PlexTrackInfo,
+    SoulseekTrackResult,
+    SpotifyTrack,
+)
+from backend.app.core.plex_client import PlexClient
+from backend.app.core.spotify_client import SpotifyClient
+
+
+__all__ = [
+    "PlexClient",
+    "SpotifyClient",
+    "MusicMatchingEngine",
+    "SpotifyTrack",
+    "PlexTrackInfo",
+    "SoulseekTrackResult",
+]
+

--- a/backend/app/core/matching_engine.py
+++ b/backend/app/core/matching_engine.py
@@ -1,0 +1,146 @@
+"""Utility classes and helpers for matching music metadata across services."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from difflib import SequenceMatcher
+from typing import Iterable, List, Optional
+
+from app.utils.logging_config import get_logger
+
+
+logger = get_logger("matching_engine")
+
+
+_FEATURE_PATTERN = re.compile(r"\bfeat(?:\.|uring)?\s+[^\-()]*", re.IGNORECASE)
+_REMIX_PATTERN = re.compile(r"\bremaster(?:ed)?\b", re.IGNORECASE)
+_SPECIAL_EDITION_PATTERN = re.compile(r"\bspecial\s+edition\b", re.IGNORECASE)
+_PAREN_CONTENT_PATTERN = re.compile(r"\([^)]*\)")
+_SEPARATORS_PATTERN = re.compile(r"[^a-z0-9]+")
+
+
+@dataclass
+class SpotifyTrack:
+    id: str
+    name: str
+    artists: List[str]
+    album: str | None = None
+    duration_ms: int | None = None
+
+
+@dataclass
+class PlexTrackInfo:
+    id: str
+    title: str
+    artist: str
+    album: str | None = None
+    duration_ms: int | None = None
+
+
+@dataclass
+class SoulseekTrackResult:
+    id: str | None
+    title: str
+    artist: str | None
+    filename: str
+    duration_ms: int | None = None
+    bitrate: int | None = None
+
+
+class MusicMatchingEngine:
+    """Determine the best Plex or Soulseek match for a Spotify track."""
+
+    def _normalise(self, value: str | None) -> str:
+        if not value:
+            return ""
+
+        text = value.lower()
+        text = _PAREN_CONTENT_PATTERN.sub(" ", text)
+        text = _FEATURE_PATTERN.sub(" ", text)
+        text = _REMIX_PATTERN.sub(" ", text)
+        text = _SPECIAL_EDITION_PATTERN.sub(" ", text)
+        text = _SEPARATORS_PATTERN.sub(" ", text)
+        return " ".join(text.split())
+
+    def _ratio(self, left: str | None, right: str | None) -> float:
+        normalised_left = self._normalise(left)
+        normalised_right = self._normalise(right)
+        if not normalised_left or not normalised_right:
+            return 0.0
+        return SequenceMatcher(None, normalised_left, normalised_right).ratio()
+
+    def calculate_match_confidence(self, spotify_track: SpotifyTrack, plex_track: PlexTrackInfo) -> float:
+        """Return a weighted similarity score between Spotify and Plex tracks."""
+
+        title_score = self._ratio(spotify_track.name, plex_track.title)
+        artist_score = self._ratio(" ".join(spotify_track.artists), plex_track.artist)
+        album_score = self._ratio(spotify_track.album, plex_track.album)
+
+        duration_score = 0.0
+        if spotify_track.duration_ms and plex_track.duration_ms:
+            delta = abs(spotify_track.duration_ms - plex_track.duration_ms)
+            max_duration = max(spotify_track.duration_ms, plex_track.duration_ms)
+            duration_score = 1.0 - (delta / max_duration)
+            duration_score = max(duration_score, 0.0)
+
+        confidence = (title_score * 0.6) + (artist_score * 0.3) + (album_score * 0.05) + (duration_score * 0.05)
+        logger.debug(
+            "Match confidence calculated: title=%.3f artist=%.3f album=%.3f duration=%.3f -> %.3f",
+            title_score,
+            artist_score,
+            album_score,
+            duration_score,
+            confidence,
+        )
+        return confidence
+
+    def find_best_match(self, spotify_track: SpotifyTrack, plex_tracks: Iterable[PlexTrackInfo]) -> dict[str, object]:
+        """Return the Plex track with the highest confidence."""
+
+        best_track: Optional[PlexTrackInfo] = None
+        best_confidence = 0.0
+        for candidate in plex_tracks:
+            confidence = self.calculate_match_confidence(spotify_track, candidate)
+            if confidence > best_confidence:
+                best_track = candidate
+                best_confidence = confidence
+
+        matched = best_track is not None and best_confidence >= 0.5
+        logger.info(
+            "Best Plex match for %s: track=%s confidence=%.3f", spotify_track.id, getattr(best_track, "id", None), best_confidence
+        )
+        return {
+            "track": best_track,
+            "confidence": best_confidence,
+            "matched": matched,
+        }
+
+    def calculate_slskd_match_confidence(
+        self, spotify_track: SpotifyTrack, slskd_track: SoulseekTrackResult
+    ) -> float:
+        """Return similarity score for Soulseek results."""
+
+        title_score = self._ratio(spotify_track.name, slskd_track.title or slskd_track.filename)
+        artist_score = self._ratio(" ".join(spotify_track.artists), slskd_track.artist)
+
+        duration_score = 0.0
+        if spotify_track.duration_ms and slskd_track.duration_ms:
+            delta = abs(spotify_track.duration_ms - slskd_track.duration_ms)
+            max_duration = max(spotify_track.duration_ms, slskd_track.duration_ms)
+            duration_score = 1.0 - (delta / max_duration)
+            duration_score = max(duration_score, 0.0)
+
+        confidence = (title_score * 0.7) + (artist_score * 0.25) + (duration_score * 0.05)
+        logger.debug(
+            "Soulseek confidence: title=%.3f artist=%.3f duration=%.3f -> %.3f",
+            title_score,
+            artist_score,
+            duration_score,
+            confidence,
+        )
+        return confidence
+
+
+__all__ = ["MusicMatchingEngine", "SpotifyTrack", "PlexTrackInfo", "SoulseekTrackResult"]
+

--- a/backend/app/core/plex_client.py
+++ b/backend/app/core/plex_client.py
@@ -1,0 +1,150 @@
+"""Plex client wrapper used by the backend services."""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Dict, List
+
+from app.config.settings import config_manager
+from app.utils.logging_config import get_logger
+
+try:  # pragma: no cover - import guarded for environments without plexapi
+    from plexapi.server import PlexServer  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - handled gracefully at runtime
+    PlexServer = None  # type: ignore[assignment]
+
+
+logger = get_logger("plex_client")
+
+
+class PlexClient:
+    """Small wrapper around :class:`plexapi.server.PlexServer`."""
+
+    def __init__(self, base_url: str | None = None, token: str | None = None, library: str | None = None) -> None:
+        config = config_manager.get_plex_config()
+
+        self._base_url = base_url or config.get("base_url") or os.getenv("PLEX_URL")
+        self._token = token or config.get("token")
+        self._library_name = library or config.get("library") or "Music"
+        self._client = None
+        self._connect()
+
+    def _connect(self) -> None:
+        if PlexServer is None:
+            logger.warning("plexapi not available - Plex client disabled")
+            self._client = None
+            return
+
+        if not self._base_url or not self._token:
+            logger.error("Missing Plex configuration: base_url=%s token_present=%s", self._base_url, bool(self._token))
+            self._client = None
+            return
+
+        try:
+            self._client = PlexServer(self._base_url, self._token)
+            logger.info("Connected to Plex server at %s", self._base_url)
+        except Exception as exc:  # pragma: no cover - defensive safety net
+            logger.error("Failed to connect to Plex server: %s", exc)
+            self._client = None
+
+    def _get_music_library(self):
+        if self._client is None:
+            raise RuntimeError("Plex client is not connected")
+
+        try:
+            library = self._client.library.section(self._library_name)
+        except Exception as exc:
+            logger.error("Unable to access Plex library %s: %s", self._library_name, exc)
+            raise RuntimeError("Failed to access Plex library") from exc
+        return library
+
+    def is_connected(self) -> bool:
+        """Return ``True`` when a Plex server connection is established."""
+
+        return self._client is not None
+
+    def get_all_artists(self) -> List[Dict[str, Any]]:
+        """Return a list of artists from the Plex music library."""
+
+        library = self._get_music_library()
+        try:
+            artists = library.search(libtype="artist")
+        except Exception as exc:
+            logger.error("Failed to fetch Plex artists: %s", exc)
+            raise RuntimeError("Failed to fetch Plex artists") from exc
+
+        results: List[Dict[str, Any]] = []
+        for artist in artists:
+            artist_id = getattr(artist, "ratingKey", getattr(artist, "key", None))
+            results.append({
+                "id": str(artist_id) if artist_id is not None else None,
+                "name": getattr(artist, "title", ""),
+            })
+        logger.info("Fetched %s Plex artists", len(results))
+        return results
+
+    def get_albums_by_artist(self, artist_id: str) -> List[Dict[str, Any]]:
+        """Return all albums for a given Plex artist identifier."""
+
+        library = self._get_music_library()
+        try:
+            artist = library.fetchItem(artist_id)
+        except Exception as exc:
+            logger.error("Failed to fetch Plex artist %s: %s", artist_id, exc)
+            raise RuntimeError("Failed to fetch artist") from exc
+
+        if artist is None:
+            raise RuntimeError("Artist not found")
+
+        try:
+            albums = artist.albums()
+        except Exception as exc:
+            logger.error("Failed to load albums for Plex artist %s: %s", artist_id, exc)
+            raise RuntimeError("Failed to fetch albums") from exc
+
+        results: List[Dict[str, Any]] = []
+        for album in albums:
+            album_id = getattr(album, "ratingKey", getattr(album, "key", None))
+            results.append({
+                "id": str(album_id) if album_id is not None else None,
+                "title": getattr(album, "title", ""),
+                "artist_id": artist_id,
+            })
+        logger.info("Fetched %s albums for Plex artist %s", len(results), artist_id)
+        return results
+
+    def get_tracks_by_album(self, album_id: str) -> List[Dict[str, Any]]:
+        """Return the tracks belonging to a Plex album identifier."""
+
+        library = self._get_music_library()
+        try:
+            album = library.fetchItem(album_id)
+        except Exception as exc:
+            logger.error("Failed to fetch Plex album %s: %s", album_id, exc)
+            raise RuntimeError("Failed to fetch album") from exc
+
+        if album is None:
+            raise RuntimeError("Album not found")
+
+        try:
+            tracks = album.tracks()
+        except Exception as exc:
+            logger.error("Failed to load tracks for Plex album %s: %s", album_id, exc)
+            raise RuntimeError("Failed to fetch tracks") from exc
+
+        results: List[Dict[str, Any]] = []
+        for track in tracks:
+            track_id = getattr(track, "ratingKey", getattr(track, "key", None))
+            duration = getattr(track, "duration", None)
+            if isinstance(duration, (int, float)):
+                duration_value = int(duration)
+            else:
+                duration_value = None
+            results.append({
+                "id": str(track_id) if track_id is not None else None,
+                "title": getattr(track, "title", ""),
+                "album_id": album_id,
+                "duration": duration_value,
+            })
+        logger.info("Fetched %s tracks for Plex album %s", len(results), album_id)
+        return results

--- a/backend/app/core/spotify_client.py
+++ b/backend/app/core/spotify_client.py
@@ -1,0 +1,310 @@
+"""Spotify client wrapper adding rate limiting and retry support."""
+
+from __future__ import annotations
+
+import os
+import time
+from typing import Any, Callable, Dict, Iterable, List
+
+from app.config.settings import config_manager
+from app.utils.logging_config import get_logger
+
+try:  # pragma: no cover - handled gracefully during testing when spotipy is absent
+    import spotipy
+    from spotipy import Spotify
+    from spotipy.exceptions import SpotifyException
+    from spotipy.oauth2 import SpotifyOAuth
+except ModuleNotFoundError:  # pragma: no cover - optional dependency for exercises
+    spotipy = None  # type: ignore[assignment]
+    Spotify = Any  # type: ignore[misc,assignment]
+    SpotifyOAuth = Any  # type: ignore[misc,assignment]
+
+    class SpotifyException(Exception):
+        """Fallback exception used when spotipy is unavailable."""
+
+
+logger = get_logger("spotify_client")
+
+
+class SpotifyClient:
+    """Wrapper around :mod:`spotipy` providing Harmony specific helpers."""
+
+    RETRYABLE_STATUS = {429, 502, 503}
+
+    def __init__(
+        self,
+        client: Spotify | None = None,
+        auth_manager: SpotifyOAuth | None = None,
+        *,
+        client_id: str | None = None,
+        client_secret: str | None = None,
+        redirect_uri: str | None = None,
+        scope: str | None = None,
+        rate_limit_seconds: float = 0.2,
+        max_retries: int = 3,
+    ) -> None:
+        config = config_manager.get_spotify_config()
+
+        self._client_id = client_id or config.get("client_id") or os.getenv("SPOTIFY_CLIENT_ID")
+        self._client_secret = (
+            client_secret or config.get("client_secret") or os.getenv("SPOTIFY_CLIENT_SECRET")
+        )
+        self._redirect_uri = (
+            redirect_uri or config.get("redirect_uri") or os.getenv("SPOTIFY_REDIRECT_URI")
+        )
+        self._scope = scope or config.get("scope") or "user-library-read playlist-read-private"
+
+        self._rate_limit_seconds = max(rate_limit_seconds, 0.0)
+        self._max_retries = max(max_retries, 1)
+        self._last_call = 0.0
+
+        if client is not None:
+            self._client = client
+            self._auth_manager = auth_manager
+        elif spotipy is None:
+            logger.warning("spotipy not installed - Spotify client disabled")
+            self._client = None
+            self._auth_manager = auth_manager
+        else:
+            if auth_manager is None:
+                auth_manager = SpotifyOAuth(
+                    client_id=self._client_id,
+                    client_secret=self._client_secret,
+                    redirect_uri=self._redirect_uri,
+                    scope=self._scope,
+                )
+            self._auth_manager = auth_manager
+            self._client = Spotify(auth_manager=self._auth_manager)
+
+        logger.info("Spotify client initialised (scopes=%s)", self._scope)
+
+    # ------------------------------------------------------------------
+    # Helpers
+    def _enforce_rate_limit(self) -> None:
+        """Ensure at least ``rate_limit_seconds`` between Spotify API calls."""
+
+        if self._rate_limit_seconds <= 0:
+            return
+
+        elapsed = time.monotonic() - self._last_call
+        if elapsed < self._rate_limit_seconds:
+            sleep_time = self._rate_limit_seconds - elapsed
+            logger.debug("Sleeping %.3fs to respect Spotify rate limit", sleep_time)
+            time.sleep(sleep_time)
+
+    def _execute_with_retry(self, action: str, func: Callable[[], Any]) -> Any:
+        """Execute ``func`` with retry handling for transient Spotify errors."""
+
+        last_exc: Exception | None = None
+        for attempt in range(1, self._max_retries + 1):
+            self._enforce_rate_limit()
+            try:
+                result = func()
+            except SpotifyException as exc:  # pragma: no cover - exercised in unit tests via mocks
+                status = getattr(exc, "http_status", None)
+                headers: Dict[str, Any] = getattr(exc, "headers", {}) or {}
+                retry_after = headers.get("Retry-After") or headers.get("retry-after")
+                if status in self.RETRYABLE_STATUS and attempt < self._max_retries:
+                    delay = self._calculate_retry_delay(status, retry_after, attempt)
+                    logger.warning(
+                        "Spotify call %s failed with status %s (attempt %s/%s) - retrying in %.2fs",
+                        action,
+                        status,
+                        attempt,
+                        self._max_retries,
+                        delay,
+                    )
+                    time.sleep(delay)
+                    last_exc = exc
+                    continue
+                logger.error("Spotify call %s failed: %s", action, exc)
+                raise
+            except Exception as exc:  # pragma: no cover - defensive safety net
+                logger.error("Spotify call %s raised unexpected error: %s", action, exc)
+                last_exc = exc
+            else:
+                self._last_call = time.monotonic()
+                return result
+
+            self._last_call = time.monotonic()
+
+        if last_exc is not None:
+            raise last_exc
+        raise RuntimeError(f"Spotify call {action} failed")
+
+    def _calculate_retry_delay(self, status: int | None, retry_after: Any, attempt: int) -> float:
+        if status == 429 and retry_after is not None:
+            try:
+                return max(float(retry_after), self._rate_limit_seconds)
+            except (TypeError, ValueError):
+                logger.debug("Retry-After header invalid: %s", retry_after)
+        # Exponential backoff for other cases
+        return min(2.0 ** attempt * 0.5, 10.0)
+
+    def _ensure_client(self) -> Spotify:
+        if self._client is None:
+            raise RuntimeError("Spotify client not available")
+        return self._client
+
+    # ------------------------------------------------------------------
+    # Public API
+    def is_authenticated(self) -> bool:
+        """Return ``True`` if the OAuth manager currently holds a token."""
+
+        auth_manager = getattr(self, "_auth_manager", None)
+        if auth_manager is None:
+            return self._client is not None
+
+        token_info: Dict[str, Any] | None = None
+        try:
+            get_token = getattr(auth_manager, "get_cached_token", None)
+            if callable(get_token):
+                token_info = get_token()
+        except Exception as exc:  # pragma: no cover - defensive logging
+            logger.warning("Failed to read cached Spotify token: %s", exc)
+            return False
+
+        return bool(token_info and token_info.get("access_token"))
+
+    def search_tracks(self, query: str, limit: int = 20) -> List[dict[str, Any]]:
+        """Search Spotify tracks matching ``query``."""
+
+        logger.info("Searching Spotify tracks for query=%s limit=%s", query, limit)
+        client = self._ensure_client()
+
+        def _call() -> Any:
+            return client.search(q=query, type="track", limit=limit)
+
+        data = self._execute_with_retry("search_tracks", _call)
+        tracks = data.get("tracks", {}).get("items", []) if isinstance(data, dict) else []
+        return [self._format_track(item) for item in tracks]
+
+    def search_artists(self, query: str, limit: int = 20) -> List[dict[str, Any]]:
+        """Search Spotify artists for ``query``."""
+
+        logger.info("Searching Spotify artists for query=%s limit=%s", query, limit)
+        client = self._ensure_client()
+
+        def _call() -> Any:
+            return client.search(q=query, type="artist", limit=limit)
+
+        data = self._execute_with_retry("search_artists", _call)
+        artists = data.get("artists", {}).get("items", []) if isinstance(data, dict) else []
+        return [self._format_artist(item) for item in artists]
+
+    def search_albums(self, query: str, limit: int = 20) -> List[dict[str, Any]]:
+        """Search Spotify albums for ``query``."""
+
+        logger.info("Searching Spotify albums for query=%s limit=%s", query, limit)
+        client = self._ensure_client()
+
+        def _call() -> Any:
+            return client.search(q=query, type="album", limit=limit)
+
+        data = self._execute_with_retry("search_albums", _call)
+        albums = data.get("albums", {}).get("items", []) if isinstance(data, dict) else []
+        return [self._format_album(item) for item in albums]
+
+    def get_user_playlists(self) -> List[dict[str, Any]]:
+        """Return playlists of the current Spotify user."""
+
+        logger.info("Fetching current user playlists")
+        client = self._ensure_client()
+
+        def _call() -> Any:
+            return client.current_user_playlists()
+
+        data = self._execute_with_retry("get_user_playlists", _call)
+        playlists = data.get("items", []) if isinstance(data, dict) else []
+        return [self._format_playlist(item) for item in playlists]
+
+    def get_track_details(self, track_id: str) -> dict[str, Any]:
+        """Return detailed information for a Spotify track."""
+
+        logger.info("Fetching Spotify track details for %s", track_id)
+        client = self._ensure_client()
+
+        def _call() -> Any:
+            return client.track(track_id)
+
+        data = self._execute_with_retry("get_track_details", _call)
+        if not isinstance(data, dict):
+            raise RuntimeError("Unexpected response from Spotify track API")
+        return self._format_track_details(data)
+
+    # ------------------------------------------------------------------
+    # Formatting helpers
+    def _format_track(self, item: Dict[str, Any]) -> Dict[str, Any]:
+        artists = self._extract_names(item.get("artists", []))
+        album = item.get("album", {})
+        album_name = album.get("name") if isinstance(album, dict) else None
+        return {
+            "id": item.get("id"),
+            "name": item.get("name"),
+            "artists": artists,
+            "album": album_name,
+            "duration_ms": item.get("duration_ms"),
+            "popularity": item.get("popularity"),
+        }
+
+    def _format_artist(self, item: Dict[str, Any]) -> Dict[str, Any]:
+        return {
+            "id": item.get("id"),
+            "name": item.get("name"),
+            "genres": list(item.get("genres", []) or []),
+            "followers": item.get("followers", {}).get("total") if isinstance(item.get("followers"), dict) else None,
+        }
+
+    def _format_album(self, item: Dict[str, Any]) -> Dict[str, Any]:
+        artists = self._extract_names(item.get("artists", []))
+        return {
+            "id": item.get("id"),
+            "name": item.get("name"),
+            "artists": artists,
+            "release_date": item.get("release_date"),
+            "total_tracks": item.get("total_tracks"),
+        }
+
+    def _format_playlist(self, item: Dict[str, Any]) -> Dict[str, Any]:
+        owner = item.get("owner", {})
+        owner_name = owner.get("display_name") if isinstance(owner, dict) else None
+        tracks = item.get("tracks", {})
+        track_count = tracks.get("total") if isinstance(tracks, dict) else None
+        return {
+            "id": item.get("id"),
+            "name": item.get("name"),
+            "owner": owner_name,
+            "tracks": track_count,
+        }
+
+    def _format_track_details(self, item: Dict[str, Any]) -> Dict[str, Any]:
+        album = item.get("album", {}) if isinstance(item.get("album"), dict) else {}
+        return {
+            "id": item.get("id"),
+            "name": item.get("name"),
+            "artists": self._extract_names(item.get("artists", [])),
+            "album": {
+                "id": album.get("id"),
+                "name": album.get("name"),
+                "release_date": album.get("release_date"),
+            },
+            "duration_ms": item.get("duration_ms"),
+            "popularity": item.get("popularity"),
+            "preview_url": item.get("preview_url"),
+            "uri": item.get("uri"),
+        }
+
+    def _extract_names(self, items: Iterable[Any]) -> List[str]:
+        names: List[str] = []
+        for value in items:
+            if isinstance(value, dict):
+                name = value.get("name")
+            else:
+                name = value
+            if isinstance(name, str) and name:
+                names.append(name)
+        return names
+
+
+__all__ = ["SpotifyClient"]
+

--- a/backend/app/db.py
+++ b/backend/app/db.py
@@ -1,0 +1,45 @@
+"""Database configuration for the Harmony backend."""
+
+from collections.abc import Generator
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, declarative_base, sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.utils.logging_config import get_logger
+
+logger = get_logger("db")
+
+DATABASE_URL = "sqlite:///./harmony.db"
+
+engine_kwargs: dict[str, object] = {}
+
+if DATABASE_URL.startswith("sqlite"):
+    engine_kwargs["connect_args"] = {"check_same_thread": False}
+
+    if DATABASE_URL in {"sqlite://", "sqlite:///:memory:"}:
+        engine_kwargs["poolclass"] = StaticPool
+
+engine = create_engine(DATABASE_URL, **engine_kwargs)
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+Base = declarative_base()
+
+
+def init_db() -> None:
+    """Initialise database tables for all registered models."""
+
+    import app.models  # noqa: F401 - ensure core models are registered
+    import backend.app.models.plex_models  # noqa: F401 - register Plex models
+    import backend.app.models.sync_job  # noqa: F401 - register sync job model
+    import backend.app.models.matching_models  # noqa: F401 - register matching models
+
+    Base.metadata.create_all(bind=engine)
+    logger.info("Database initialized")
+
+
+def get_db() -> Generator[Session, None, None]:
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,0 +1,7 @@
+"""Model exports for the backend package."""
+
+from backend.app.models.plex_models import PlexAlbum, PlexArtist, PlexTrack
+from backend.app.models.sync_job import SyncJob
+from backend.app.models.matching_models import MatchHistory
+
+__all__ = ["PlexArtist", "PlexAlbum", "PlexTrack", "SyncJob", "MatchHistory"]

--- a/backend/app/models/matching_models.py
+++ b/backend/app/models/matching_models.py
@@ -1,0 +1,25 @@
+"""Database models for the Harmony matching subsystem."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy import DateTime, Float, Integer, String
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db import Base
+
+
+class MatchHistory(Base):
+    __tablename__ = "match_history"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    source: Mapped[str] = mapped_column(String, nullable=False)
+    spotify_track_id: Mapped[str] = mapped_column(String, nullable=False)
+    target_id: Mapped[str] = mapped_column(String, nullable=False)
+    confidence: Mapped[float] = mapped_column(Float, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, nullable=False)
+
+
+__all__ = ["MatchHistory"]
+

--- a/backend/app/models/plex_models.py
+++ b/backend/app/models/plex_models.py
@@ -1,0 +1,47 @@
+"""SQLAlchemy models representing Plex library metadata."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy import DateTime, ForeignKey, Integer, String
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.db import Base
+
+
+class PlexArtist(Base):
+    __tablename__ = "plex_artists"
+
+    id: Mapped[str] = mapped_column(String, primary_key=True)
+    name: Mapped[str] = mapped_column(String, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, nullable=False)
+
+    albums: Mapped[list["PlexAlbum"]] = relationship("PlexAlbum", back_populates="artist", cascade="all, delete-orphan")
+
+
+class PlexAlbum(Base):
+    __tablename__ = "plex_albums"
+
+    id: Mapped[str] = mapped_column(String, primary_key=True)
+    title: Mapped[str] = mapped_column(String, nullable=False)
+    artist_id: Mapped[str] = mapped_column(String, ForeignKey("plex_artists.id", ondelete="CASCADE"), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, nullable=False)
+
+    artist: Mapped[PlexArtist] = relationship("PlexArtist", back_populates="albums")
+    tracks: Mapped[list["PlexTrack"]] = relationship("PlexTrack", back_populates="album", cascade="all, delete-orphan")
+
+
+class PlexTrack(Base):
+    __tablename__ = "plex_tracks"
+
+    id: Mapped[str] = mapped_column(String, primary_key=True)
+    title: Mapped[str] = mapped_column(String, nullable=False)
+    album_id: Mapped[str] = mapped_column(String, ForeignKey("plex_albums.id", ondelete="CASCADE"), nullable=False)
+    duration: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, nullable=False)
+
+    album: Mapped[PlexAlbum] = relationship("PlexAlbum", back_populates="tracks")
+
+
+__all__ = ["PlexArtist", "PlexAlbum", "PlexTrack"]

--- a/backend/app/models/sync_job.py
+++ b/backend/app/models/sync_job.py
@@ -1,0 +1,27 @@
+"""Database model for synchronisation jobs."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy import Column, DateTime, Enum, Integer, String, Text
+
+from app.db import Base
+
+SYNC_STATUS = ("pending", "in_progress", "completed", "failed")
+
+
+class SyncJob(Base):
+    """Persist the status of a synchronisation run."""
+
+    __tablename__ = "sync_jobs"
+
+    id = Column(Integer, primary_key=True, index=True)
+    spotify_id = Column(String, nullable=False, index=True)
+    status = Column(Enum(*SYNC_STATUS, name="sync_job_status"), nullable=False, default="pending")
+    created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False)
+    error_message = Column(Text, nullable=True)
+
+    def __repr__(self) -> str:
+        return f"<SyncJob id={self.id} spotify_id={self.spotify_id!r} status={self.status!r}>"

--- a/backend/app/routers/__init__.py
+++ b/backend/app/routers/__init__.py
@@ -1,0 +1,5 @@
+"""Router exports for the backend package."""
+
+from . import matching_router, plex_router, spotify_router, sync_router
+
+__all__ = ["plex_router", "spotify_router", "matching_router", "sync_router"]

--- a/backend/app/routers/matching_router.py
+++ b/backend/app/routers/matching_router.py
@@ -1,0 +1,196 @@
+"""Endpoints exposing Spotify/Plex/Soulseek matching functionality."""
+
+from __future__ import annotations
+
+from typing import List
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field, field_validator
+from sqlalchemy.orm import Session
+
+from app.db import get_db
+from app.utils.logging_config import get_logger
+from backend.app.core.matching_engine import (
+    MusicMatchingEngine,
+    PlexTrackInfo,
+    SoulseekTrackResult,
+    SpotifyTrack,
+)
+from backend.app.core.spotify_client import SpotifyClient
+from backend.app.models.matching_models import MatchHistory
+from backend.app.models.plex_models import PlexAlbum, PlexArtist, PlexTrack
+
+
+logger = get_logger("matching_router")
+
+
+class SpotifyToPlexRequest(BaseModel):
+    spotify_track_id: str = Field(..., min_length=1)
+    plex_artist_id: str = Field(..., min_length=1)
+
+
+class SoulseekResultPayload(BaseModel):
+    id: str | None = None
+    title: str
+    artist: str | None = None
+    filename: str
+    duration_ms: int | None = Field(default=None, ge=0)
+    bitrate: int | None = Field(default=None, ge=0)
+
+    @field_validator("title", "filename")
+    @classmethod
+    def _validate_non_empty(cls, value: str) -> str:
+        if not value:
+            raise ValueError("must not be empty")
+        return value
+
+
+class SpotifyToSoulseekRequest(BaseModel):
+    spotify_track_id: str = Field(..., min_length=1)
+    results: List[SoulseekResultPayload]
+
+
+class MatchResponse(BaseModel):
+    source: str
+    spotify_track_id: str
+    target_id: str | None
+    target_title: str | None
+    target_artist: str | None
+    confidence: float
+    matched: bool
+
+
+router = APIRouter(prefix="/matching", tags=["Matching"])
+
+spotify_client = SpotifyClient()
+matching_engine = MusicMatchingEngine()
+
+
+def _load_spotify_track(spotify_track_id: str) -> SpotifyTrack:
+    details = spotify_client.get_track_details(spotify_track_id)
+    if not details:
+        raise HTTPException(status_code=404, detail="Spotify track not found")
+    album = details.get("album") or {}
+    if not isinstance(album, dict):
+        album = {}
+    return SpotifyTrack(
+        id=details.get("id", spotify_track_id),
+        name=details.get("name", ""),
+        artists=list(details.get("artists", [])),
+        album=album.get("name"),
+        duration_ms=details.get("duration_ms"),
+    )
+
+
+def _store_history(db: Session, source: str, spotify_track_id: str, target_id: str, confidence: float) -> None:
+    history = MatchHistory(
+        source=source,
+        spotify_track_id=spotify_track_id,
+        target_id=target_id,
+        confidence=confidence,
+    )
+    db.add(history)
+    db.commit()
+
+
+@router.post("/spotify-to-plex", response_model=MatchResponse)
+def match_spotify_to_plex(payload: SpotifyToPlexRequest, db: Session = Depends(get_db)) -> MatchResponse:
+    artist = db.get(PlexArtist, payload.plex_artist_id)
+    if artist is None:
+        logger.warning("Plex artist %s not found", payload.plex_artist_id)
+        raise HTTPException(status_code=404, detail="Plex artist not found")
+
+    tracks_with_albums = (
+        db.query(PlexTrack, PlexAlbum)
+        .join(PlexAlbum, PlexTrack.album_id == PlexAlbum.id)
+        .filter(PlexAlbum.artist_id == payload.plex_artist_id)
+        .all()
+    )
+
+    if not tracks_with_albums:
+        logger.warning("No Plex tracks stored for artist %s", payload.plex_artist_id)
+        raise HTTPException(status_code=404, detail="No Plex tracks for artist")
+
+    spotify_track = _load_spotify_track(payload.spotify_track_id)
+    plex_tracks = [
+        PlexTrackInfo(
+            id=track.id,
+            title=track.title,
+            artist=artist.name,
+            album=album.title,
+            duration_ms=track.duration,
+        )
+        for track, album in tracks_with_albums
+    ]
+
+    result = matching_engine.find_best_match(spotify_track, plex_tracks)
+    best_track = result.get("track")
+    confidence = float(result.get("confidence", 0.0))
+    matched = bool(result.get("matched")) and best_track is not None
+
+    if matched:
+        _store_history(db, "plex", spotify_track.id, best_track.id, confidence)
+
+    return MatchResponse(
+        source="plex",
+        spotify_track_id=spotify_track.id,
+        target_id=getattr(best_track, "id", None),
+        target_title=getattr(best_track, "title", None),
+        target_artist=getattr(best_track, "artist", None),
+        confidence=confidence,
+        matched=matched,
+    )
+
+
+@router.post("/spotify-to-soulseek", response_model=MatchResponse)
+def match_spotify_to_soulseek(
+    payload: SpotifyToSoulseekRequest, db: Session = Depends(get_db)
+) -> MatchResponse:
+    if not payload.results:
+        raise HTTPException(status_code=400, detail="No Soulseek results provided")
+
+    spotify_track = _load_spotify_track(payload.spotify_track_id)
+    soulseek_results = [
+        SoulseekTrackResult(
+            id=item.id,
+            title=item.title,
+            artist=item.artist,
+            filename=item.filename,
+            duration_ms=item.duration_ms,
+            bitrate=item.bitrate,
+        )
+        for item in payload.results
+    ]
+
+    best_result = None
+    best_confidence = 0.0
+    for result in soulseek_results:
+        confidence = matching_engine.calculate_slskd_match_confidence(spotify_track, result)
+        if confidence > best_confidence:
+            best_confidence = confidence
+            best_result = result
+
+    matched = best_result is not None and best_confidence >= 0.5
+
+    target_id = None
+    target_title = None
+    target_artist = None
+    if matched and best_result is not None:
+        target_id = best_result.id or best_result.filename
+        target_title = best_result.title
+        target_artist = best_result.artist
+        _store_history(db, "soulseek", spotify_track.id, target_id, best_confidence)
+
+    return MatchResponse(
+        source="soulseek",
+        spotify_track_id=spotify_track.id,
+        target_id=target_id,
+        target_title=target_title,
+        target_artist=target_artist,
+        confidence=best_confidence,
+        matched=matched,
+    )
+
+
+__all__ = ["router"]
+

--- a/backend/app/routers/plex_router.py
+++ b/backend/app/routers/plex_router.py
@@ -1,0 +1,99 @@
+"""Plex API endpoints backed by the persistent database."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+
+from app.db import get_db
+from app.utils.logging_config import get_logger
+from backend.app.core.plex_client import PlexClient
+from backend.app.models.plex_models import PlexAlbum, PlexArtist, PlexTrack
+
+logger = get_logger("plex_router")
+
+router = APIRouter(prefix="/plex", tags=["Plex"])
+
+plex_client = PlexClient()
+
+
+def _serialise_artist(artist: PlexArtist) -> dict[str, Any]:
+    return {"id": artist.id, "name": artist.name}
+
+
+def _serialise_album(album: PlexAlbum) -> dict[str, Any]:
+    return {"id": album.id, "title": album.title, "artist_id": album.artist_id}
+
+
+def _serialise_track(track: PlexTrack) -> dict[str, Any]:
+    return {
+        "id": track.id,
+        "title": track.title,
+        "album_id": track.album_id,
+        "duration": track.duration,
+    }
+
+
+@router.get("/status")
+def plex_status() -> dict[str, bool]:
+    """Return the connectivity status of the Plex client."""
+
+    try:
+        connected = plex_client.is_connected()
+    except Exception as exc:  # pragma: no cover - defensive safety net
+        logger.error("Plex status check failed: %s", exc)
+        raise HTTPException(status_code=503, detail="Unable to determine Plex status") from exc
+
+    return {"connected": connected}
+
+
+@router.get("/artists")
+def get_artists(db: Session = Depends(get_db)) -> dict[str, list[dict[str, Any]]]:
+    """List all artists stored in the local Plex cache."""
+
+    artists = db.query(PlexArtist).order_by(PlexArtist.name.asc()).all()
+    logger.info("Returned %s Plex artists", len(artists))
+    return {"artists": [_serialise_artist(artist) for artist in artists]}
+
+
+@router.get("/albums/{artist_id}")
+def get_albums(artist_id: str, db: Session = Depends(get_db)) -> dict[str, Any]:
+    """List albums for a given artist."""
+
+    artist = db.get(PlexArtist, artist_id)
+    if artist is None:
+        logger.warning("Requested albums for unknown artist %s", artist_id)
+        raise HTTPException(status_code=404, detail="Artist not found")
+
+    albums = (
+        db.query(PlexAlbum)
+        .filter(PlexAlbum.artist_id == artist_id)
+        .order_by(PlexAlbum.title.asc())
+        .all()
+    )
+    logger.info("Returned %s Plex albums for artist %s", len(albums), artist_id)
+    return {"artist": _serialise_artist(artist), "albums": [_serialise_album(album) for album in albums]}
+
+
+@router.get("/tracks/{album_id}")
+def get_tracks(album_id: str, db: Session = Depends(get_db)) -> dict[str, Any]:
+    """List tracks for a given album."""
+
+    album = db.get(PlexAlbum, album_id)
+    if album is None:
+        logger.warning("Requested tracks for unknown album %s", album_id)
+        raise HTTPException(status_code=404, detail="Album not found")
+
+    tracks = (
+        db.query(PlexTrack)
+        .filter(PlexTrack.album_id == album_id)
+        .order_by(PlexTrack.title.asc())
+        .all()
+    )
+    logger.info("Returned %s Plex tracks for album %s", len(tracks), album_id)
+    return {
+        "album": _serialise_album(album),
+        "tracks": [_serialise_track(track) for track in tracks],
+    }

--- a/backend/app/routers/spotify_router.py
+++ b/backend/app/routers/spotify_router.py
@@ -1,0 +1,160 @@
+"""FastAPI routes exposing Spotify search and metadata."""
+
+from __future__ import annotations
+
+from typing import Any, List
+
+from fastapi import APIRouter, HTTPException, Query
+from pydantic import BaseModel, Field
+
+from app.utils.logging_config import get_logger
+from backend.app.core.spotify_client import SpotifyClient
+
+
+logger = get_logger("spotify_router")
+
+
+class TrackSummary(BaseModel):
+    id: str | None = Field(default=None, description="Spotify track identifier")
+    name: str | None = Field(default=None, description="Track title")
+    artists: List[str] = Field(default_factory=list, description="Artists on the track")
+    album: str | None = Field(default=None, description="Album title")
+    duration_ms: int | None = Field(default=None, description="Duration in milliseconds")
+    popularity: int | None = Field(default=None, description="Spotify popularity score")
+
+
+class ArtistSummary(BaseModel):
+    id: str | None = None
+    name: str | None = None
+    genres: List[str] = Field(default_factory=list)
+    followers: int | None = None
+
+
+class AlbumSummary(BaseModel):
+    id: str | None = None
+    name: str | None = None
+    artists: List[str] = Field(default_factory=list)
+    release_date: str | None = None
+    total_tracks: int | None = None
+
+
+class PlaylistSummary(BaseModel):
+    id: str | None = None
+    name: str | None = None
+    owner: str | None = None
+    tracks: int | None = Field(default=None, description="Number of tracks")
+
+
+class AlbumDetail(BaseModel):
+    id: str | None = None
+    name: str | None = None
+    release_date: str | None = None
+
+
+class TrackDetails(BaseModel):
+    id: str
+    name: str
+    artists: List[str]
+    album: AlbumDetail | None = None
+    duration_ms: int | None = None
+    popularity: int | None = None
+    preview_url: str | None = None
+    uri: str | None = None
+
+
+class StatusResponse(BaseModel):
+    authenticated: bool
+
+
+class TrackSearchResponse(BaseModel):
+    tracks: List[TrackSummary]
+
+
+class ArtistSearchResponse(BaseModel):
+    artists: List[ArtistSummary]
+
+
+class AlbumSearchResponse(BaseModel):
+    albums: List[AlbumSummary]
+
+
+class PlaylistResponse(BaseModel):
+    playlists: List[PlaylistSummary]
+
+
+router = APIRouter(prefix="/spotify", tags=["Spotify"])
+
+spotify_client = SpotifyClient()
+
+
+def _handle_spotify_error(action: str, exc: Exception) -> HTTPException:
+    logger.error("Spotify %s failed: %s", action, exc)
+    return HTTPException(status_code=502, detail=f"Spotify {action} failed")
+
+
+@router.get("/status", response_model=StatusResponse)
+def spotify_status() -> StatusResponse:
+    try:
+        authenticated = spotify_client.is_authenticated()
+    except Exception as exc:  # pragma: no cover - defensive safety net
+        logger.error("Unable to determine Spotify authentication state: %s", exc)
+        raise HTTPException(status_code=503, detail="Spotify status unavailable") from exc
+
+    return StatusResponse(authenticated=bool(authenticated))
+
+
+@router.get("/search/tracks", response_model=TrackSearchResponse)
+def search_tracks(query: str = Query(..., min_length=1), limit: int = Query(20, ge=1, le=50)) -> TrackSearchResponse:
+    try:
+        results = spotify_client.search_tracks(query, limit=limit)
+    except Exception as exc:
+        raise _handle_spotify_error("track search", exc) from exc
+
+    return TrackSearchResponse(tracks=[TrackSummary(**item) for item in results])
+
+
+@router.get("/search/artists", response_model=ArtistSearchResponse)
+def search_artists(query: str = Query(..., min_length=1), limit: int = Query(20, ge=1, le=50)) -> ArtistSearchResponse:
+    try:
+        results = spotify_client.search_artists(query, limit=limit)
+    except Exception as exc:
+        raise _handle_spotify_error("artist search", exc) from exc
+
+    return ArtistSearchResponse(artists=[ArtistSummary(**item) for item in results])
+
+
+@router.get("/search/albums", response_model=AlbumSearchResponse)
+def search_albums(query: str = Query(..., min_length=1), limit: int = Query(20, ge=1, le=50)) -> AlbumSearchResponse:
+    try:
+        results = spotify_client.search_albums(query, limit=limit)
+    except Exception as exc:
+        raise _handle_spotify_error("album search", exc) from exc
+
+    return AlbumSearchResponse(albums=[AlbumSummary(**item) for item in results])
+
+
+@router.get("/playlists", response_model=PlaylistResponse)
+def list_playlists() -> PlaylistResponse:
+    try:
+        playlists = spotify_client.get_user_playlists()
+    except Exception as exc:
+        raise _handle_spotify_error("playlist retrieval", exc) from exc
+
+    return PlaylistResponse(playlists=[PlaylistSummary(**item) for item in playlists])
+
+
+@router.get("/track/{track_id}", response_model=TrackDetails)
+def track_details(track_id: str) -> TrackDetails:
+    try:
+        details = spotify_client.get_track_details(track_id)
+    except Exception as exc:
+        raise _handle_spotify_error("track lookup", exc) from exc
+
+    if not details:
+        raise HTTPException(status_code=404, detail="Spotify track not found")
+
+    return TrackDetails(**details)
+
+
+__all__ = ["router"]
+

--- a/backend/app/workers/__init__.py
+++ b/backend/app/workers/__init__.py
@@ -1,0 +1,5 @@
+"""Worker exports for the backend package."""
+
+from backend.app.workers.matching_worker import MatchingJob, MatchingWorker
+
+__all__ = ["MatchingWorker", "MatchingJob"]

--- a/backend/app/workers/matching_worker.py
+++ b/backend/app/workers/matching_worker.py
@@ -1,0 +1,186 @@
+"""Asynchronous worker processing Spotify matching jobs."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import Iterable, Literal, Optional
+
+from sqlalchemy.orm import Session
+
+from app.db import SessionLocal
+from app.utils.logging_config import get_logger
+from backend.app.core.matching_engine import (
+    MusicMatchingEngine,
+    PlexTrackInfo,
+    SoulseekTrackResult,
+    SpotifyTrack,
+)
+from backend.app.core.spotify_client import SpotifyClient
+from backend.app.models.matching_models import MatchHistory
+from backend.app.models.plex_models import PlexAlbum, PlexArtist, PlexTrack
+
+
+logger = get_logger("matching_worker")
+
+
+@dataclass
+class MatchingJob:
+    job_type: Literal["spotify_to_plex", "spotify_to_soulseek"]
+    spotify_track_id: str
+    plex_artist_id: str | None = None
+    soulseek_results: Iterable[SoulseekTrackResult] | None = None
+
+
+class MatchingWorker:
+    """Background worker for matching Spotify tracks against other services."""
+
+    def __init__(
+        self,
+        spotify_client: SpotifyClient | None = None,
+        engine: MusicMatchingEngine | None = None,
+    ) -> None:
+        self._spotify = spotify_client or SpotifyClient()
+        self._engine = engine or MusicMatchingEngine()
+        self._queue: asyncio.Queue[MatchingJob | None] = asyncio.Queue()
+        self._task: asyncio.Task[None] | None = None
+
+    async def start(self) -> None:
+        if self._task is None:
+            self._task = asyncio.create_task(self._run())
+            logger.info("Matching worker started")
+
+    async def stop(self) -> None:
+        await self._queue.put(None)
+        if self._task is not None:
+            await self._task
+            self._task = None
+        logger.info("Matching worker stopped")
+
+    async def enqueue_spotify_to_plex(self, spotify_track_id: str, plex_artist_id: str) -> None:
+        job = MatchingJob("spotify_to_plex", spotify_track_id=spotify_track_id, plex_artist_id=plex_artist_id)
+        await self._queue.put(job)
+        logger.debug("Enqueued Spotify->Plex job for track %s", spotify_track_id)
+
+    async def enqueue_spotify_to_soulseek(
+        self, spotify_track_id: str, results: Iterable[SoulseekTrackResult]
+    ) -> None:
+        job = MatchingJob("spotify_to_soulseek", spotify_track_id=spotify_track_id, soulseek_results=list(results))
+        await self._queue.put(job)
+        logger.debug("Enqueued Spotify->Soulseek job for track %s", spotify_track_id)
+
+    async def _run(self) -> None:
+        while True:
+            job = await self._queue.get()
+            if job is None:
+                self._queue.task_done()
+                break
+            try:
+                if job.job_type == "spotify_to_plex":
+                    self._process_spotify_to_plex(job.spotify_track_id, job.plex_artist_id)
+                else:
+                    results = list(job.soulseek_results or [])
+                    self._process_spotify_to_soulseek(job.spotify_track_id, results)
+            except Exception as exc:  # pragma: no cover - defensive logging
+                logger.error("Matching job %s failed: %s", job.job_type, exc)
+            finally:
+                self._queue.task_done()
+
+    def _process_spotify_to_plex(self, spotify_track_id: str, plex_artist_id: str | None) -> None:
+        if plex_artist_id is None:
+            logger.error("Missing Plex artist id for Spotify match job")
+            return
+
+        spotify_track = self._load_spotify_track(spotify_track_id)
+        with SessionLocal() as session:
+            artist = session.get(PlexArtist, plex_artist_id)
+            if artist is None:
+                logger.warning("Plex artist %s not found", plex_artist_id)
+                return
+
+            tracks = (
+                session.query(PlexTrack, PlexAlbum)
+                .join(PlexAlbum, PlexTrack.album_id == PlexAlbum.id)
+                .filter(PlexAlbum.artist_id == plex_artist_id)
+                .all()
+            )
+
+            plex_tracks = [
+                PlexTrackInfo(
+                    id=track.id,
+                    title=track.title,
+                    artist=artist.name,
+                    album=album.title,
+                    duration_ms=track.duration,
+                )
+                for track, album in tracks
+            ]
+
+            if not plex_tracks:
+                logger.info("No Plex tracks available for artist %s", plex_artist_id)
+                return
+
+            result = self._engine.find_best_match(spotify_track, plex_tracks)
+            best_track: Optional[PlexTrackInfo] = result.get("track")  # type: ignore[assignment]
+            confidence = float(result.get("confidence", 0.0))
+            matched = bool(result.get("matched")) and best_track is not None
+
+            if matched and best_track is not None:
+                self._store_history(session, "plex", spotify_track.id, best_track.id, confidence)
+                logger.info(
+                    "Matched Spotify track %s to Plex track %s with confidence %.3f",
+                    spotify_track.id,
+                    best_track.id,
+                    confidence,
+                )
+
+    def _process_spotify_to_soulseek(self, spotify_track_id: str, results: Iterable[SoulseekTrackResult]) -> None:
+        spotify_track = self._load_spotify_track(spotify_track_id)
+        best_result: Optional[SoulseekTrackResult] = None
+        best_confidence = 0.0
+        for candidate in results:
+            confidence = self._engine.calculate_slskd_match_confidence(spotify_track, candidate)
+            if confidence > best_confidence:
+                best_confidence = confidence
+                best_result = candidate
+
+        if best_result is None:
+            logger.info("No Soulseek match found for Spotify track %s", spotify_track.id)
+            return
+
+        with SessionLocal() as session:
+            target_id = best_result.id or best_result.filename
+            self._store_history(session, "soulseek", spotify_track.id, target_id, best_confidence)
+            logger.info(
+                "Matched Spotify track %s to Soulseek result %s with confidence %.3f",
+                spotify_track.id,
+                target_id,
+                best_confidence,
+            )
+
+    def _load_spotify_track(self, spotify_track_id: str) -> SpotifyTrack:
+        data = self._spotify.get_track_details(spotify_track_id)
+        album = data.get("album") or {}
+        if not isinstance(album, dict):
+            album = {}
+        return SpotifyTrack(
+            id=data.get("id", spotify_track_id),
+            name=data.get("name", ""),
+            artists=list(data.get("artists", [])),
+            album=album.get("name"),
+            duration_ms=data.get("duration_ms"),
+        )
+
+    def _store_history(self, session: Session, source: str, spotify_track_id: str, target_id: str, confidence: float) -> None:
+        history = MatchHistory(
+            source=source,
+            spotify_track_id=spotify_track_id,
+            target_id=target_id,
+            confidence=confidence,
+        )
+        session.add(history)
+        session.commit()
+
+
+__all__ = ["MatchingWorker", "MatchingJob"]
+

--- a/backend/app/workers/plex_worker.py
+++ b/backend/app/workers/plex_worker.py
@@ -1,0 +1,108 @@
+"""Worker responsible for synchronising Plex metadata into the database."""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+from app.db import SessionLocal
+from app.utils.logging_config import get_logger
+from backend.app.core.plex_client import PlexClient
+from backend.app.models.plex_models import PlexAlbum, PlexArtist, PlexTrack
+
+logger = get_logger("plex_worker")
+
+
+class PlexWorker:
+    """Synchronise Plex artists, albums and tracks into SQLite."""
+
+    def __init__(self, client: PlexClient | None = None) -> None:
+        self.client = client or PlexClient()
+
+    def sync(self) -> None:
+        """Fetch data from Plex and persist it to the database."""
+
+        logger.info("Starting Plex metadata synchronisation")
+
+        try:
+            artists_data = self.client.get_all_artists()
+        except Exception as exc:
+            logger.error("Unable to fetch artists from Plex: %s", exc)
+            raise
+
+        with SessionLocal() as session:
+            try:
+                session.query(PlexTrack).delete(synchronize_session=False)
+                session.query(PlexAlbum).delete(synchronize_session=False)
+                session.query(PlexArtist).delete(synchronize_session=False)
+
+                for artist_record in artists_data:
+                    artist_id = self._normalise_identifier(artist_record.get("id"))
+                    if not artist_id:
+                        logger.warning("Skipping Plex artist without identifier: %s", artist_record)
+                        continue
+
+                    name = str(artist_record.get("name", ""))
+                    artist = PlexArtist(id=artist_id, name=name)
+                    session.add(artist)
+                    logger.info("Stored Plex artist %s", artist_id)
+
+                    albums_data = self._fetch_albums(artist_id)
+                    for album_record in albums_data:
+                        album_id = self._normalise_identifier(album_record.get("id"))
+                        if not album_id:
+                            logger.warning("Skipping Plex album without identifier: %s", album_record)
+                            continue
+
+                        title = str(album_record.get("title", ""))
+                        album = PlexAlbum(id=album_id, title=title, artist_id=artist_id)
+                        session.add(album)
+                        logger.info("Stored Plex album %s for artist %s", album_id, artist_id)
+
+                        tracks_data = self._fetch_tracks(album_id)
+                        for track_record in tracks_data:
+                            track_id = self._normalise_identifier(track_record.get("id"))
+                            if not track_id:
+                                logger.warning("Skipping Plex track without identifier: %s", track_record)
+                                continue
+
+                            title = str(track_record.get("title", ""))
+                            duration = track_record.get("duration")
+                            duration_value = int(duration) if isinstance(duration, (int, float)) else None
+
+                            track = PlexTrack(
+                                id=track_id,
+                                title=title,
+                                album_id=album_id,
+                                duration=duration_value,
+                            )
+                            session.add(track)
+                            logger.info("Stored Plex track %s for album %s", track_id, album_id)
+
+                session.commit()
+            except Exception:
+                session.rollback()
+                logger.error("Plex synchronisation failed", exc_info=True)
+                raise
+
+        logger.info("Plex metadata synchronisation finished with %s artists", len(artists_data))
+
+    def _fetch_albums(self, artist_id: str) -> Iterable[dict[str, object]]:
+        try:
+            return self.client.get_albums_by_artist(artist_id)
+        except Exception as exc:
+            logger.error("Unable to fetch albums for artist %s: %s", artist_id, exc)
+            raise
+
+    def _fetch_tracks(self, album_id: str) -> Iterable[dict[str, object]]:
+        try:
+            return self.client.get_tracks_by_album(album_id)
+        except Exception as exc:
+            logger.error("Unable to fetch tracks for album %s: %s", album_id, exc)
+            raise
+
+    @staticmethod
+    def _normalise_identifier(value: object) -> str | None:
+        if value is None:
+            return None
+        text = str(value).strip()
+        return text or None

--- a/fastapi/__init__.py
+++ b/fastapi/__init__.py
@@ -11,8 +11,10 @@ class HTTPException(Exception):
 
 
 class APIRouter:
-    def __init__(self) -> None:
+    def __init__(self, *, prefix: str | None = None, tags: List[str] | None = None) -> None:
         self.routes: List[Tuple[str, str, Callable[..., Any]]] = []
+        self.prefix = prefix or ""
+        self.tags = tags or []
 
     def delete(self, path: str, **_kwargs: Any) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
         def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
@@ -40,6 +42,10 @@ def Query(default: Any = None, **_kwargs: Any) -> Any:  # pragma: no cover - sim
     return default
 
 
+def Depends(dependency: Callable[..., Any]) -> Callable[..., Any]:  # pragma: no cover - simple helper
+    return dependency
+
+
 class FastAPI:
     def __init__(self) -> None:
         self.routers: List[APIRouter] = []
@@ -62,6 +68,7 @@ class FastAPI:
 
 __all__ = [
     "APIRouter",
+    "Depends",
     "FastAPI",
     "HTTPException",
     "Query",

--- a/tests/test_matching.py
+++ b/tests/test_matching.py
@@ -1,0 +1,207 @@
+"""Tests covering the matching engine and API endpoints."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.db import SessionLocal, init_db
+from backend.app.core.matching_engine import (
+    MusicMatchingEngine,
+    PlexTrackInfo,
+    SoulseekTrackResult,
+    SpotifyTrack,
+)
+from backend.app.models.matching_models import MatchHistory
+from backend.app.models.plex_models import PlexAlbum, PlexArtist, PlexTrack
+from backend.app.routers import matching_router
+from fastapi import HTTPException
+
+
+class SimpleResponse:
+    def __init__(self, status_code: int, payload: dict[str, object]) -> None:
+        self.status_code = status_code
+        self._payload = payload
+
+    def json(self) -> dict[str, object]:
+        return self._payload
+
+
+class SimpleTestClient:
+    """Minimal stand-in for FastAPI's TestClient used in tests."""
+
+    def post(self, path: str, json: dict[str, object]) -> SimpleResponse:
+        if path == "/matching/spotify-to-plex":
+            request = matching_router.SpotifyToPlexRequest(**json)
+            with SessionLocal() as session:
+                try:
+                    result = matching_router.match_spotify_to_plex(request, db=session)
+                except HTTPException as exc:  # pragma: no cover - defensive safety net
+                    return SimpleResponse(exc.status_code, {"detail": exc.detail or ""})
+            if hasattr(result, "model_dump"):
+                payload = result.model_dump()
+            elif hasattr(result, "dict"):
+                payload = result.dict()
+            else:
+                payload = result
+            return SimpleResponse(200, payload)
+
+        if path == "/matching/spotify-to-soulseek":
+            request = matching_router.SpotifyToSoulseekRequest(**json)
+            with SessionLocal() as session:
+                try:
+                    result = matching_router.match_spotify_to_soulseek(request, db=session)
+                except HTTPException as exc:  # pragma: no cover - defensive safety net
+                    return SimpleResponse(exc.status_code, {"detail": exc.detail or ""})
+            if hasattr(result, "model_dump"):
+                payload = result.model_dump()
+            elif hasattr(result, "dict"):
+                payload = result.dict()
+            else:
+                payload = result
+            return SimpleResponse(200, payload)
+
+        raise AssertionError(f"Unsupported path {path}")
+
+
+@pytest.fixture(autouse=True)
+def prepare_database() -> None:
+    init_db()
+    with SessionLocal() as session:
+        session.query(MatchHistory).delete()
+        session.query(PlexTrack).delete()
+        session.query(PlexAlbum).delete()
+        session.query(PlexArtist).delete()
+        session.commit()
+    yield
+    with SessionLocal() as session:
+        session.query(MatchHistory).delete()
+        session.query(PlexTrack).delete()
+        session.query(PlexAlbum).delete()
+        session.query(PlexArtist).delete()
+        session.commit()
+
+
+def test_calculate_match_confidence_handles_normalisation() -> None:
+    engine = MusicMatchingEngine()
+    spotify_track = SpotifyTrack(
+        id="sp1",
+        name="Song Title (feat. Guest) - Remastered 2011",
+        artists=["Main Artist"],
+        album="Great Album (Special Edition)",
+        duration_ms=200_000,
+    )
+    plex_track = PlexTrackInfo(
+        id="pl1",
+        title="Song Title",
+        artist="Main Artist",
+        album="Great Album",
+        duration_ms=199_500,
+    )
+
+    confidence = engine.calculate_match_confidence(spotify_track, plex_track)
+
+    assert confidence > 0.85
+
+
+def test_calculate_slskd_match_confidence_accounts_for_duration() -> None:
+    engine = MusicMatchingEngine()
+    spotify_track = SpotifyTrack(
+        id="sp1",
+        name="Song Title",
+        artists=["Main Artist"],
+        album="Great Album",
+        duration_ms=210_000,
+    )
+    slskd_result = SoulseekTrackResult(
+        id="result-1",
+        title="Main Artist - Song Title (Remastered)",
+        artist="Main Artist",
+        filename="Main Artist - Song Title.mp3",
+        duration_ms=211_000,
+        bitrate=320,
+    )
+
+    confidence = engine.calculate_slskd_match_confidence(spotify_track, slskd_result)
+
+    assert confidence > 0.7
+
+
+class FakeSpotifyClient:
+    def get_track_details(self, track_id: str) -> dict:
+        return {
+            "id": track_id,
+            "name": "Song Title (feat. Guest)",
+            "artists": ["Main Artist"],
+            "album": {"name": "Great Album"},
+            "duration_ms": 200_000,
+        }
+
+
+@pytest.fixture()
+def test_app(monkeypatch: pytest.MonkeyPatch) -> SimpleTestClient:
+    monkeypatch.setattr(matching_router, "spotify_client", FakeSpotifyClient())
+    monkeypatch.setattr(matching_router, "matching_engine", MusicMatchingEngine())
+    return SimpleTestClient()
+
+
+def test_matching_plex_endpoint_returns_best_result(test_app: SimpleTestClient) -> None:
+    with SessionLocal() as session:
+        session.add(PlexArtist(id="artist-1", name="Main Artist"))
+        session.add(PlexAlbum(id="album-1", title="Great Album", artist_id="artist-1"))
+        session.add(PlexTrack(id="track-1", title="Song Title", album_id="album-1", duration=200_000))
+        session.add(PlexTrack(id="track-2", title="Unrelated", album_id="album-1", duration=180_000))
+        session.commit()
+
+    response = test_app.post(
+        "/matching/spotify-to-plex",
+        json={"spotify_track_id": "sp1", "plex_artist_id": "artist-1"},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["matched"] is True
+    assert payload["target_id"] == "track-1"
+
+    with SessionLocal() as session:
+        history = session.query(MatchHistory).all()
+
+    assert len(history) == 1
+    assert history[0].source == "plex"
+
+
+def test_matching_soulseek_endpoint_returns_best_result(test_app: SimpleTestClient) -> None:
+    response = test_app.post(
+        "/matching/spotify-to-soulseek",
+        json={
+            "spotify_track_id": "sp1",
+            "results": [
+                {
+                    "id": "result-1",
+                    "title": "Main Artist - Song Title",
+                    "artist": "Main Artist",
+                    "filename": "Main Artist - Song Title.mp3",
+                    "duration_ms": 200_000,
+                    "bitrate": 320,
+                },
+                {
+                    "id": "result-2",
+                    "title": "Other Track",
+                    "artist": "Someone Else",
+                    "filename": "Other Track.mp3",
+                    "duration_ms": 150_000,
+                    "bitrate": 192,
+                },
+            ],
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["matched"] is True
+    assert payload["target_id"] == "result-1"
+
+    with SessionLocal() as session:
+        history = session.query(MatchHistory).order_by(MatchHistory.id.asc()).all()
+
+    assert len(history) == 1
+    assert history[0].source == "soulseek"

--- a/tests/test_plex.py
+++ b/tests/test_plex.py
@@ -1,0 +1,164 @@
+"""Integration tests for the Plex backend components."""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import HTTPException
+
+from app.db import SessionLocal, init_db
+from backend.app.models.plex_models import PlexAlbum, PlexArtist, PlexTrack
+from backend.app.routers import plex_router
+from backend.app.workers.plex_worker import PlexWorker
+
+
+@pytest.fixture(autouse=True)
+def prepare_database() -> None:
+    """Ensure Plex tables exist and are empty before each test."""
+
+    init_db()
+    with SessionLocal() as session:
+        session.query(PlexTrack).delete()
+        session.query(PlexAlbum).delete()
+        session.query(PlexArtist).delete()
+        session.commit()
+    yield
+    with SessionLocal() as session:
+        session.query(PlexTrack).delete()
+        session.query(PlexAlbum).delete()
+        session.query(PlexArtist).delete()
+        session.commit()
+
+
+def test_status_endpoint_reports_connection(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The status endpoint surfaces the Plex client's connectivity flag."""
+
+    class DummyClient:
+        def is_connected(self) -> bool:
+            return True
+
+    monkeypatch.setattr(plex_router, "plex_client", DummyClient())
+
+    assert plex_router.plex_status() == {"connected": True}
+
+
+def test_get_artists_returns_sorted_entries() -> None:
+    """Artists are retrieved from the database in alphabetical order."""
+
+    with SessionLocal() as session:
+        session.add(PlexArtist(id="2", name="Zeta"))
+        session.add(PlexArtist(id="1", name="Alpha"))
+        session.commit()
+
+    with SessionLocal() as session:
+        response = plex_router.get_artists(db=session)
+
+    assert response == {
+        "artists": [
+            {"id": "1", "name": "Alpha"},
+            {"id": "2", "name": "Zeta"},
+        ]
+    }
+
+
+def test_get_albums_requires_existing_artist() -> None:
+    """Requesting albums for an unknown artist raises a 404 error."""
+
+    with SessionLocal() as session:
+        with pytest.raises(HTTPException) as excinfo:
+            plex_router.get_albums("missing", db=session)
+
+    assert excinfo.value.status_code == 404
+
+
+def test_get_albums_returns_payload_for_artist() -> None:
+    """Albums are filtered by artist and returned with basic metadata."""
+
+    with SessionLocal() as session:
+        session.add(PlexArtist(id="artist-1", name="Example Artist"))
+        session.add(PlexAlbum(id="album-a", title="First", artist_id="artist-1"))
+        session.add(PlexAlbum(id="album-b", title="Second", artist_id="artist-1"))
+        session.add(PlexAlbum(id="album-c", title="Other", artist_id="another"))
+        session.commit()
+
+    with SessionLocal() as session:
+        response = plex_router.get_albums("artist-1", db=session)
+
+    assert response == {
+        "artist": {"id": "artist-1", "name": "Example Artist"},
+        "albums": [
+            {"id": "album-a", "title": "First", "artist_id": "artist-1"},
+            {"id": "album-b", "title": "Second", "artist_id": "artist-1"},
+        ],
+    }
+
+
+def test_get_tracks_requires_existing_album() -> None:
+    """Unknown albums yield a 404 error."""
+
+    with SessionLocal() as session:
+        with pytest.raises(HTTPException) as excinfo:
+            plex_router.get_tracks("missing", db=session)
+
+    assert excinfo.value.status_code == 404
+
+
+def test_get_tracks_returns_album_tracks() -> None:
+    """Tracks are returned for the requested album only."""
+
+    with SessionLocal() as session:
+        session.add(PlexArtist(id="artist-1", name="Example Artist"))
+        session.add(PlexAlbum(id="album-1", title="Greatest", artist_id="artist-1"))
+        session.add(PlexTrack(id="track-1", title="Song A", album_id="album-1", duration=120))
+        session.add(PlexTrack(id="track-2", title="Song B", album_id="album-1", duration=None))
+        session.add(PlexTrack(id="track-x", title="Other", album_id="album-x", duration=99))
+        session.commit()
+
+    with SessionLocal() as session:
+        response = plex_router.get_tracks("album-1", db=session)
+
+    assert response == {
+        "album": {"id": "album-1", "title": "Greatest", "artist_id": "artist-1"},
+        "tracks": [
+            {"id": "track-1", "title": "Song A", "album_id": "album-1", "duration": 120},
+            {"id": "track-2", "title": "Song B", "album_id": "album-1", "duration": None},
+        ],
+    }
+
+
+def test_worker_syncs_data_into_database() -> None:
+    """The Plex worker fetches metadata and stores it in SQLite."""
+
+    class FakePlexClient:
+        def get_all_artists(self) -> list[dict[str, object]]:
+            return [{"id": "artist-1", "name": "Example Artist"}]
+
+        def get_albums_by_artist(self, artist_id: str) -> list[dict[str, object]]:
+            assert artist_id == "artist-1"
+            return [{"id": "album-1", "title": "Greatest", "artist_id": artist_id}]
+
+        def get_tracks_by_album(self, album_id: str) -> list[dict[str, object]]:
+            assert album_id == "album-1"
+            return [
+                {"id": "track-1", "title": "Song A", "album_id": album_id, "duration": 245},
+                {"id": "track-2", "title": "Song B", "album_id": album_id, "duration": None},
+            ]
+
+    with SessionLocal() as session:
+        session.add(PlexArtist(id="old", name="Old Artist"))
+        session.add(PlexAlbum(id="old-album", title="Old", artist_id="old"))
+        session.add(PlexTrack(id="old-track", title="Legacy", album_id="old-album", duration=1))
+        session.commit()
+
+    worker = PlexWorker(client=FakePlexClient())
+    worker.sync()
+
+    with SessionLocal() as session:
+        artists = session.query(PlexArtist).order_by(PlexArtist.id).all()
+        albums = session.query(PlexAlbum).order_by(PlexAlbum.id).all()
+        tracks = session.query(PlexTrack).order_by(PlexTrack.id).all()
+
+    assert [artist.id for artist in artists] == ["artist-1"]
+    assert albums[0].title == "Greatest"
+    assert albums[0].artist_id == "artist-1"
+    assert [track.id for track in tracks] == ["track-1", "track-2"]
+    assert tracks[0].duration == 245

--- a/tests/test_plex_router.py
+++ b/tests/test_plex_router.py
@@ -1,63 +1,12 @@
-import asyncio
+"""Compatibility tests for the public Plex router import path."""
 
-from app.routers import plex_router
+from __future__ import annotations
 
-
-def test_status_endpoint_reports_connection():
-    async def runner():
-        response = await plex_router.status()
-        assert response == {"plex_connected": True}
-
-    asyncio.run(runner())
+from app.routers import plex_router as public_router
+from backend.app.routers import plex_router as backend_router
 
 
-def test_list_libraries_returns_stub_data():
-    async def runner():
-        response = await plex_router.list_libraries()
-        assert response.model_dump() == {"libraries": ["Music"]}
+def test_public_router_aliases_backend_router() -> None:
+    """The legacy app package exposes the backend Plex router module."""
 
-    asyncio.run(runner())
-
-
-def test_search_tracks_returns_matching_tracks():
-    async def runner():
-        response = await plex_router.search_tracks(query="song")
-        assert response.model_dump() == {
-            "tracks": [
-                {
-                    "title": "Song One",
-                    "artist": "Artist A",
-                    "album": "Album X",
-                    "duration": 210,
-                },
-                {
-                    "title": "Song Two",
-                    "artist": "Artist B",
-                    "album": "Album Y",
-                    "duration": 198,
-                },
-            ]
-        }
-
-    asyncio.run(runner())
-
-
-def test_search_albums_returns_matching_albums():
-    async def runner():
-        response = await plex_router.search_albums(query="album")
-        assert response.model_dump() == {
-            "albums": [
-                {"title": "Album X", "artist": "Artist A", "year": 2020, "track_count": 1},
-                {"title": "Album Y", "artist": "Artist B", "year": 2019, "track_count": 1},
-            ]
-        }
-
-    asyncio.run(runner())
-
-
-def test_get_artists_endpoint():
-    async def runner():
-        response = await plex_router.get_artists()
-        assert response == {"artists": ["Artist A", "Artist B", "Different"]}
-
-    asyncio.run(runner())
+    assert public_router is backend_router

--- a/tests/test_spotify.py
+++ b/tests/test_spotify.py
@@ -1,0 +1,157 @@
+"""Unit tests for the backend Spotify client wrapper."""
+
+from __future__ import annotations
+
+import pytest
+
+from backend.app.core.spotify_client import SpotifyClient
+
+
+class FakeAuthManager:
+    def __init__(self) -> None:
+        self._token = {"access_token": "token"}
+
+    def get_cached_token(self) -> dict[str, str]:
+        return dict(self._token)
+
+
+class FakeSpotifyAPI:
+    def __init__(self) -> None:
+        self._track_calls: list[str] = []
+
+    def search(self, *, q: str, type: str, limit: int) -> dict:
+        if type == "track":
+            return {
+                "tracks": {
+                    "items": [
+                        {
+                            "id": "track-1",
+                            "name": "Song One",
+                            "artists": [{"name": "Artist A"}],
+                            "album": {"name": "Album X"},
+                            "duration_ms": 210000,
+                            "popularity": 55,
+                        }
+                    ]
+                }
+            }
+        if type == "artist":
+            return {
+                "artists": {
+                    "items": [
+                        {
+                            "id": "artist-1",
+                            "name": "Artist A",
+                            "genres": ["rock"],
+                            "followers": {"total": 1000},
+                        }
+                    ]
+                }
+            }
+        if type == "album":
+            return {
+                "albums": {
+                    "items": [
+                        {
+                            "id": "album-1",
+                            "name": "Album X",
+                            "artists": [{"name": "Artist A"}],
+                            "release_date": "2020-01-01",
+                            "total_tracks": 10,
+                        }
+                    ]
+                }
+            }
+        raise ValueError(f"Unsupported search type {type}")
+
+    def current_user_playlists(self) -> dict:
+        return {
+            "items": [
+                {
+                    "id": "playlist-1",
+                    "name": "Favourites",
+                    "owner": {"display_name": "Tester"},
+                    "tracks": {"total": 25},
+                }
+            ]
+        }
+
+    def track(self, track_id: str) -> dict:
+        self._track_calls.append(track_id)
+        return {
+            "id": track_id,
+            "name": "Song One",
+            "artists": [{"name": "Artist A"}],
+            "album": {"id": "album-1", "name": "Album X", "release_date": "2020-01-01"},
+            "duration_ms": 210000,
+            "popularity": 55,
+            "preview_url": "https://example.com/sample.mp3",
+            "uri": "spotify:track:track-1",
+        }
+
+
+@pytest.fixture()
+def spotify_client() -> SpotifyClient:
+    return SpotifyClient(client=FakeSpotifyAPI(), auth_manager=FakeAuthManager(), rate_limit_seconds=0, max_retries=1)
+
+
+def test_is_authenticated_uses_cached_token(spotify_client: SpotifyClient) -> None:
+    assert spotify_client.is_authenticated() is True
+
+
+def test_search_tracks_returns_formatted_results(spotify_client: SpotifyClient) -> None:
+    results = spotify_client.search_tracks("Song")
+    assert results == [
+        {
+            "id": "track-1",
+            "name": "Song One",
+            "artists": ["Artist A"],
+            "album": "Album X",
+            "duration_ms": 210000,
+            "popularity": 55,
+        }
+    ]
+
+
+def test_search_artists_returns_expected_payload(spotify_client: SpotifyClient) -> None:
+    results = spotify_client.search_artists("Artist")
+    assert results == [
+        {
+            "id": "artist-1",
+            "name": "Artist A",
+            "genres": ["rock"],
+            "followers": 1000,
+        }
+    ]
+
+
+def test_search_albums_returns_expected_payload(spotify_client: SpotifyClient) -> None:
+    results = spotify_client.search_albums("Album")
+    assert results == [
+        {
+            "id": "album-1",
+            "name": "Album X",
+            "artists": ["Artist A"],
+            "release_date": "2020-01-01",
+            "total_tracks": 10,
+        }
+    ]
+
+
+def test_get_user_playlists_formats_response(spotify_client: SpotifyClient) -> None:
+    playlists = spotify_client.get_user_playlists()
+    assert playlists == [
+        {
+            "id": "playlist-1",
+            "name": "Favourites",
+            "owner": "Tester",
+            "tracks": 25,
+        }
+    ]
+
+
+def test_get_track_details_returns_structured_payload(spotify_client: SpotifyClient) -> None:
+    details = spotify_client.get_track_details("track-1")
+    assert details["id"] == "track-1"
+    assert details["album"]["name"] == "Album X"
+    assert details["artists"] == ["Artist A"]

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -1,0 +1,104 @@
+"""Tests for synchronisation job persistence and worker integration."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from app.db import SessionLocal, init_db
+from backend.app.models.sync_job import SyncJob
+from backend.app.workers.sync_worker import SyncWorker
+
+
+@pytest.fixture(autouse=True)
+def setup_database() -> None:
+    """Ensure the sync_jobs table exists and is empty for each test."""
+
+    init_db()
+    with SessionLocal() as session:
+        session.query(SyncJob).delete()
+        session.commit()
+    yield
+    with SessionLocal() as session:
+        session.query(SyncJob).delete()
+        session.commit()
+
+
+def _run(coro):
+    """Helper to execute async code within sync tests."""
+
+    return asyncio.run(coro)
+
+
+def test_sync_job_creation(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Starting a sync creates a pending job entry."""
+
+    async def fake_sync_track(self, spotify_track_id: str) -> dict[str, str]:
+        return {"id": spotify_track_id}
+
+    monkeypatch.setattr(SyncWorker, "sync_track", fake_sync_track)
+
+    worker = SyncWorker()
+
+    async def scenario() -> None:
+        job_id = await worker.start_sync("track-123")
+        with SessionLocal() as session:
+            job = session.get(SyncJob, job_id)
+            assert job is not None
+            assert job.spotify_id == "track-123"
+            assert job.status == "pending"
+        task = worker._tasks.get(job_id)
+        if task is not None:
+            await task
+
+    _run(scenario())
+
+
+def test_worker_updates_status_to_completed(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A successful worker run marks the job as completed."""
+
+    async def fake_sync_track(self, spotify_track_id: str) -> dict[str, str]:
+        await asyncio.sleep(0)
+        return {"id": spotify_track_id}
+
+    monkeypatch.setattr(SyncWorker, "sync_track", fake_sync_track)
+
+    worker = SyncWorker()
+
+    async def scenario() -> None:
+        job_id = await worker.start_sync("track-456")
+        task = worker._tasks.get(job_id)
+        if task is not None:
+            await task
+        with SessionLocal() as session:
+            job = session.get(SyncJob, job_id)
+            assert job is not None
+            assert job.status == "completed"
+            assert job.error_message is None
+
+    _run(scenario())
+
+
+def test_worker_records_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Errors during sync are persisted on the job record."""
+
+    async def failing_sync_track(self, spotify_track_id: str) -> None:
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(SyncWorker, "sync_track", failing_sync_track)
+
+    worker = SyncWorker()
+
+    async def scenario() -> None:
+        job_id = await worker.start_sync("track-789")
+        task = worker._tasks.get(job_id)
+        if task is not None:
+            await task
+        with SessionLocal() as session:
+            job = session.get(SyncJob, job_id)
+            assert job is not None
+            assert job.status == "failed"
+            assert job.error_message == "boom"
+
+    _run(scenario())


### PR DESCRIPTION
## Summary
- add a Spotify client that wraps spotipy with OAuth configuration, rate limiting, and retry-aware helpers for searches and metadata retrieval
- expose Spotify search/status endpoints plus Spotify-to-Plex/Soulseek matching APIs backed by new SQLAlchemy models and persistence logic
- implement an asynchronous matching worker and accompanying unit tests that exercise the client, engine, and API flows

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d0a8f0addc8321a7150ad20712a106