### PR TITLE
feat: implement downloads management page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ Alle Änderungen an diesem Projekt werden in diesem Dokument festgehalten. Diese
 
 ## [Unreleased]
 ### Added
-- Noch keine Einträge.
+- Frontend-Downloads-Seite mit Start-Formular, Fortschrittsanzeige und Zeitstempeln.
+- Dokumentation des Endpunkts `GET /api/download` inkl. Response-Beispiel.
 
 ### Changed
 - Noch keine Einträge.

--- a/ToDo.md
+++ b/ToDo.md
@@ -5,5 +5,6 @@
 - [x] Sync- und Suchfunktionen zwischen Spotify/Plex/Soulseek vereinheitlichen.
 - [x] Download-Management via `/api/download` inkl. Worker-Integration fertigstellen.
 - [x] Aktivitätsfeed `/api/activity` als In-Memory-Queue bereitstellen.
+- [x] Downloads-Frontend mit Tabelle und Start-Formular bereitstellen.
 - [ ] Streaming-Router für Audio-Features planen und implementieren (Frontend-Integration vorbereiten).
 - [ ] Frontend-Testlauf im CI wieder aktivieren, sobald npm-Registry-Zugriff verfügbar ist.

--- a/docs/api.md
+++ b/docs/api.md
@@ -60,6 +60,7 @@ POST /api/metadata/update HTTP/1.1
 | --- | --- | --- |
 | `POST` | `/api/sync` | Startet einen manuellen Playlist- und Bibliotheksabgleich. |
 | `POST` | `/api/search` | Führt eine Quell-übergreifende Suche (Spotify/Plex/Soulseek) aus. |
+| `GET` | `/api/download` | Listet aktive Downloads inklusive Status, Fortschritt und Zeitstempel. |
 | `POST` | `/api/download` | Persistiert Downloads und übergibt sie an den Soulseek-Worker. |
 | `GET` | `/api/activity` | Liefert den In-Memory-Aktivitätsfeed (max. 50 Einträge). |
 
