### PR TITLE
feat: add artist configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,11 @@ Alle Änderungen an diesem Projekt werden in diesem Dokument festgehalten. Diese
 - Frontend-Downloads-Seite mit Start-Formular, Fortschrittsanzeige und Zeitstempeln.
 - Dokumentation des Endpunkts `GET /api/download` inkl. Response-Beispiel.
 - AutoSyncWorker, der Spotify-Playlists und gespeicherte Tracks automatisch mit Plex abgleicht, fehlende Titel via Soulseek lädt und anschließend per Beets importiert (manuell triggerbar über `/api/sync`).
+- Artist-Konfiguration mit neuen Spotify- und Settings-Endpunkten sowie der Tabelle `artist_preferences`.
 
 ### Changed
 - Dashboard-Aktivitätsfeed mit lokalisierten Typen, sortierten Einträgen und farbcodierten Status-Badges verfeinert.
+- AutoSyncWorker filtert Spotify-Tracks anhand gespeicherter Artist-Präferenzen.
 
 ### Fixed
 - Noch keine Einträge.

--- a/ToDo.md
+++ b/ToDo.md
@@ -8,5 +8,6 @@
 - [x] Downloads-Frontend mit Tabelle und Start-Formular bereitstellen.
 - [x] Activity-Feed-Widget im Dashboard mit Polling, Sortierung und Status-Badges finalisieren.
 - [x] AutoSyncWorker für Spotify↔Plex implementieren, Soulseek/Beets-Anbindung ergänzen und Dokumentation aktualisieren.
+- [x] Artist-Konfiguration für Spotify-Releases (API, DB, AutoSync) umsetzen.
 - [ ] Streaming-Router für Audio-Features planen und implementieren (Frontend-Integration vorbereiten).
 - [ ] Frontend-Testlauf im CI wieder aktivieren, sobald npm-Registry-Zugriff verfügbar ist.

--- a/app/core/spotify_client.py
+++ b/app/core/spotify_client.py
@@ -170,3 +170,13 @@ class SpotifyClient:
         if seed_genres:
             params["seed_genres"] = seed_genres
         return self._execute(self._client.recommendations, **params)
+
+    def get_followed_artists(self, limit: int = 50) -> Dict[str, Any]:
+        return self._execute(self._client.current_user_followed_artists, limit=limit)
+
+    def get_artist_releases(self, artist_id: str) -> Dict[str, Any]:
+        return self._execute(
+            self._client.artist_albums,
+            artist_id,
+            album_type="album,single,compilation",
+        )

--- a/app/models.py
+++ b/app/models.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from datetime import datetime
 
-from sqlalchemy import Column, DateTime, Float, Integer, String, Text
+from sqlalchemy import Boolean, Column, DateTime, Float, Integer, String, Text
 
 from app.db import Base
 
@@ -75,3 +75,11 @@ class SettingHistory(Base):
     old_value = Column(Text, nullable=True)
     new_value = Column(Text, nullable=True)
     changed_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+
+
+class ArtistPreference(Base):
+    __tablename__ = "artist_preferences"
+
+    artist_id = Column(String(128), primary_key=True)
+    release_id = Column(String(128), primary_key=True)
+    selected = Column(Boolean, nullable=False, default=True)

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -19,6 +19,15 @@ class SpotifySearchResponse(BaseModel):
     items: List[Dict[str, Any]]
 
 
+class FollowedArtistsResponse(BaseModel):
+    artists: List[Dict[str, Any]]
+
+
+class ArtistReleasesResponse(BaseModel):
+    artist_id: str
+    releases: List[Dict[str, Any]]
+
+
 class PlaylistEntry(BaseModel):
     id: str
     name: str
@@ -137,3 +146,17 @@ class SettingsHistoryEntry(BaseModel):
 
 class SettingsHistoryResponse(BaseModel):
     history: List[SettingsHistoryEntry]
+
+
+class ArtistPreferenceEntry(BaseModel):
+    artist_id: str
+    release_id: str
+    selected: bool
+
+
+class ArtistPreferencesPayload(BaseModel):
+    preferences: List[ArtistPreferenceEntry] = Field(default_factory=list)
+
+
+class ArtistPreferencesResponse(BaseModel):
+    preferences: List[ArtistPreferenceEntry]

