### PR TITLE
Load service config from database settings

### DIFF
--- a/BACKUP
+++ b/BACKUP
@@ -98,6 +98,10 @@ See [the docs](https://docs.pytest.org/en/stable/how-to/cache.html) for more inf
   "tests/test_beets.py::TestWrite::test_timeout",
   "tests/test_beets.py::TestWrite::test_with_query",
   "tests/test_beets.py::TestWrite::test_without_query",
+  "tests/test_config.py::test_configuration_falls_back_to_environment",
+  "tests/test_config.py::test_plex_configuration_from_database",
+  "tests/test_config.py::test_soulseek_configuration_from_database",
+  "tests/test_config.py::test_spotify_configuration_from_database[entries0-expected0]",
   "tests/test_matching.py::test_album_matching_engine",
   "tests/test_matching.py::test_match_confidence",
   "tests/test_matching.py::test_matching_api_album",
@@ -133,6 +137,7 @@ See [the docs](https://docs.pytest.org/en/stable/how-to/cache.html) for more inf
 Alle nennenswerten Änderungen dieses Projekts werden in dieser Datei dokumentiert.
 
 ## v1.4.0 – Spotify API Vollintegration
+- Konfiguration für Spotify, Plex und slskd kann jetzt in der Datenbank persistiert und über die Settings-API gepflegt werden.
 - Vollständige Spotify-Integration inkl. Playlist-Sync, Audio-Features, Recommendations und Benutzerbibliothek.
 - Erweiterter Spotify-Router mit neuen Endpunkten für Playlists (Add/Remove/Reorder), Profil, Top-Tracks/-Artists.
 - PlaylistSyncWorker synchronisiert persistierte Playlists regelmäßig in die Datenbank.
@@ -278,6 +283,8 @@ Requests die Test-Suite (`pytest`) unter Python 3.11 aus.
 | `HARMONY_LOG_LEVEL` | Log-Level (`INFO`, `DEBUG`, …) |
 | `HARMONY_DISABLE_WORKERS` | `1` deaktiviert alle Hintergrund-Worker (z. B. für Tests) |
 
+> **Hinweis:** Spotify-, Plex- und slskd-Zugangsdaten können über den `/settings`-Endpoint gepflegt und in der Datenbank persistiert werden. Beim Laden der Anwendung haben Werte aus der Datenbank Vorrang vor Umgebungsvariablen; letztere dienen weiterhin als Fallback.
+
 ## API-Endpoints
 
 Eine vollständige Referenz der FastAPI-Routen befindet sich in [`docs/api.md`](docs/api.md). Die wichtigsten Gruppen im Überblick:
@@ -321,7 +328,10 @@ from __future__ import annotations
 
 import os
 from dataclasses import dataclass
-from typing import Optional
+from typing import Iterable, Mapping, Optional
+
+from sqlalchemy import create_engine, text
+from sqlalchemy.exc import SQLAlchemyError
 
 
 @dataclass(slots=True)
@@ -371,29 +381,136 @@ DEFAULT_SPOTIFY_SCOPE = (
 )
 
 
+def _load_settings_from_db(
+    keys: Iterable[str], *, database_url: Optional[str] = None
+) -> dict[str, Optional[str]]:
+    """Fetch selected settings from the database."""
+
+    database_url = database_url or os.getenv("DATABASE_URL", DEFAULT_DB_URL)
+    if not database_url:
+        return {}
+
+    connect_args = {"check_same_thread": False} if database_url.startswith("sqlite") else {}
+
+    try:
+        engine = create_engine(database_url, connect_args=connect_args)
+    except SQLAlchemyError:
+        return {}
+
+    settings: dict[str, Optional[str]] = {}
+    try:
+        with engine.connect() as connection:
+            for key in keys:
+                try:
+                    row = connection.execute(
+                        text("SELECT value FROM settings WHERE key = :key LIMIT 1"),
+                        {"key": key},
+                    ).first()
+                except SQLAlchemyError:
+                    return {}
+
+                if row is not None:
+                    # Preserve keys found in the database, even if the value is NULL.
+                    settings[key] = row[0]
+    except SQLAlchemyError:
+        return {}
+    finally:
+        engine.dispose()
+
+    return settings
+
+
+def get_setting(key: str, *, database_url: Optional[str] = None) -> Optional[str]:
+    """Return a single setting value from the database if available."""
+
+    settings = _load_settings_from_db([key], database_url=database_url)
+    return settings.get(key)
+
+
+def _resolve_setting(
+    key: str,
+    *,
+    db_settings: Mapping[str, Optional[str]],
+    fallback: Optional[str],
+) -> Optional[str]:
+    if key in db_settings:
+        value = db_settings[key]
+        return fallback if value is None else value
+    return fallback
+
+
 def load_config() -> AppConfig:
-    """Load application configuration from environment variables."""
+    """Load application configuration prioritising database backed settings."""
+
+    database_url = os.getenv("DATABASE_URL", DEFAULT_DB_URL)
+
+    config_keys = [
+        "SPOTIFY_CLIENT_ID",
+        "SPOTIFY_CLIENT_SECRET",
+        "SPOTIFY_REDIRECT_URI",
+        "PLEX_BASE_URL",
+        "PLEX_TOKEN",
+        "PLEX_LIBRARY",
+        "SLSKD_URL",
+        "SLSKD_API_KEY",
+    ]
+    db_settings = _load_settings_from_db(config_keys, database_url=database_url)
 
     spotify = SpotifyConfig(
-        client_id=os.getenv("SPOTIFY_CLIENT_ID"),
-        client_secret=os.getenv("SPOTIFY_CLIENT_SECRET"),
-        redirect_uri=os.getenv("SPOTIFY_REDIRECT_URI"),
+        client_id=_resolve_setting(
+            "SPOTIFY_CLIENT_ID",
+            db_settings=db_settings,
+            fallback=os.getenv("SPOTIFY_CLIENT_ID"),
+        ),
+        client_secret=_resolve_setting(
+            "SPOTIFY_CLIENT_SECRET",
+            db_settings=db_settings,
+            fallback=os.getenv("SPOTIFY_CLIENT_SECRET"),
+        ),
+        redirect_uri=_resolve_setting(
+            "SPOTIFY_REDIRECT_URI",
+            db_settings=db_settings,
+            fallback=os.getenv("SPOTIFY_REDIRECT_URI"),
+        ),
         scope=os.getenv("SPOTIFY_SCOPE", DEFAULT_SPOTIFY_SCOPE),
     )
 
+    plex_base_url_env = os.getenv("PLEX_BASE_URL") or os.getenv("PLEX_URL")
     plex = PlexConfig(
-        base_url=os.getenv("PLEX_BASE_URL") or os.getenv("PLEX_URL"),
-        token=os.getenv("PLEX_TOKEN"),
-        library_name=os.getenv("PLEX_LIBRARY"),
+        base_url=_resolve_setting(
+            "PLEX_BASE_URL",
+            db_settings=db_settings,
+            fallback=plex_base_url_env,
+        ),
+        token=_resolve_setting(
+            "PLEX_TOKEN",
+            db_settings=db_settings,
+            fallback=os.getenv("PLEX_TOKEN"),
+        ),
+        library_name=_resolve_setting(
+            "PLEX_LIBRARY",
+            db_settings=db_settings,
+            fallback=os.getenv("PLEX_LIBRARY"),
+        ),
     )
 
+    soulseek_base_env = os.getenv("SLSKD_URL") or DEFAULT_SOULSEEK_URL
     soulseek = SoulseekConfig(
-        base_url=os.getenv("SLSKD_URL", DEFAULT_SOULSEEK_URL),
-        api_key=os.getenv("SLSKD_API_KEY"),
+        base_url=_resolve_setting(
+            "SLSKD_URL",
+            db_settings=db_settings,
+            fallback=soulseek_base_env,
+        )
+        or DEFAULT_SOULSEEK_URL,
+        api_key=_resolve_setting(
+            "SLSKD_API_KEY",
+            db_settings=db_settings,
+            fallback=os.getenv("SLSKD_API_KEY"),
+        ),
     )
 
     logging = LoggingConfig(level=os.getenv("HARMONY_LOG_LEVEL", "INFO"))
-    database = DatabaseConfig(url=os.getenv("DATABASE_URL", DEFAULT_DB_URL))
+    database = DatabaseConfig(url=database_url)
 
     return AppConfig(
         spotify=spotify,
@@ -2339,6 +2456,7 @@ async def listen_notifications(client: PlexClient = Depends(get_plex_client)) ->
 from __future__ import annotations
 
 from datetime import datetime
+from typing import Final
 
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy import select
@@ -2348,6 +2466,18 @@ from app.dependencies import get_db
 from app.models import Setting, SettingHistory
 from app.schemas import SettingsHistoryResponse, SettingsPayload, SettingsResponse
 
+CONFIGURATION_KEYS: Final[tuple[str, ...]] = (
+    "SPOTIFY_CLIENT_ID",
+    "SPOTIFY_CLIENT_SECRET",
+    "SPOTIFY_REDIRECT_URI",
+    "PLEX_BASE_URL",
+    "PLEX_TOKEN",
+    "PLEX_LIBRARY",
+    "SLSKD_URL",
+    "SLSKD_API_KEY",
+)
+
+
 router = APIRouter()
 
 
@@ -2355,6 +2485,8 @@ router = APIRouter()
 def get_settings(session: Session = Depends(get_db)) -> SettingsResponse:
     settings = session.execute(select(Setting)).scalars().all()
     settings_dict = {setting.key: setting.value for setting in settings}
+    for key in CONFIGURATION_KEYS:
+        settings_dict.setdefault(key, None)
     updated_at = max((setting.updated_at or setting.created_at for setting in settings), default=datetime.utcnow())
     return SettingsResponse(settings=settings_dict, updated_at=updated_at)
 
@@ -5312,6 +5444,99 @@ class TestRouterQuery:
         assert response.status_code == 400
         assert response.json()["detail"] == "Invalid query syntax"
 
+
+===== tests/test_config.py =====
+from __future__ import annotations
+
+import pytest
+
+from app.config import load_config
+from app.db import session_scope
+from app.models import Setting
+
+
+def _insert_settings(entries: dict[str, str | None]) -> None:
+    with session_scope() as session:
+        for key, value in entries.items():
+            session.add(Setting(key=key, value=value))
+
+
+@pytest.mark.parametrize(
+    "entries,expected",
+    [
+        (
+            {
+                "SPOTIFY_CLIENT_ID": "db-client-id",
+                "SPOTIFY_CLIENT_SECRET": "db-secret",
+                "SPOTIFY_REDIRECT_URI": "http://localhost/callback",
+            },
+            {
+                "client_id": "db-client-id",
+                "client_secret": "db-secret",
+                "redirect_uri": "http://localhost/callback",
+            },
+        ),
+    ],
+)
+def test_spotify_configuration_from_database(monkeypatch: pytest.MonkeyPatch, entries, expected) -> None:
+    for key in ("SPOTIFY_CLIENT_ID", "SPOTIFY_CLIENT_SECRET", "SPOTIFY_REDIRECT_URI"):
+        monkeypatch.delenv(key, raising=False)
+
+    _insert_settings(entries)
+
+    config = load_config()
+
+    assert config.spotify.client_id == expected["client_id"]
+    assert config.spotify.client_secret == expected["client_secret"]
+    assert config.spotify.redirect_uri == expected["redirect_uri"]
+
+
+def test_plex_configuration_from_database(monkeypatch: pytest.MonkeyPatch) -> None:
+    for key in ("PLEX_BASE_URL", "PLEX_URL", "PLEX_TOKEN", "PLEX_LIBRARY"):
+        monkeypatch.delenv(key, raising=False)
+
+    _insert_settings(
+        {
+            "PLEX_BASE_URL": "http://plex.local:32400",
+            "PLEX_TOKEN": "db-token",
+            "PLEX_LIBRARY": "Music",
+        }
+    )
+
+    config = load_config()
+
+    assert config.plex.base_url == "http://plex.local:32400"
+    assert config.plex.token == "db-token"
+    assert config.plex.library_name == "Music"
+
+
+def test_soulseek_configuration_from_database(monkeypatch: pytest.MonkeyPatch) -> None:
+    for key in ("SLSKD_URL", "SLSKD_API_KEY"):
+        monkeypatch.delenv(key, raising=False)
+
+    _insert_settings(
+        {
+            "SLSKD_URL": "http://slskd:5030",
+            "SLSKD_API_KEY": "db-api-key",
+        }
+    )
+
+    config = load_config()
+
+    assert config.soulseek.base_url == "http://slskd:5030"
+    assert config.soulseek.api_key == "db-api-key"
+
+
+def test_configuration_falls_back_to_environment(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SPOTIFY_CLIENT_ID", "env-client")
+    monkeypatch.setenv("PLEX_BASE_URL", "http://env-plex")
+    monkeypatch.setenv("SLSKD_URL", "http://env-slskd")
+
+    config = load_config()
+
+    assert config.spotify.client_id == "env-client"
+    assert config.plex.base_url == "http://env-plex"
+    assert config.soulseek.base_url == "http://env-slskd"
 
 ===== tests/test_matching.py =====
 from __future__ import annotations
@@ -5999,6 +6224,10 @@ See [the docs](https://docs.pytest.org/en/stable/how-to/cache.html) for more inf
   "tests/test_beets.py::TestWrite::test_timeout",
   "tests/test_beets.py::TestWrite::test_with_query",
   "tests/test_beets.py::TestWrite::test_without_query",
+  "tests/test_config.py::test_configuration_falls_back_to_environment",
+  "tests/test_config.py::test_plex_configuration_from_database",
+  "tests/test_config.py::test_soulseek_configuration_from_database",
+  "tests/test_config.py::test_spotify_configuration_from_database[entries0-expected0]",
   "tests/test_matching.py::test_album_matching_engine",
   "tests/test_matching.py::test_match_confidence",
   "tests/test_matching.py::test_matching_api_album",
@@ -6034,6 +6263,7 @@ See [the docs](https://docs.pytest.org/en/stable/how-to/cache.html) for more inf
 Alle nennenswerten Änderungen dieses Projekts werden in dieser Datei dokumentiert.
 
 ## v1.4.0 – Spotify API Vollintegration
+- Konfiguration für Spotify, Plex und slskd kann jetzt in der Datenbank persistiert und über die Settings-API gepflegt werden.
 - Vollständige Spotify-Integration inkl. Playlist-Sync, Audio-Features, Recommendations und Benutzerbibliothek.
 - Erweiterter Spotify-Router mit neuen Endpunkten für Playlists (Add/Remove/Reorder), Profil, Top-Tracks/-Artists.
 - PlaylistSyncWorker synchronisiert persistierte Playlists regelmäßig in die Datenbank.
@@ -6179,6 +6409,8 @@ Requests die Test-Suite (`pytest`) unter Python 3.11 aus.
 | `HARMONY_LOG_LEVEL` | Log-Level (`INFO`, `DEBUG`, …) |
 | `HARMONY_DISABLE_WORKERS` | `1` deaktiviert alle Hintergrund-Worker (z. B. für Tests) |
 
+> **Hinweis:** Spotify-, Plex- und slskd-Zugangsdaten können über den `/settings`-Endpoint gepflegt und in der Datenbank persistiert werden. Beim Laden der Anwendung haben Werte aus der Datenbank Vorrang vor Umgebungsvariablen; letztere dienen weiterhin als Fallback.
+
 ## API-Endpoints
 
 Eine vollständige Referenz der FastAPI-Routen befindet sich in [`docs/api.md`](docs/api.md). Die wichtigsten Gruppen im Überblick:
@@ -6222,7 +6454,10 @@ from __future__ import annotations
 
 import os
 from dataclasses import dataclass
-from typing import Optional
+from typing import Iterable, Mapping, Optional
+
+from sqlalchemy import create_engine, text
+from sqlalchemy.exc import SQLAlchemyError
 
 
 @dataclass(slots=True)
@@ -6272,29 +6507,136 @@ DEFAULT_SPOTIFY_SCOPE = (
 )
 
 
+def _load_settings_from_db(
+    keys: Iterable[str], *, database_url: Optional[str] = None
+) -> dict[str, Optional[str]]:
+    """Fetch selected settings from the database."""
+
+    database_url = database_url or os.getenv("DATABASE_URL", DEFAULT_DB_URL)
+    if not database_url:
+        return {}
+
+    connect_args = {"check_same_thread": False} if database_url.startswith("sqlite") else {}
+
+    try:
+        engine = create_engine(database_url, connect_args=connect_args)
+    except SQLAlchemyError:
+        return {}
+
+    settings: dict[str, Optional[str]] = {}
+    try:
+        with engine.connect() as connection:
+            for key in keys:
+                try:
+                    row = connection.execute(
+                        text("SELECT value FROM settings WHERE key = :key LIMIT 1"),
+                        {"key": key},
+                    ).first()
+                except SQLAlchemyError:
+                    return {}
+
+                if row is not None:
+                    # Preserve keys found in the database, even if the value is NULL.
+                    settings[key] = row[0]
+    except SQLAlchemyError:
+        return {}
+    finally:
+        engine.dispose()
+
+    return settings
+
+
+def get_setting(key: str, *, database_url: Optional[str] = None) -> Optional[str]:
+    """Return a single setting value from the database if available."""
+
+    settings = _load_settings_from_db([key], database_url=database_url)
+    return settings.get(key)
+
+
+def _resolve_setting(
+    key: str,
+    *,
+    db_settings: Mapping[str, Optional[str]],
+    fallback: Optional[str],
+) -> Optional[str]:
+    if key in db_settings:
+        value = db_settings[key]
+        return fallback if value is None else value
+    return fallback
+
+
 def load_config() -> AppConfig:
-    """Load application configuration from environment variables."""
+    """Load application configuration prioritising database backed settings."""
+
+    database_url = os.getenv("DATABASE_URL", DEFAULT_DB_URL)
+
+    config_keys = [
+        "SPOTIFY_CLIENT_ID",
+        "SPOTIFY_CLIENT_SECRET",
+        "SPOTIFY_REDIRECT_URI",
+        "PLEX_BASE_URL",
+        "PLEX_TOKEN",
+        "PLEX_LIBRARY",
+        "SLSKD_URL",
+        "SLSKD_API_KEY",
+    ]
+    db_settings = _load_settings_from_db(config_keys, database_url=database_url)
 
     spotify = SpotifyConfig(
-        client_id=os.getenv("SPOTIFY_CLIENT_ID"),
-        client_secret=os.getenv("SPOTIFY_CLIENT_SECRET"),
-        redirect_uri=os.getenv("SPOTIFY_REDIRECT_URI"),
+        client_id=_resolve_setting(
+            "SPOTIFY_CLIENT_ID",
+            db_settings=db_settings,
+            fallback=os.getenv("SPOTIFY_CLIENT_ID"),
+        ),
+        client_secret=_resolve_setting(
+            "SPOTIFY_CLIENT_SECRET",
+            db_settings=db_settings,
+            fallback=os.getenv("SPOTIFY_CLIENT_SECRET"),
+        ),
+        redirect_uri=_resolve_setting(
+            "SPOTIFY_REDIRECT_URI",
+            db_settings=db_settings,
+            fallback=os.getenv("SPOTIFY_REDIRECT_URI"),
+        ),
         scope=os.getenv("SPOTIFY_SCOPE", DEFAULT_SPOTIFY_SCOPE),
     )
 
+    plex_base_url_env = os.getenv("PLEX_BASE_URL") or os.getenv("PLEX_URL")
     plex = PlexConfig(
-        base_url=os.getenv("PLEX_BASE_URL") or os.getenv("PLEX_URL"),
-        token=os.getenv("PLEX_TOKEN"),
-        library_name=os.getenv("PLEX_LIBRARY"),
+        base_url=_resolve_setting(
+            "PLEX_BASE_URL",
+            db_settings=db_settings,
+            fallback=plex_base_url_env,
+        ),
+        token=_resolve_setting(
+            "PLEX_TOKEN",
+            db_settings=db_settings,
+            fallback=os.getenv("PLEX_TOKEN"),
+        ),
+        library_name=_resolve_setting(
+            "PLEX_LIBRARY",
+            db_settings=db_settings,
+            fallback=os.getenv("PLEX_LIBRARY"),
+        ),
     )
 
+    soulseek_base_env = os.getenv("SLSKD_URL") or DEFAULT_SOULSEEK_URL
     soulseek = SoulseekConfig(
-        base_url=os.getenv("SLSKD_URL", DEFAULT_SOULSEEK_URL),
-        api_key=os.getenv("SLSKD_API_KEY"),
+        base_url=_resolve_setting(
+            "SLSKD_URL",
+            db_settings=db_settings,
+            fallback=soulseek_base_env,
+        )
+        or DEFAULT_SOULSEEK_URL,
+        api_key=_resolve_setting(
+            "SLSKD_API_KEY",
+            db_settings=db_settings,
+            fallback=os.getenv("SLSKD_API_KEY"),
+        ),
     )
 
     logging = LoggingConfig(level=os.getenv("HARMONY_LOG_LEVEL", "INFO"))
-    database = DatabaseConfig(url=os.getenv("DATABASE_URL", DEFAULT_DB_URL))
+    database = DatabaseConfig(url=database_url)
 
     return AppConfig(
         spotify=spotify,
@@ -8240,6 +8582,7 @@ async def listen_notifications(client: PlexClient = Depends(get_plex_client)) ->
 from __future__ import annotations
 
 from datetime import datetime
+from typing import Final
 
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy import select
@@ -8249,6 +8592,18 @@ from app.dependencies import get_db
 from app.models import Setting, SettingHistory
 from app.schemas import SettingsHistoryResponse, SettingsPayload, SettingsResponse
 
+CONFIGURATION_KEYS: Final[tuple[str, ...]] = (
+    "SPOTIFY_CLIENT_ID",
+    "SPOTIFY_CLIENT_SECRET",
+    "SPOTIFY_REDIRECT_URI",
+    "PLEX_BASE_URL",
+    "PLEX_TOKEN",
+    "PLEX_LIBRARY",
+    "SLSKD_URL",
+    "SLSKD_API_KEY",
+)
+
+
 router = APIRouter()
 
 
@@ -8256,6 +8611,8 @@ router = APIRouter()
 def get_settings(session: Session = Depends(get_db)) -> SettingsResponse:
     settings = session.execute(select(Setting)).scalars().all()
     settings_dict = {setting.key: setting.value for setting in settings}
+    for key in CONFIGURATION_KEYS:
+        settings_dict.setdefault(key, None)
     updated_at = max((setting.updated_at or setting.created_at for setting in settings), default=datetime.utcnow())
     return SettingsResponse(settings=settings_dict, updated_at=updated_at)
 
@@ -11214,6 +11571,99 @@ class TestRouterQuery:
         assert response.json()["detail"] == "Invalid query syntax"
 
 
+===== tests/test_config.py =====
+from __future__ import annotations
+
+import pytest
+
+from app.config import load_config
+from app.db import session_scope
+from app.models import Setting
+
+
+def _insert_settings(entries: dict[str, str | None]) -> None:
+    with session_scope() as session:
+        for key, value in entries.items():
+            session.add(Setting(key=key, value=value))
+
+
+@pytest.mark.parametrize(
+    "entries,expected",
+    [
+        (
+            {
+                "SPOTIFY_CLIENT_ID": "db-client-id",
+                "SPOTIFY_CLIENT_SECRET": "db-secret",
+                "SPOTIFY_REDIRECT_URI": "http://localhost/callback",
+            },
+            {
+                "client_id": "db-client-id",
+                "client_secret": "db-secret",
+                "redirect_uri": "http://localhost/callback",
+            },
+        ),
+    ],
+)
+def test_spotify_configuration_from_database(monkeypatch: pytest.MonkeyPatch, entries, expected) -> None:
+    for key in ("SPOTIFY_CLIENT_ID", "SPOTIFY_CLIENT_SECRET", "SPOTIFY_REDIRECT_URI"):
+        monkeypatch.delenv(key, raising=False)
+
+    _insert_settings(entries)
+
+    config = load_config()
+
+    assert config.spotify.client_id == expected["client_id"]
+    assert config.spotify.client_secret == expected["client_secret"]
+    assert config.spotify.redirect_uri == expected["redirect_uri"]
+
+
+def test_plex_configuration_from_database(monkeypatch: pytest.MonkeyPatch) -> None:
+    for key in ("PLEX_BASE_URL", "PLEX_URL", "PLEX_TOKEN", "PLEX_LIBRARY"):
+        monkeypatch.delenv(key, raising=False)
+
+    _insert_settings(
+        {
+            "PLEX_BASE_URL": "http://plex.local:32400",
+            "PLEX_TOKEN": "db-token",
+            "PLEX_LIBRARY": "Music",
+        }
+    )
+
+    config = load_config()
+
+    assert config.plex.base_url == "http://plex.local:32400"
+    assert config.plex.token == "db-token"
+    assert config.plex.library_name == "Music"
+
+
+def test_soulseek_configuration_from_database(monkeypatch: pytest.MonkeyPatch) -> None:
+    for key in ("SLSKD_URL", "SLSKD_API_KEY"):
+        monkeypatch.delenv(key, raising=False)
+
+    _insert_settings(
+        {
+            "SLSKD_URL": "http://slskd:5030",
+            "SLSKD_API_KEY": "db-api-key",
+        }
+    )
+
+    config = load_config()
+
+    assert config.soulseek.base_url == "http://slskd:5030"
+    assert config.soulseek.api_key == "db-api-key"
+
+
+def test_configuration_falls_back_to_environment(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SPOTIFY_CLIENT_ID", "env-client")
+    monkeypatch.setenv("PLEX_BASE_URL", "http://env-plex")
+    monkeypatch.setenv("SLSKD_URL", "http://env-slskd")
+
+    config = load_config()
+
+    assert config.spotify.client_id == "env-client"
+    assert config.plex.base_url == "http://env-plex"
+    assert config.soulseek.base_url == "http://env-slskd"
+
 ===== tests/test_matching.py =====
 from __future__ import annotations
 
@@ -11798,4 +12248,3 @@ def test_recommendations_endpoint(client: SimpleTestClient) -> None:
     body = response.json()
     assert body["tracks"] == [{"id": "track-3"}]
     assert body["seeds"] == [{"type": "track", "id": "track-1"}]
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Alle nennenswerten Änderungen dieses Projekts werden in dieser Datei dokumentiert.
 
 ## v1.4.0 – Spotify API Vollintegration
+- Konfiguration für Spotify, Plex und slskd kann jetzt in der Datenbank persistiert und über die Settings-API gepflegt werden.
 - Vollständige Spotify-Integration inkl. Playlist-Sync, Audio-Features, Recommendations und Benutzerbibliothek.
 - Erweiterter Spotify-Router mit neuen Endpunkten für Playlists (Add/Remove/Reorder), Profil, Top-Tracks/-Artists.
 - PlaylistSyncWorker synchronisiert persistierte Playlists regelmäßig in die Datenbank.

--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ Requests die Test-Suite (`pytest`) unter Python 3.11 aus.
 | `HARMONY_LOG_LEVEL` | Log-Level (`INFO`, `DEBUG`, …) |
 | `HARMONY_DISABLE_WORKERS` | `1` deaktiviert alle Hintergrund-Worker (z. B. für Tests) |
 
+> **Hinweis:** Spotify-, Plex- und slskd-Zugangsdaten können über den `/settings`-Endpoint gepflegt und in der Datenbank persistiert werden. Beim Laden der Anwendung haben Werte aus der Datenbank Vorrang vor Umgebungsvariablen; letztere dienen weiterhin als Fallback.
+
 ## API-Endpoints
 
 Eine vollständige Referenz der FastAPI-Routen befindet sich in [`docs/api.md`](docs/api.md). Die wichtigsten Gruppen im Überblick:

--- a/app/config.py
+++ b/app/config.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 
 import os
 from dataclasses import dataclass
-from typing import Optional
+from typing import Iterable, Mapping, Optional
+
+from sqlalchemy import create_engine, text
+from sqlalchemy.exc import SQLAlchemyError
 
 
 @dataclass(slots=True)
@@ -53,29 +56,136 @@ DEFAULT_SPOTIFY_SCOPE = (
 )
 
 
+def _load_settings_from_db(
+    keys: Iterable[str], *, database_url: Optional[str] = None
+) -> dict[str, Optional[str]]:
+    """Fetch selected settings from the database."""
+
+    database_url = database_url or os.getenv("DATABASE_URL", DEFAULT_DB_URL)
+    if not database_url:
+        return {}
+
+    connect_args = {"check_same_thread": False} if database_url.startswith("sqlite") else {}
+
+    try:
+        engine = create_engine(database_url, connect_args=connect_args)
+    except SQLAlchemyError:
+        return {}
+
+    settings: dict[str, Optional[str]] = {}
+    try:
+        with engine.connect() as connection:
+            for key in keys:
+                try:
+                    row = connection.execute(
+                        text("SELECT value FROM settings WHERE key = :key LIMIT 1"),
+                        {"key": key},
+                    ).first()
+                except SQLAlchemyError:
+                    return {}
+
+                if row is not None:
+                    # Preserve keys found in the database, even if the value is NULL.
+                    settings[key] = row[0]
+    except SQLAlchemyError:
+        return {}
+    finally:
+        engine.dispose()
+
+    return settings
+
+
+def get_setting(key: str, *, database_url: Optional[str] = None) -> Optional[str]:
+    """Return a single setting value from the database if available."""
+
+    settings = _load_settings_from_db([key], database_url=database_url)
+    return settings.get(key)
+
+
+def _resolve_setting(
+    key: str,
+    *,
+    db_settings: Mapping[str, Optional[str]],
+    fallback: Optional[str],
+) -> Optional[str]:
+    if key in db_settings:
+        value = db_settings[key]
+        return fallback if value is None else value
+    return fallback
+
+
 def load_config() -> AppConfig:
-    """Load application configuration from environment variables."""
+    """Load application configuration prioritising database backed settings."""
+
+    database_url = os.getenv("DATABASE_URL", DEFAULT_DB_URL)
+
+    config_keys = [
+        "SPOTIFY_CLIENT_ID",
+        "SPOTIFY_CLIENT_SECRET",
+        "SPOTIFY_REDIRECT_URI",
+        "PLEX_BASE_URL",
+        "PLEX_TOKEN",
+        "PLEX_LIBRARY",
+        "SLSKD_URL",
+        "SLSKD_API_KEY",
+    ]
+    db_settings = _load_settings_from_db(config_keys, database_url=database_url)
 
     spotify = SpotifyConfig(
-        client_id=os.getenv("SPOTIFY_CLIENT_ID"),
-        client_secret=os.getenv("SPOTIFY_CLIENT_SECRET"),
-        redirect_uri=os.getenv("SPOTIFY_REDIRECT_URI"),
+        client_id=_resolve_setting(
+            "SPOTIFY_CLIENT_ID",
+            db_settings=db_settings,
+            fallback=os.getenv("SPOTIFY_CLIENT_ID"),
+        ),
+        client_secret=_resolve_setting(
+            "SPOTIFY_CLIENT_SECRET",
+            db_settings=db_settings,
+            fallback=os.getenv("SPOTIFY_CLIENT_SECRET"),
+        ),
+        redirect_uri=_resolve_setting(
+            "SPOTIFY_REDIRECT_URI",
+            db_settings=db_settings,
+            fallback=os.getenv("SPOTIFY_REDIRECT_URI"),
+        ),
         scope=os.getenv("SPOTIFY_SCOPE", DEFAULT_SPOTIFY_SCOPE),
     )
 
+    plex_base_url_env = os.getenv("PLEX_BASE_URL") or os.getenv("PLEX_URL")
     plex = PlexConfig(
-        base_url=os.getenv("PLEX_BASE_URL") or os.getenv("PLEX_URL"),
-        token=os.getenv("PLEX_TOKEN"),
-        library_name=os.getenv("PLEX_LIBRARY"),
+        base_url=_resolve_setting(
+            "PLEX_BASE_URL",
+            db_settings=db_settings,
+            fallback=plex_base_url_env,
+        ),
+        token=_resolve_setting(
+            "PLEX_TOKEN",
+            db_settings=db_settings,
+            fallback=os.getenv("PLEX_TOKEN"),
+        ),
+        library_name=_resolve_setting(
+            "PLEX_LIBRARY",
+            db_settings=db_settings,
+            fallback=os.getenv("PLEX_LIBRARY"),
+        ),
     )
 
+    soulseek_base_env = os.getenv("SLSKD_URL") or DEFAULT_SOULSEEK_URL
     soulseek = SoulseekConfig(
-        base_url=os.getenv("SLSKD_URL", DEFAULT_SOULSEEK_URL),
-        api_key=os.getenv("SLSKD_API_KEY"),
+        base_url=_resolve_setting(
+            "SLSKD_URL",
+            db_settings=db_settings,
+            fallback=soulseek_base_env,
+        )
+        or DEFAULT_SOULSEEK_URL,
+        api_key=_resolve_setting(
+            "SLSKD_API_KEY",
+            db_settings=db_settings,
+            fallback=os.getenv("SLSKD_API_KEY"),
+        ),
     )
 
     logging = LoggingConfig(level=os.getenv("HARMONY_LOG_LEVEL", "INFO"))
-    database = DatabaseConfig(url=os.getenv("DATABASE_URL", DEFAULT_DB_URL))
+    database = DatabaseConfig(url=database_url)
 
     return AppConfig(
         spotify=spotify,

--- a/app/routers/settings_router.py
+++ b/app/routers/settings_router.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from datetime import datetime
+from typing import Final
 
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy import select
@@ -11,6 +12,18 @@ from app.dependencies import get_db
 from app.models import Setting, SettingHistory
 from app.schemas import SettingsHistoryResponse, SettingsPayload, SettingsResponse
 
+CONFIGURATION_KEYS: Final[tuple[str, ...]] = (
+    "SPOTIFY_CLIENT_ID",
+    "SPOTIFY_CLIENT_SECRET",
+    "SPOTIFY_REDIRECT_URI",
+    "PLEX_BASE_URL",
+    "PLEX_TOKEN",
+    "PLEX_LIBRARY",
+    "SLSKD_URL",
+    "SLSKD_API_KEY",
+)
+
+
 router = APIRouter()
 
 
@@ -18,6 +31,8 @@ router = APIRouter()
 def get_settings(session: Session = Depends(get_db)) -> SettingsResponse:
     settings = session.execute(select(Setting)).scalars().all()
     settings_dict = {setting.key: setting.value for setting in settings}
+    for key in CONFIGURATION_KEYS:
+        settings_dict.setdefault(key, None)
     updated_at = max((setting.updated_at or setting.created_at for setting in settings), default=datetime.utcnow())
     return SettingsResponse(settings=settings_dict, updated_at=updated_at)
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import pytest
+
+from app.config import load_config
+from app.db import session_scope
+from app.models import Setting
+
+
+def _insert_settings(entries: dict[str, str | None]) -> None:
+    with session_scope() as session:
+        for key, value in entries.items():
+            session.add(Setting(key=key, value=value))
+
+
+@pytest.mark.parametrize(
+    "entries,expected",
+    [
+        (
+            {
+                "SPOTIFY_CLIENT_ID": "db-client-id",
+                "SPOTIFY_CLIENT_SECRET": "db-secret",
+                "SPOTIFY_REDIRECT_URI": "http://localhost/callback",
+            },
+            {
+                "client_id": "db-client-id",
+                "client_secret": "db-secret",
+                "redirect_uri": "http://localhost/callback",
+            },
+        ),
+    ],
+)
+def test_spotify_configuration_from_database(monkeypatch: pytest.MonkeyPatch, entries, expected) -> None:
+    for key in ("SPOTIFY_CLIENT_ID", "SPOTIFY_CLIENT_SECRET", "SPOTIFY_REDIRECT_URI"):
+        monkeypatch.delenv(key, raising=False)
+
+    _insert_settings(entries)
+
+    config = load_config()
+
+    assert config.spotify.client_id == expected["client_id"]
+    assert config.spotify.client_secret == expected["client_secret"]
+    assert config.spotify.redirect_uri == expected["redirect_uri"]
+
+
+def test_plex_configuration_from_database(monkeypatch: pytest.MonkeyPatch) -> None:
+    for key in ("PLEX_BASE_URL", "PLEX_URL", "PLEX_TOKEN", "PLEX_LIBRARY"):
+        monkeypatch.delenv(key, raising=False)
+
+    _insert_settings(
+        {
+            "PLEX_BASE_URL": "http://plex.local:32400",
+            "PLEX_TOKEN": "db-token",
+            "PLEX_LIBRARY": "Music",
+        }
+    )
+
+    config = load_config()
+
+    assert config.plex.base_url == "http://plex.local:32400"
+    assert config.plex.token == "db-token"
+    assert config.plex.library_name == "Music"
+
+
+def test_soulseek_configuration_from_database(monkeypatch: pytest.MonkeyPatch) -> None:
+    for key in ("SLSKD_URL", "SLSKD_API_KEY"):
+        monkeypatch.delenv(key, raising=False)
+
+    _insert_settings(
+        {
+            "SLSKD_URL": "http://slskd:5030",
+            "SLSKD_API_KEY": "db-api-key",
+        }
+    )
+
+    config = load_config()
+
+    assert config.soulseek.base_url == "http://slskd:5030"
+    assert config.soulseek.api_key == "db-api-key"
+
+
+def test_configuration_falls_back_to_environment(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SPOTIFY_CLIENT_ID", "env-client")
+    monkeypatch.setenv("PLEX_BASE_URL", "http://env-plex")
+    monkeypatch.setenv("SLSKD_URL", "http://env-slskd")
+
+    config = load_config()
+
+    assert config.spotify.client_id == "env-client"
+    assert config.plex.base_url == "http://env-plex"
+    assert config.soulseek.base_url == "http://env-slskd"


### PR DESCRIPTION
## Summary
- load Spotify, Plex and slskd credentials from the database with env fallbacks
- expose all service configuration keys in the settings endpoint response
- document the new configuration flow and cover it with unit tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d1bc773d888321ada7bc1f7dbb016a