@@ -99,7 +100,13 @@ Content-Type: application/json
   "status": "queued",
   "download_id": 42,
   "downloads": [
-    {"id": 42, "filename": "Daft Punk - Harder.mp3", "state": "queued", "progress": 0.0}
+    {
+      "id": 42,
+      "filename": "Daft Punk - Harder.mp3",
+      "state": "queued",
+      "progress": 0.0,
+      "created_at": "2024-03-18T12:00:00Z"
+    }
   ]
 }
 ```
@@ -131,7 +138,7 @@ GET /api/activity HTTP/1.1
 
 ![Downloads-Verwaltung](downloads-page.svg)
 
-Die neue Downloads-Seite im Harmony-Frontend ermöglicht das Starten von Test-Downloads über eine beliebige Datei- oder Track-ID und zeigt aktive Transfers inklusive Status und Fortschrittsbalken an. Über Tailwind- und shadcn/ui-Komponenten werden Ladezustände, Leerlaufmeldungen sowie Fehler-Toasts konsistent dargestellt. Jeder erfolgreich gestartete Download löst eine Bestätigungsmeldung aus, während fehlgeschlagene Anfragen klar hervorgehoben werden.
+Die neue Downloads-Seite im Harmony-Frontend ermöglicht das Starten von Test-Downloads über eine beliebige Datei- oder Track-ID und zeigt aktive Transfers inklusive Status, Fortschrittsbalken und Erstellungszeitpunkt an. Über Tailwind- und shadcn/ui-Komponenten werden Ladezustände, Leerlaufmeldungen ("Keine Downloads aktiv") sowie Fehler-Toasts konsistent dargestellt. Jeder erfolgreich gestartete Download löst eine Bestätigungsmeldung aus, während fehlgeschlagene Anfragen klar hervorgehoben werden.
 
 ![Activity-Feed-Widget](activity-feed-widget.svg)
 

--- a/frontend/src/__tests__/DownloadsPage.test.tsx
+++ b/frontend/src/__tests__/DownloadsPage.test.tsx
@@ -22,13 +22,25 @@ describe('DownloadsPage', () => {
 
   it('renders downloads table', async () => {
     mockedFetchDownloads.mockResolvedValue([
-      { id: 1, filename: 'Test File.mp3', status: 'running', progress: 45 }
+      {
+        id: 1,
+        filename: 'Test File.mp3',
+        status: 'running',
+        progress: 45,
+        created_at: '2024-01-01T12:00:00Z'
+      }
     ]);
 
     renderWithProviders(<DownloadsPage />, { toastFn: toastMock, route: '/downloads' });
 
     expect(await screen.findByText('Test File.mp3')).toBeInTheDocument();
     expect(screen.getByText('45%')).toBeInTheDocument();
+    const expectedDateLabel = new Intl.DateTimeFormat(undefined, {
+      dateStyle: 'short',
+      timeStyle: 'short'
+    }).format(new Date('2024-01-01T12:00:00Z'));
+
+    await waitFor(() => expect(screen.getByText(expectedDateLabel)).toBeInTheDocument());
   });
 
   it('starts a download via the form', async () => {
@@ -37,7 +49,8 @@ describe('DownloadsPage', () => {
       id: 2,
       filename: 'Another File.mp3',
       status: 'queued',
-      progress: 0
+      progress: 0,
+      created_at: '2024-01-02T08:15:00Z'
     });
 
     renderWithProviders(<DownloadsPage />, { toastFn: toastMock, route: '/downloads' });

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -110,6 +110,7 @@ export interface DownloadEntry {
   filename: string;
   status: string;
   progress: number;
+  created_at?: string;
 }
 
 export interface StartDownloadPayload {

--- a/frontend/src/pages/DownloadsPage.tsx
+++ b/frontend/src/pages/DownloadsPage.tsx
@@ -69,13 +69,18 @@ const DownloadsPage = () => {
     if (!trackId.trim()) {
       toast({
         title: 'Track-ID erforderlich',
-        description: 'Bitte geben Sie eine Datei- oder Track-ID an.',
+        description: 'Bitte Track oder Dateiname eingeben.',
         variant: 'destructive'
       });
       return;
     }
     void startDownloadMutation.mutate({ track_id: trackId.trim() });
   };
+
+  const dateFormatter = useMemo(() => new Intl.DateTimeFormat(undefined, {
+    dateStyle: 'short',
+    timeStyle: 'short'
+  }), []);
 
   const rows = useMemo(() => downloads ?? [], [downloads]);
 
@@ -93,7 +98,7 @@ const DownloadsPage = () => {
             <Input
               value={trackId}
               onChange={(event) => setTrackId(event.target.value)}
-              placeholder="Datei- oder Track-ID eingeben"
+              placeholder="Track oder Dateiname eingeben"
               aria-label="Track-ID"
             />
             <Button type="submit" disabled={startDownloadMutation.isPending}>
@@ -125,7 +130,7 @@ const DownloadsPage = () => {
           ) : isError ? (
             <p className="text-sm text-destructive">Downloads konnten nicht geladen werden.</p>
           ) : rows.length === 0 ? (
-            <p className="text-sm text-muted-foreground">Keine aktiven Downloads vorhanden.</p>
+            <p className="text-sm text-muted-foreground">Keine Downloads aktiv.</p>
           ) : (
             <div className="overflow-hidden rounded-lg border">
               <Table>
@@ -135,11 +140,15 @@ const DownloadsPage = () => {
                     <TableHead>Dateiname</TableHead>
                     <TableHead>Status</TableHead>
                     <TableHead>Fortschritt</TableHead>
+                    <TableHead>Angelegt</TableHead>
                   </TableRow>
                 </TableHeader>
                 <TableBody>
                   {rows.map((download) => {
                     const progressValue = mapProgressToPercent(download.progress);
+                    const createdAtLabel = download.created_at
+                      ? dateFormatter.format(new Date(download.created_at))
+                      : 'Unbekannt';
                     return (
                       <TableRow key={download.id}>
                         <TableCell className="text-sm text-muted-foreground">{download.id}</TableCell>
@@ -151,6 +160,7 @@ const DownloadsPage = () => {
                             <span className="text-xs text-muted-foreground">{progressValue}%</span>
                           </div>
                         </TableCell>
+                        <TableCell className="text-sm text-muted-foreground">{createdAtLabel}</TableCell>
                       </TableRow>
                     );
                   })}


### PR DESCRIPTION
## Summary
- enhance the downloads page with track input, progress display, and created-at timestamps
- add API typing, documentation, and changelog notes for the downloads endpoint
- cover the new UI with unit tests and refresh the project ToDo list

## Testing
- npm run build
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d335944828832190c8ef9d582a3b3b