### PR TITLE
feat: enhance dashboard activity feed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Alle Änderungen an diesem Projekt werden in diesem Dokument festgehalten. Diese
 - Dokumentation des Endpunkts `GET /api/download` inkl. Response-Beispiel.
 
 ### Changed
-- Noch keine Einträge.
+- Dashboard-Aktivitätsfeed mit lokalisierten Typen, sortierten Einträgen und farbcodierten Status-Badges verfeinert.
 
 ### Fixed
 - Noch keine Einträge.

--- a/ToDo.md
+++ b/ToDo.md
@@ -6,5 +6,6 @@
 - [x] Download-Management via `/api/download` inkl. Worker-Integration fertigstellen.
 - [x] Aktivitätsfeed `/api/activity` als In-Memory-Queue bereitstellen.
 - [x] Downloads-Frontend mit Tabelle und Start-Formular bereitstellen.
+- [x] Activity-Feed-Widget im Dashboard mit Polling, Sortierung und Status-Badges finalisieren.
 - [ ] Streaming-Router für Audio-Features planen und implementieren (Frontend-Integration vorbereiten).
 - [ ] Frontend-Testlauf im CI wieder aktivieren, sobald npm-Registry-Zugriff verfügbar ist.

--- a/docs/api.md
+++ b/docs/api.md
@@ -142,7 +142,7 @@ Die neue Downloads-Seite im Harmony-Frontend ermöglicht das Starten von Test-Do
 
 ![Activity-Feed-Widget](activity-feed-widget.svg)
 
-Auf dem Dashboard ergänzt das Activity-Feed-Widget die bestehenden Statuskacheln. Es pollt den `/api/activity`-Endpunkt alle zehn Sekunden, visualisiert die letzten Aktionen mit Zeitstempel, Typ und Status-Badge und informiert per Toast, falls der Feed leer bleibt oder das Backend nicht erreichbar ist. Dadurch behalten Operatorinnen laufende Sync-, Such- und Download-Aktivitäten im Blick, ohne das Backend manuell abfragen zu müssen.
+Auf dem Dashboard ergänzt das Activity-Feed-Widget die bestehenden Statuskacheln. Es pollt den `/api/activity`-Endpunkt alle zehn Sekunden, sortiert die Einträge nach dem neuesten Zeitstempel und visualisiert die letzten Aktionen mit lokalisierten Typen sowie farbcodierten Status-Badges. Für leere Feeds oder Fehlerfälle erscheinen Toast-Benachrichtigungen, sodass Operatorinnen laufende Sync-, Such- und Download-Aktivitäten ohne manuelle API-Abfragen im Blick behalten.
 
 ## Spotify (`/spotify`)
 