--- a/docs/api.md
+++ b/docs/api.md
@@ -151,6 +151,8 @@ Auf dem Dashboard ergänzt das Activity-Feed-Widget die bestehenden Statuskachel
 | Methode | Pfad | Beschreibung |
 | --- | --- | --- |
 | `GET` | `/spotify/status` | Prüft, ob der Spotify-Client authentifiziert ist. |
+| `GET` | `/spotify/artists/followed` | Listet alle vom Benutzer gefolgten Artists. |
+| `GET` | `/spotify/artist/{artist_id}/releases` | Liefert Alben, Singles und Compilations eines Artists. |
 | `GET` | `/spotify/search/tracks?query=...` | Sucht nach Tracks (weitere Endpunkte für Artists/Albums identisch). |
 | `GET` | `/spotify/track/{track_id}` | Liefert Track-Details. |
 | `GET` | `/spotify/audio-features/{track_id}` | Einzelne Audio-Features. |
@@ -310,6 +312,8 @@ Content-Type: application/json
 | `GET` | `/settings` | Liefert alle Settings als Key-Value-Map inklusive `updated_at`. |
 | `POST` | `/settings` | Legt/aktualisiert einen Eintrag (`{"key": "plex_artist_count", "value": "123"}`). |
 | `GET` | `/settings/history` | Zeigt die letzten 50 Änderungen mit Zeitstempel. |
+| `GET` | `/settings/artist-preferences` | Gibt die markierten Releases pro Artist zurück. |
+| `POST` | `/settings/artist-preferences` | Persistiert die Auswahl (`{"preferences": [{"artist_id": ..., "release_id": ..., "selected": true}]}`). |
 
 ## Beets (`/beets`)
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -62,6 +62,13 @@ Beispiele:
 - `app/models.py` definiert SQLAlchemy-Modelle wie `Playlist`, `Download`, `Match`, `Setting`, `SettingHistory`.
 - `app/schemas.py` enthält die Pydantic-Modelle für Anfragen und Antworten.
 
+### Artist-Konfiguration
+
+- Die Tabelle `artist_preferences` speichert pro Spotify-Artist die gewählten Releases (`artist_id`, `release_id`, `selected`).
+- Der `settings_router` stellt `GET/POST /settings/artist-preferences` bereit, um diese Auswahl abzurufen bzw. zu persistieren.
+- Der `spotify_router` liefert mit `GET /spotify/artists/followed` und `GET /spotify/artist/{id}/releases` die Grundlage für die Konfiguration.
+- Der `AutoSyncWorker` lädt die markierten Releases beim Sync und filtert Spotify-Tracks, sodass nur gewünschte Veröffentlichungen gegen Plex abgeglichen werden.
+
 ### Hintergrund-Worker
 
 Während des Startup-Events (`app/main.py`) werden – sofern `HARMONY_DISABLE_WORKERS` nicht gesetzt ist – folgende Worker gestartet:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import os
 from contextlib import asynccontextmanager
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 import sys
 
@@ -41,6 +41,14 @@ class StubSpotifyClient:
         }
         self.saved_track_ids: set[str] = set()
         self.recommendation_payload: Dict[str, Any] = {"tracks": [], "seeds": []}
+        self.followed_artists: List[Dict[str, Any]] = [
+            {"id": "artist-1", "name": "Tester"}
+        ]
+        self.artist_releases: Dict[str, List[Dict[str, Any]]] = {
+            "artist-1": [
+                {"id": "release-1", "name": "Test Release", "album_group": "album"}
+            ]
+        }
 
     def is_authenticated(self) -> bool:
         return True
@@ -56,6 +64,18 @@ class StubSpotifyClient:
 
     def get_user_playlists(self, limit: int = 50) -> Dict[str, Any]:
         return {"items": [dict(item) for item in self.playlists]}
