### PR TITLE
feat: expand spotify integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@
 # v1.x.x
 - Vollständige slskd API-Integration (Transfers & Users).
 
-# v1.4.0
+## v1.4.0
+- Erweiterter Spotify-Client unterstützt Audio Features, Empfehlungen, Benutzerbibliothek und Playlisten-Management.
+- FastAPI-Router ergänzt neue Endpunkte für `/spotify/me`, Top-Tracks/-Artists, Audio Features und Playlist-Operationen.
 - Vollständige Plex-Integration auf Basis der offiziellen API (aiohttp, async).
 - Neue API-Endpunkte für Bibliotheken, Status, Playback, Playlists, Playqueues und Bewertungen.
 - Unterstützung für Echtzeit-Benachrichtigungen, Geräte- & Live-TV-Übersichten sowie Tag-Synchronisierung.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Harmony ist ein FastAPI-Backend, das Spotify, Plex und den Soulseek-Daemon (slsk
 
 - Modularer Aufbau mit Core-Clients und Routern
 - OAuth-basierter Spotify-Client mit Rate-Limiting und Retry-Logik
+- Spotify Web API Abdeckung für Audio Features, Playlists, Recommendations und User Library
 - Plex-Client zur Abfrage der Musikbibliothek
 - Asynchroner Soulseek-Client (slskd) mit Rate-Limiting
 - Persistente Soulseek-Downloads mit Fortschritts- und Statusverfolgung
@@ -23,6 +24,11 @@ Der `BeetsClient` ruft intern Befehle wie `beet import`, `beet update`,
 `beet ls`, `beet stats` und `beet version` auf, um die lokale Musikbibliothek zu
 verwalten. Damit die Integration funktioniert, muss das Kommando `beet`
 installiert und im `PATH` der Anwendung verfügbar sein.
+
+## Neu in v1.4.0
+
+- Spotify-Router unterstützt Audio Features, Benutzerbibliothek, Empfehlungen und Playlist-Management.
+- Neue API-Endpunkte für User-Profile, Top-Tracks/-Artists sowie Playlist-Operationen (Add/Remove/Reorder).
 
 ## Neu in v1.3.0
 
@@ -96,8 +102,21 @@ Die wichtigsten API-Endpunkte sind:
 - `GET /spotify/search/tracks?query=...`
 - `GET /spotify/search/artists?query=...`
 - `GET /spotify/search/albums?query=...`
+- `GET /spotify/audio-features/{track_id}`
+- `GET /spotify/audio-features?ids=...`
 - `GET /spotify/playlists`
+- `GET /spotify/playlists/{playlist_id}/tracks`
+- `POST /spotify/playlists/{playlist_id}/tracks`
+- `DELETE /spotify/playlists/{playlist_id}/tracks`
+- `PUT /spotify/playlists/{playlist_id}/reorder`
 - `GET /spotify/track/{track_id}`
+- `GET /spotify/me`
+- `GET /spotify/me/tracks`
+- `PUT /spotify/me/tracks`
+- `DELETE /spotify/me/tracks`
+- `GET /spotify/me/top/tracks`
+- `GET /spotify/me/top/artists`
+- `GET /spotify/recommendations`
 - `GET /plex/status`
 - `GET /plex/library/sections`
 - `GET /plex/library/sections/{section_id}/all`

--- a/app/routers/spotify_router.py
+++ b/app/routers/spotify_router.py
@@ -1,20 +1,41 @@
 """Spotify API endpoints."""
 from __future__ import annotations
 
+from typing import List, Optional
+
 from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
 from app.core.spotify_client import SpotifyClient
 from app.dependencies import get_db, get_spotify_client
 from app.models import Playlist
 from app.schemas import (
+    AudioFeaturesResponse,
+    PlaylistItemsResponse,
     PlaylistResponse,
+    RecommendationsResponse,
+    SavedTracksResponse,
     SpotifySearchResponse,
     StatusResponse,
     TrackDetailResponse,
+    UserProfileResponse,
 )
 
 router = APIRouter()
+
+
+class PlaylistTracksPayload(BaseModel):
+    uris: List[str]
+
+
+class PlaylistReorderPayload(BaseModel):
+    range_start: int
+    insert_before: int
+
+
+class TrackIdsPayload(BaseModel):
+    ids: List[str]
 
 
 @router.get("/status", response_model=StatusResponse)
@@ -68,3 +89,177 @@ def get_track_details(
     if not details:
         raise HTTPException(status_code=404, detail="Track not found")
     return TrackDetailResponse(track=details)
+
+
+@router.get("/audio-features/{track_id}", response_model=AudioFeaturesResponse)
+def get_audio_features(
+    track_id: str,
+    client: SpotifyClient = Depends(get_spotify_client),
+) -> AudioFeaturesResponse:
+    features = client.get_audio_features(track_id)
+    if not features:
+        raise HTTPException(status_code=404, detail="Audio features not found")
+    return AudioFeaturesResponse(audio_features=features)
+
+
+@router.get("/audio-features", response_model=AudioFeaturesResponse)
+def get_multiple_audio_features(
+    ids: str = Query(..., min_length=1),
+    client: SpotifyClient = Depends(get_spotify_client),
+) -> AudioFeaturesResponse:
+    track_ids = [item.strip() for item in ids.split(",") if item.strip()]
+    if not track_ids:
+        raise HTTPException(status_code=400, detail="No track IDs provided")
+    features = client.get_multiple_audio_features(track_ids)
+    return AudioFeaturesResponse(audio_features=features.get("audio_features", []))
+
+
+@router.get(
+    "/playlists/{playlist_id}/tracks",
+    response_model=PlaylistItemsResponse,
+)
+def get_playlist_items(
+    playlist_id: str,
+    limit: int = Query(100, ge=1, le=100),
+    client: SpotifyClient = Depends(get_spotify_client),
+) -> PlaylistItemsResponse:
+    items = client.get_playlist_items(playlist_id, limit=limit)
+    total = items.get("total")
+    if total is None:
+        total = items.get("tracks", {}).get("total")
+    if total is None:
+        total = len(items.get("items", []))
+    return PlaylistItemsResponse(
+        items=items.get("items", []),
+        total=total,
+    )
+
+
+@router.post(
+    "/playlists/{playlist_id}/tracks",
+    response_model=StatusResponse,
+)
+def add_tracks_to_playlist(
+    playlist_id: str,
+    payload: PlaylistTracksPayload,
+    client: SpotifyClient = Depends(get_spotify_client),
+) -> StatusResponse:
+    if not payload.uris:
+        raise HTTPException(status_code=400, detail="No track URIs provided")
+    client.add_tracks_to_playlist(playlist_id, payload.uris)
+    return StatusResponse(status="tracks-added")
+
+
+@router.delete(
+    "/playlists/{playlist_id}/tracks",
+    response_model=StatusResponse,
+)
+def remove_tracks_from_playlist(
+    playlist_id: str,
+    payload: PlaylistTracksPayload,
+    client: SpotifyClient = Depends(get_spotify_client),
+) -> StatusResponse:
+    if not payload.uris:
+        raise HTTPException(status_code=400, detail="No track URIs provided")
+    client.remove_tracks_from_playlist(playlist_id, payload.uris)
+    return StatusResponse(status="tracks-removed")
+
+
+@router.put(
+    "/playlists/{playlist_id}/reorder",
+    response_model=StatusResponse,
+)
+def reorder_playlist(
+    playlist_id: str,
+    payload: PlaylistReorderPayload,
+    client: SpotifyClient = Depends(get_spotify_client),
+) -> StatusResponse:
+    client.reorder_playlist_items(
+        playlist_id,
+        range_start=payload.range_start,
+        insert_before=payload.insert_before,
+    )
+    return StatusResponse(status="playlist-reordered")
+
+
+@router.get("/me/tracks", response_model=SavedTracksResponse)
+def get_saved_tracks(
+    limit: int = Query(20, ge=1, le=50),
+    client: SpotifyClient = Depends(get_spotify_client),
+) -> SavedTracksResponse:
+    saved = client.get_saved_tracks(limit=limit)
+    return SavedTracksResponse(items=saved.get("items", []), total=saved.get("total", len(saved.get("items", []))))
+
+
+@router.put("/me/tracks", response_model=StatusResponse)
+def save_tracks(
+    payload: TrackIdsPayload,
+    client: SpotifyClient = Depends(get_spotify_client),
+) -> StatusResponse:
+    if not payload.ids:
+        raise HTTPException(status_code=400, detail="No track IDs provided")
+    client.save_tracks(payload.ids)
+    return StatusResponse(status="tracks-saved")
+
+
+@router.delete("/me/tracks", response_model=StatusResponse)
+def remove_saved_tracks(
+    payload: TrackIdsPayload,
+    client: SpotifyClient = Depends(get_spotify_client),
+) -> StatusResponse:
+    if not payload.ids:
+        raise HTTPException(status_code=400, detail="No track IDs provided")
+    client.remove_saved_tracks(payload.ids)
+    return StatusResponse(status="tracks-removed")
+
+
+@router.get("/me", response_model=UserProfileResponse)
+def get_current_user(
+    client: SpotifyClient = Depends(get_spotify_client),
+) -> UserProfileResponse:
+    profile = client.get_current_user()
+    return UserProfileResponse(profile=profile)
+
+
+@router.get("/me/top/tracks", response_model=SpotifySearchResponse)
+def get_top_tracks(
+    limit: int = Query(20, ge=1, le=50),
+    client: SpotifyClient = Depends(get_spotify_client),
+) -> SpotifySearchResponse:
+    response = client.get_top_tracks(limit=limit)
+    return SpotifySearchResponse(items=response.get("items", []))
+
+
+@router.get("/me/top/artists", response_model=SpotifySearchResponse)
+def get_top_artists(
+    limit: int = Query(20, ge=1, le=50),
+    client: SpotifyClient = Depends(get_spotify_client),
+) -> SpotifySearchResponse:
+    response = client.get_top_artists(limit=limit)
+    return SpotifySearchResponse(items=response.get("items", []))
+
+
+@router.get("/recommendations", response_model=RecommendationsResponse)
+def get_recommendations(
+    seed_tracks: Optional[str] = Query(None),
+    seed_artists: Optional[str] = Query(None),
+    seed_genres: Optional[str] = Query(None),
+    limit: int = Query(20, ge=1, le=100),
+    client: SpotifyClient = Depends(get_spotify_client),
+) -> RecommendationsResponse:
+    def _split(value: Optional[str]) -> Optional[List[str]]:
+        if value is None:
+            return None
+        result = [item.strip() for item in value.split(",") if item.strip()]
+        return result or None
+
+    response = client.get_recommendations(
+        seed_tracks=_split(seed_tracks),
+        seed_artists=_split(seed_artists),
+        seed_genres=_split(seed_genres),
+        limit=limit,
+    )
+    return RecommendationsResponse(
+        tracks=response.get("tracks", []),
+        seeds=response.get("seeds", []),
+    )

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
 from pydantic import BaseModel, Field, ConfigDict
 
@@ -34,6 +34,29 @@ class PlaylistResponse(BaseModel):
 
 class TrackDetailResponse(BaseModel):
     track: Dict[str, Any]
+
+
+class AudioFeaturesResponse(BaseModel):
+    audio_features: Union[Dict[str, Any], List[Dict[str, Any]]]
+
+
+class PlaylistItemsResponse(BaseModel):
+    items: List[Dict[str, Any]]
+    total: int
+
+
+class SavedTracksResponse(BaseModel):
+    items: List[Dict[str, Any]]
+    total: int
+
+
+class UserProfileResponse(BaseModel):
+    profile: Dict[str, Any]
+
+
+class RecommendationsResponse(BaseModel):
+    tracks: List[Dict[str, Any]]
+    seeds: List[Dict[str, Any]]
 
 
 class SoulseekSearchRequest(BaseModel):

--- a/tests/simple_client.py
+++ b/tests/simple_client.py
@@ -62,8 +62,8 @@ class SimpleTestClient:
     def put(self, path: str, json: Optional[Dict[str, Any]] = None) -> SimpleResponse:
         return self._loop.run_until_complete(self._request("PUT", path, json_body=json))
 
-    def delete(self, path: str) -> SimpleResponse:
-        return self._loop.run_until_complete(self._request("DELETE", path))
+    def delete(self, path: str, json: Optional[Dict[str, Any]] = None) -> SimpleResponse:
+        return self._loop.run_until_complete(self._request("DELETE", path, json_body=json))
 
     async def _request(
         self,

--- a/tests/test_spotify.py
+++ b/tests/test_spotify.py
@@ -41,3 +41,66 @@ def test_playlist_sync_worker_persists_playlists(client: SimpleTestClient) -> No
     assert updated["name"] == "Focus Updated"
     assert updated["track_count"] == 15
     assert playlists[0]["id"] == "playlist-1"
+
+
+def test_audio_features_endpoints(client: SimpleTestClient) -> None:
+    stub = client.app.state.spotify_stub
+    stub.audio_features["track-2"] = {"id": "track-2", "danceability": 0.7}
+
+    single = client.get("/spotify/audio-features/track-1")
+    assert single.status_code == 200
+    assert single.json()["audio_features"]["id"] == "track-1"
+
+    multiple = client.get("/spotify/audio-features", params={"ids": "track-1,track-2"})
+    assert multiple.status_code == 200
+    features = multiple.json()["audio_features"]
+    assert isinstance(features, list)
+    assert {item["id"] for item in features} == {"track-1", "track-2"}
+
+
+def test_playlist_items_endpoint(client: SimpleTestClient) -> None:
+    stub = client.app.state.spotify_stub
+    stub.playlist_items["playlist-42"] = {
+        "items": [{"track": {"id": "track-1"}}, {"track": {"id": "track-2"}}],
+        "total": 2,
+    }
+
+    response = client.get("/spotify/playlists/playlist-42/tracks")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["total"] == 2
+    assert len(body["items"]) == 2
+
+
+def test_save_and_remove_tracks(client: SimpleTestClient) -> None:
+    stub = client.app.state.spotify_stub
+
+    save_response = client.put("/spotify/me/tracks", json={"ids": ["track-1", "track-2"]})
+    assert save_response.status_code == 200
+    assert stub.saved_track_ids == {"track-1", "track-2"}
+
+    saved = client.get("/spotify/me/tracks")
+    assert saved.status_code == 200
+    data = saved.json()
+    assert data["total"] == 2
+
+    remove_response = client.delete("/spotify/me/tracks", json={"ids": ["track-1"]})
+    assert remove_response.status_code == 200
+    assert stub.saved_track_ids == {"track-2"}
+
+
+def test_recommendations_endpoint(client: SimpleTestClient) -> None:
+    stub = client.app.state.spotify_stub
+    stub.recommendation_payload = {
+        "tracks": [{"id": "track-3"}],
+        "seeds": [{"type": "track", "id": "track-1"}],
+    }
+
+    response = client.get(
+        "/spotify/recommendations",
+        params={"seed_tracks": "track-1", "limit": 1},
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["tracks"] == [{"id": "track-3"}]
+    assert body["seeds"] == [{"type": "track", "id": "track-1"}]


### PR DESCRIPTION
## Summary
- extend the Spotify client with audio features, playlist management, user library, profile, and recommendation helpers
- expose new FastAPI endpoints and schemas for the extended Spotify features and document them in the README/CHANGELOG
- update the Spotify test stub and suite to cover audio features, playlist items, saved tracks, and recommendations

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d199ebc2d48321a115d32dac9f6134