--- a/frontend/src/__tests__/ActivityFeed.test.tsx
+++ b/frontend/src/__tests__/ActivityFeed.test.tsx
@@ -25,9 +25,11 @@ describe('ActivityFeed', () => {
 
     renderWithProviders(<ActivityFeed />, { toastFn: toastMock });
 
-    expect(await screen.findByText('sync')).toBeInTheDocument();
-    expect(screen.getByText('download')).toBeInTheDocument();
-    expect(screen.getByText('queued')).toBeInTheDocument();
+    expect(await screen.findByText('Synchronisierung')).toBeInTheDocument();
+    expect(screen.getByText('Download')).toBeInTheDocument();
+
+    expect(screen.getByText('Abgeschlossen')).toHaveClass('bg-emerald-100');
+    expect(screen.getByText('Wartend')).toHaveClass('bg-amber-100');
   });
 
   it('notifies when no activities are available', async () => {

--- a/frontend/src/components/ActivityFeed.tsx
+++ b/frontend/src/components/ActivityFeed.tsx
@@ -3,8 +3,80 @@ import { Loader2 } from 'lucide-react';
 import { Card, CardContent, CardHeader, CardTitle } from './ui/card';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from './ui/table';
 import { useToast } from '../hooks/useToast';
-import { fetchActivityFeed, ActivityItem } from '../lib/api';
+import { fetchActivityFeed, ActivityItem, ActivityStatus, ActivityType } from '../lib/api';
 import { useQuery } from '../lib/query';
+import { cn } from '../lib/utils';
+
+const ACTIVITY_TYPE_LABELS = {
+  sync: 'Synchronisierung',
+  search: 'Suche',
+  download: 'Download',
+  metadata: 'Metadaten'
+} as const satisfies Record<string, string>;
+
+type KnownActivityType = keyof typeof ACTIVITY_TYPE_LABELS;
+
+const STATUS_STYLES = {
+  completed:
+    'bg-emerald-100 text-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-200',
+  running: 'bg-sky-100 text-sky-800 dark:bg-sky-900/40 dark:text-sky-200',
+  queued: 'bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-200',
+  failed: 'bg-rose-100 text-rose-800 dark:bg-rose-900/40 dark:text-rose-200',
+  cancelled: 'bg-slate-100 text-slate-800 dark:bg-slate-900/40 dark:text-slate-200'
+} as const satisfies Record<string, string>;
+
+const STATUS_LABELS = {
+  completed: 'Abgeschlossen',
+  running: 'Laufend',
+  queued: 'Wartend',
+  failed: 'Fehlgeschlagen',
+  cancelled: 'Abgebrochen'
+} as const satisfies Record<string, string>;
+
+type KnownStatus = keyof typeof STATUS_STYLES;
+
+const isKnownActivityType = (type: ActivityType): type is KnownActivityType =>
+  Object.prototype.hasOwnProperty.call(ACTIVITY_TYPE_LABELS, type);
+
+const isKnownStatus = (status: string): status is KnownStatus =>
+  Object.prototype.hasOwnProperty.call(STATUS_STYLES, status);
+
+const prettify = (value: string) => {
+  const normalized = value.replace(/[_-]+/g, ' ').trim();
+  if (!normalized) {
+    return value;
+  }
+  return normalized
+    .split(' ')
+    .filter(Boolean)
+    .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
+    .join(' ');
+};
+
+const getTypeLabel = (type: ActivityType) =>
+  isKnownActivityType(type) ? ACTIVITY_TYPE_LABELS[type] : prettify(type);
+
+const getStatusMeta = (status: ActivityStatus) => {
+  const normalized = status.toLowerCase();
+  if (isKnownStatus(normalized)) {
+    return {
+      label: STATUS_LABELS[normalized],
+      className: STATUS_STYLES[normalized]
+    };
+  }
+  return {
+    label: prettify(status),
+    className: 'bg-muted text-muted-foreground'
+  };
+};
+
+const parseTimestamp = (value: string) => {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return 0;
+  }
+  return date.getTime();
+};
 
 const formatTimestamp = (value: string) => {
   const date = new Date(value);
@@ -50,7 +122,12 @@ const ActivityFeed = () => {
     }
   }, [data, toast]);
 
-  const rows = useMemo(() => data ?? [], [data]);
+  const rows = useMemo(() => {
+    if (!data) {
+      return [] as ActivityItem[];
+    }
+    return [...data].sort((a, b) => parseTimestamp(b.timestamp) - parseTimestamp(a.timestamp));
+  }, [data]);
 
   return (
     <Card>
@@ -84,11 +161,21 @@ const ActivityFeed = () => {
                     <TableCell className="whitespace-nowrap text-sm text-muted-foreground">
                       {formatTimestamp(item.timestamp)}
                     </TableCell>
-                    <TableCell className="text-sm font-medium capitalize">{item.type}</TableCell>
+                    <TableCell className="text-sm font-medium">{getTypeLabel(item.type)}</TableCell>
                     <TableCell>
-                      <span className="inline-flex items-center rounded-full bg-muted px-2 py-1 text-xs font-semibold uppercase text-muted-foreground">
-                        {item.status}
-                      </span>
+                      {(() => {
+                        const { label, className } = getStatusMeta(item.status);
+                        return (
+                          <span
+                            className={cn(
+                              'inline-flex items-center rounded-full px-2 py-1 text-xs font-semibold',
+                              className
+                            )}
+                          >
+                            {label}
+                          </span>
+                        );
+                      })()}
                     </TableCell>
                   </TableRow>
                 ))}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -117,10 +117,20 @@ export interface StartDownloadPayload {
   track_id: string;
 }
 
+export type ActivityType = 'sync' | 'search' | 'download' | 'metadata' | (string & {});
+
+export type ActivityStatus =
+  | 'queued'
+  | 'running'
+  | 'completed'
+  | 'failed'
+  | 'cancelled'
+  | (string & {});
+
 export interface ActivityItem {
   timestamp: string;
-  type: string;
-  status: string;
+  type: ActivityType;
+  status: ActivityStatus;
   details?: Record<string, unknown>;
 }
 


### PR DESCRIPTION
## Summary
- localize and style the activity feed widget with sorted entries and status badges
- extend activity feed typing plus tests for the new UI behaviour
- refresh changelog, API docs and ToDo notes for the dashboard widget

## Testing
- npm run build
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d337041394832181897bce89742d7f