+
+    def get_followed_artists(self, limit: int = 50) -> Dict[str, Any]:
+        return {
+            "artists": {
+                "items": [dict(item) for item in self.followed_artists[:limit]]
+            }
+        }
+
+    def get_artist_releases(self, artist_id: str) -> Dict[str, Any]:
+        return {
+            "items": [dict(item) for item in self.artist_releases.get(artist_id, [])]
+        }
 
     def get_track_details(self, track_id: str) -> Dict[str, Any]:
         return self.tracks.get(track_id, {"id": track_id, "name": "Unknown"})

--- a/tests/test_artists.py
+++ b/tests/test_artists.py
@@ -1,0 +1,87 @@
+import pytest
+
+from app.db import session_scope
+from app.models import ArtistPreference
+from tests.test_autosync import _build_worker, _create_track
+
+
+def test_followed_artists_endpoint(client) -> None:
+    stub = client.app.state.spotify_stub
+    stub.followed_artists = [
+        {"id": "artist-a", "name": "Alpha"},
+        {"id": "artist-b", "name": "Beta"},
+    ]
+
+    response = client.get("/spotify/artists/followed")
+    assert response.status_code == 200
+    body = response.json()
+    assert {artist["id"] for artist in body["artists"]} == {"artist-a", "artist-b"}
+
+
+def test_artist_releases_endpoint(client) -> None:
+    stub = client.app.state.spotify_stub
+    stub.artist_releases["artist-a"] = [
+        {"id": "release-1", "name": "First", "album_type": "album"},
+        {"id": "release-2", "name": "Second", "album_type": "single"},
+    ]
+
+    response = client.get("/spotify/artist/artist-a/releases")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["artist_id"] == "artist-a"
+    assert {release["id"] for release in body["releases"]} == {"release-1", "release-2"}
+
+
+def test_artist_preferences_persist(client) -> None:
+    payload = {
+        "preferences": [
+            {"artist_id": "artist-a", "release_id": "release-1", "selected": True},
+            {"artist_id": "artist-a", "release_id": "release-2", "selected": False},
+        ]
+    }
+
+    save_response = client.post("/settings/artist-preferences", json=payload)
+    assert save_response.status_code == 200
+    returned = save_response.json()["preferences"]
+    assert len(returned) == 2
+
+    list_response = client.get("/settings/artist-preferences")
+    assert list_response.status_code == 200
+    listed = list_response.json()["preferences"]
+    assert listed == returned
+
+    with session_scope() as session:
+        records = session.query(ArtistPreference).all()
+        assert len(records) == 2
+        mapping = {(record.artist_id, record.release_id): record.selected for record in records}
+    assert mapping[("artist-a", "release-1")] is True
+    assert mapping[("artist-a", "release-2")] is False
+
+
+@pytest.mark.asyncio
+async def test_autosync_respects_artist_preferences() -> None:
+    allowed = _create_track("Allowed Song", "Preferred", spotify_id="track-1", album_id="release-keep")
+    blocked = _create_track("Blocked Song", "Other", spotify_id="track-2", album_id="release-skip")
+
+    worker, spotify_client, plex_client, soulseek_client, beets_client = _build_worker(
+        [allowed, blocked],
+        [],
+        {
+            "results": [
+                {
+                    "username": "dj_user",
+                    "files": [
+                        {"filename": "Allowed Song.mp3", "path": "/downloads/allowed.mp3"}
+                    ],
+                }
+            ]
+        },
+        preferences={"release-keep": True, "release-skip": False},
+    )
+
+    await worker.run_once(source="test")
+
+    assert len(soulseek_client.search.await_args_list) == 1
+    query = soulseek_client.search.await_args_list[0].args[0]
+    assert query == "Preferred Allowed Song"
+    beets_client.import_file.assert_called_once_with("/downloads/allowed.mp3", quiet=True)


### PR DESCRIPTION
## Summary
- expose Spotify endpoints to list followed artists and releases for artist configuration
- persist artist preferences and expose settings API backed by the new artist_preferences table
- filter AutoSyncWorker to honour saved release selections and cover the workflow with tests and docs

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d33c165d448321be5de97272cd8366