### PR TITLE
feat: add spotify artists management page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Alle Änderungen an diesem Projekt werden in diesem Dokument festgehalten. Diese
 - Dokumentation des Endpunkts `GET /api/download` inkl. Response-Beispiel.
 - AutoSyncWorker, der Spotify-Playlists und gespeicherte Tracks automatisch mit Plex abgleicht, fehlende Titel via Soulseek lädt und anschließend per Beets importiert (manuell triggerbar über `/api/sync`).
 - Artist-Konfiguration mit neuen Spotify- und Settings-Endpunkten sowie der Tabelle `artist_preferences`.
+- Artists-Seite im Frontend zur Verwaltung gefolgter Spotify-Artists und ihrer Releases inklusive Sync-Toggles.
 
 ### Changed
 - Dashboard-Aktivitätsfeed mit lokalisierten Typen, sortierten Einträgen und farbcodierten Status-Badges verfeinert.

--- a/ToDo.md
+++ b/ToDo.md
@@ -9,5 +9,6 @@
 - [x] Activity-Feed-Widget im Dashboard mit Polling, Sortierung und Status-Badges finalisieren.
 - [x] AutoSyncWorker für Spotify↔Plex implementieren, Soulseek/Beets-Anbindung ergänzen und Dokumentation aktualisieren.
 - [x] Artist-Konfiguration für Spotify-Releases (API, DB, AutoSync) umsetzen.
+- [x] Artists-Frontend zum Aktivieren einzelner Releases inkl. Tests und Dokumentation ergänzen.
 - [ ] Streaming-Router für Audio-Features planen und implementieren (Frontend-Integration vorbereiten).
 - [ ] Frontend-Testlauf im CI wieder aktivieren, sobald npm-Registry-Zugriff verfügbar ist.

--- a/docs/api.md
+++ b/docs/api.md
@@ -146,6 +146,10 @@ Die neue Downloads-Seite im Harmony-Frontend ermöglicht das Starten von Test-Do
 
 Auf dem Dashboard ergänzt das Activity-Feed-Widget die bestehenden Statuskacheln. Es pollt den `/api/activity`-Endpunkt alle zehn Sekunden, sortiert die Einträge nach dem neuesten Zeitstempel und visualisiert die letzten Aktionen mit lokalisierten Typen sowie farbcodierten Status-Badges. Für leere Feeds oder Fehlerfälle erscheinen Toast-Benachrichtigungen, sodass Operatorinnen laufende Sync-, Such- und Download-Aktivitäten ohne manuelle API-Abfragen im Blick behalten.
 
+### Artists-Verwaltung
+
+Die Artists-Seite im Frontend nutzt die Spotify-Endpunkte `GET /spotify/artists/followed` und `GET /spotify/artist/{artist_id}/releases`, um eine sortierbare Liste der gefolgten Artists inklusive Coverbildern anzuzeigen. In der Detailspalte lassen sich die verfügbaren Releases mit Jahr, Typ und Track-Anzahl inspizieren. Über einen Toggle "Für Sync aktivieren" kann pro Release gesteuert werden, ob der AutoSync-Worker ihn berücksichtigen soll. Änderungen werden gesammelt über `POST /settings/artist-preferences` gespeichert. Lade- und Fehlerzustände werden mit Spinnern, leeren States ("Keine Artists gefunden", "Keine Releases verfügbar") sowie Toasts visualisiert.
+
 ## Spotify (`/spotify`)
 
 | Methode | Pfad | Beschreibung |

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,6 +10,7 @@ import BeetsPage from './pages/BeetsPage';
 import DownloadsPage from './pages/DownloadsPage';
 import { ThemeProvider } from './components/theme-provider';
 import ToastProvider from './components/ToastProvider';
+import ArtistsPage from './pages/ArtistsPage';
 
 const App = () => (
   <ThemeProvider>
@@ -19,6 +20,7 @@ const App = () => (
           <Route path="/" element={<Navigate to="/dashboard" replace />} />
           <Route path="/dashboard" element={<Dashboard />} />
           <Route path="/spotify" element={<SpotifyPage />} />
+          <Route path="/artists" element={<ArtistsPage />} />
           <Route path="/plex" element={<PlexPage />} />
           <Route path="/soulseek" element={<SoulseekPage />} />
           <Route path="/downloads" element={<DownloadsPage />} />

--- a/frontend/src/__tests__/ArtistsPage.test.tsx
+++ b/frontend/src/__tests__/ArtistsPage.test.tsx
@@ -1,0 +1,145 @@
+import userEvent from '@testing-library/user-event';
+import { screen, waitFor } from '@testing-library/react';
+import ArtistsPage from '../pages/ArtistsPage';
+import { renderWithProviders } from '../test-utils';
+import {
+  fetchArtistPreferences,
+  fetchArtistReleases,
+  fetchFollowedArtists,
+  saveArtistPreferences,
+  ArtistPreferenceEntry,
+  SpotifyArtist,
+  SpotifyArtistRelease
+} from '../lib/api';
+
+jest.mock('../lib/api', () => ({
+  ...jest.requireActual('../lib/api'),
+  fetchFollowedArtists: jest.fn(),
+  fetchArtistReleases: jest.fn(),
+  fetchArtistPreferences: jest.fn(),
+  saveArtistPreferences: jest.fn()
+}));
+
+const mockedFetchFollowed = fetchFollowedArtists as jest.MockedFunction<typeof fetchFollowedArtists>;
+const mockedFetchReleases = fetchArtistReleases as jest.MockedFunction<typeof fetchArtistReleases>;
+const mockedFetchPreferences = fetchArtistPreferences as jest.MockedFunction<typeof fetchArtistPreferences>;
+const mockedSavePreferences = saveArtistPreferences as jest.MockedFunction<typeof saveArtistPreferences>;
+
+const createArtist = (overrides: Partial<SpotifyArtist> = {}): SpotifyArtist => ({
+  id: overrides.id ?? 'artist-1',
+  name: overrides.name ?? 'Artist One',
+  images: overrides.images ?? [],
+  followers: overrides.followers
+});
+
+const createRelease = (overrides: Partial<SpotifyArtistRelease> = {}): SpotifyArtistRelease => ({
+  id: overrides.id ?? 'release-1',
+  name: overrides.name ?? 'Release One',
+  album_type: overrides.album_type ?? 'album',
+  release_date: overrides.release_date ?? '2023-04-20',
+  total_tracks: overrides.total_tracks ?? 12
+});
+
+const createPreference = (overrides: Partial<ArtistPreferenceEntry> = {}): ArtistPreferenceEntry => ({
+  artist_id: overrides.artist_id ?? 'artist-1',
+  release_id: overrides.release_id ?? 'release-1',
+  selected: overrides.selected ?? false
+});
+
+describe('ArtistsPage', () => {
+  const toastMock = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedFetchPreferences.mockResolvedValue([]);
+    mockedFetchReleases.mockResolvedValue([]);
+    mockedSavePreferences.mockResolvedValue([]);
+  });
+
+  it('lädt gefolgte Artists', async () => {
+    mockedFetchFollowed.mockResolvedValue([createArtist({ name: 'Daft Punk' })]);
+
+    renderWithProviders(<ArtistsPage />, { toastFn: toastMock, route: '/artists' });
+
+    expect(await screen.findByText('Daft Punk')).toBeInTheDocument();
+    expect(screen.getByText('Releases unbekannt')).toBeInTheDocument();
+  });
+
+  it('zeigt Releases eines ausgewählten Artists an', async () => {
+    mockedFetchFollowed.mockResolvedValue([
+      createArtist({ id: 'artist-1', name: 'Daft Punk' }),
+      createArtist({ id: 'artist-2', name: 'Justice' })
+    ]);
+    mockedFetchPreferences.mockResolvedValue([createPreference({ artist_id: 'artist-1', selected: true })]);
+    mockedFetchReleases.mockImplementation(async (artistId) => {
+      if (artistId === 'artist-1') {
+        return [createRelease({ name: 'Discovery', album_type: 'album', release_date: '2001-03-12', total_tracks: 14 })];
+      }
+      return [];
+    });
+
+    renderWithProviders(<ArtistsPage />, { toastFn: toastMock, route: '/artists' });
+
+    await userEvent.click(await screen.findByText('Daft Punk'));
+
+    await waitFor(() => expect(mockedFetchReleases).toHaveBeenCalledWith('artist-1'));
+
+    expect(await screen.findByText('Discovery')).toBeInTheDocument();
+    expect(screen.getByText('Album')).toBeInTheDocument();
+    expect(screen.getByText('2001')).toBeInTheDocument();
+    expect(screen.getByText('14')).toBeInTheDocument();
+    expect(screen.getByRole('switch', { name: /Discovery/ })).toBeChecked();
+  });
+
+  it('erlaubt das Ändern und Speichern der Auswahl', async () => {
+    mockedFetchFollowed.mockResolvedValue([createArtist({ id: 'artist-1', name: 'Hot Chip' })]);
+    mockedFetchPreferences.mockResolvedValue([
+      createPreference({ artist_id: 'artist-1', release_id: 'release-1', selected: false }),
+      createPreference({ artist_id: 'artist-1', release_id: 'release-2', selected: false })
+    ]);
+    mockedFetchReleases.mockResolvedValue([
+      createRelease({ id: 'release-1', name: 'The Warning', album_type: 'album', release_date: '2006-05-22' }),
+      createRelease({ id: 'release-2', name: 'Over and Over', album_type: 'single', release_date: '2005-10-31' })
+    ]);
+    mockedSavePreferences.mockResolvedValue([
+      createPreference({ artist_id: 'artist-1', release_id: 'release-1', selected: true }),
+      createPreference({ artist_id: 'artist-1', release_id: 'release-2', selected: false })
+    ]);
+
+    renderWithProviders(<ArtistsPage />, { toastFn: toastMock, route: '/artists' });
+
+    await userEvent.click(await screen.findByText('Hot Chip'));
+
+    const switches = await screen.findAllByRole('switch');
+    expect(switches).toHaveLength(2);
+
+    await userEvent.click(switches[0]);
+
+    const saveButton = screen.getByRole('button', { name: 'Änderungen speichern' });
+    expect(saveButton).toBeEnabled();
+
+    await userEvent.click(saveButton);
+
+    await waitFor(() =>
+      expect(mockedSavePreferences).toHaveBeenCalledWith([
+        { artist_id: 'artist-1', release_id: 'release-1', selected: true },
+        { artist_id: 'artist-1', release_id: 'release-2', selected: false }
+      ])
+    );
+    expect(toastMock).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'Präferenzen gespeichert' })
+    );
+  });
+
+  it('zeigt einen Fehler-Toast, wenn Artists nicht geladen werden können', async () => {
+    mockedFetchFollowed.mockRejectedValue(new Error('network error'));
+
+    renderWithProviders(<ArtistsPage />, { toastFn: toastMock, route: '/artists' });
+
+    await waitFor(() =>
+      expect(toastMock).toHaveBeenCalledWith(
+        expect.objectContaining({ title: 'Artists konnten nicht geladen werden' })
+      )
+    );
+  });
+});

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -14,7 +14,8 @@ import {
   RefreshCcw,
   Search,
   Settings,
-  Sun
+  Sun,
+  Users
 } from 'lucide-react';
 import { cn } from '../lib/utils';
 import { Input } from './ui/input';
@@ -28,6 +29,7 @@ import { useQueryClient } from '../lib/query';
 const navItems = [
   { to: '/dashboard', label: 'Dashboard', icon: CircleDot },
   { to: '/spotify', label: 'Spotify', icon: Music },
+  { to: '/artists', label: 'Artists', icon: Users },
   { to: '/plex', label: 'Plex', icon: Disc },
   { to: '/soulseek', label: 'Soulseek', icon: Radio },
   { to: '/downloads', label: 'Downloads', icon: Download },

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -34,12 +34,42 @@ export interface SpotifyPlaylistsResponse {
   playlists: SpotifyPlaylist[];
 }
 
+export interface SpotifyImage {
+  url?: string;
+  width?: number;
+  height?: number;
+}
+
+export interface SpotifyArtist {
+  id: string;
+  name: string;
+  images?: SpotifyImage[];
+  followers?: { total?: number };
+}
+
+export interface FollowedArtistsResponse {
+  artists: SpotifyArtist[];
+}
+
 export interface SpotifyArtistSummary {
   name?: string;
 }
 
 export interface SpotifyAlbumSummary {
   name?: string;
+}
+
+export interface SpotifyArtistRelease {
+  id: string;
+  name: string;
+  album_type?: string;
+  release_date?: string;
+  total_tracks?: number;
+}
+
+export interface ArtistReleasesResponse {
+  artist_id: string;
+  releases: SpotifyArtistRelease[];
 }
 
 export interface SpotifyTrackSummary {
@@ -117,6 +147,16 @@ export interface StartDownloadPayload {
   track_id: string;
 }
 
+export interface ArtistPreferenceEntry {
+  artist_id: string;
+  release_id: string;
+  selected: boolean;
+}
+
+export interface ArtistPreferencesResponse {
+  preferences: ArtistPreferenceEntry[];
+}
+
 export type ActivityType = 'sync' | 'search' | 'download' | 'metadata' | (string & {});
 
 export type ActivityStatus =
@@ -159,6 +199,18 @@ export const fetchSpotifyPlaylists = async (): Promise<SpotifyPlaylist[]> => {
   return data.playlists;
 };
 
+export const fetchFollowedArtists = async (): Promise<SpotifyArtist[]> => {
+  const { data } = await api.get<FollowedArtistsResponse>('/spotify/artists/followed');
+  return data.artists;
+};
+
+export const fetchArtistReleases = async (
+  artistId: string
+): Promise<SpotifyArtistRelease[]> => {
+  const { data } = await api.get<ArtistReleasesResponse>(`/spotify/artist/${artistId}/releases`);
+  return data.releases;
+};
+
 export const searchSpotifyTracks = async (query: string): Promise<SpotifyTrackSummary[]> => {
   const { data } = await api.get<SpotifySearchResponse>('/spotify/search/tracks', {
     params: { query }
@@ -186,6 +238,11 @@ export const fetchSoulseekDownloads = async (): Promise<SoulseekDownloadEntry[]>
   return data.downloads;
 };
 
+export const fetchArtistPreferences = async (): Promise<ArtistPreferenceEntry[]> => {
+  const { data } = await api.get<ArtistPreferencesResponse>('/settings/artist-preferences');
+  return data.preferences;
+};
+
 export const runSpotifyToPlexMatch = async (
   payload: MatchingRequestPayload
 ): Promise<MatchingResponsePayload> => {
@@ -198,6 +255,15 @@ export const runSpotifyToSoulseekMatch = async (
 ): Promise<MatchingResponsePayload> => {
   const { data } = await api.post<MatchingResponsePayload>('/matching/spotify-to-soulseek', payload);
   return data;
+};
+
+export const saveArtistPreferences = async (
+  preferences: ArtistPreferenceEntry[]
+): Promise<ArtistPreferenceEntry[]> => {
+  const { data } = await api.post<ArtistPreferencesResponse>('/settings/artist-preferences', {
+    preferences
+  });
+  return data.preferences;
 };
 
 export const runSpotifyToPlexAlbumMatch = async (

--- a/frontend/src/pages/ArtistsPage.tsx
+++ b/frontend/src/pages/ArtistsPage.tsx
@@ -1,0 +1,361 @@
+import { useEffect, useMemo, useState } from 'react';
+import { Loader2, Users } from 'lucide-react';
+import { Button } from '../components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../components/ui/card';
+import { ScrollArea } from '../components/ui/scroll-area';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../components/ui/table';
+import { Switch } from '../components/ui/switch';
+import { useToast } from '../hooks/useToast';
+import {
+  ArtistPreferenceEntry,
+  fetchArtistPreferences,
+  fetchArtistReleases,
+  fetchFollowedArtists,
+  saveArtistPreferences,
+  SpotifyArtist,
+  SpotifyArtistRelease
+} from '../lib/api';
+import { useMutation, useQuery } from '../lib/query';
+
+const toTitleCase = (value?: string | null) => {
+  if (!value) {
+    return 'Unbekannt';
+  }
+  return value.charAt(0).toUpperCase() + value.slice(1);
+};
+
+const getReleaseYear = (value?: string | null) => {
+  if (!value) {
+    return '—';
+  }
+  const year = value.slice(0, 4);
+  return year || '—';
+};
+
+const extractImageUrl = (artist: SpotifyArtist) => {
+  const image = artist.images?.find((item) => Boolean(item?.url));
+  return image?.url ?? '';
+};
+
+const areSelectionsEqual = (a: Record<string, boolean>, b: Record<string, boolean>) => {
+  const keys = new Set([...Object.keys(a), ...Object.keys(b)]);
+  for (const key of keys) {
+    if (Boolean(a[key]) !== Boolean(b[key])) {
+      return false;
+    }
+  }
+  return true;
+};
+
+const ArtistsPage = () => {
+  const { toast } = useToast();
+  const [selectedArtistId, setSelectedArtistId] = useState<string | null>(null);
+  const [selection, setSelection] = useState<Record<string, boolean>>({});
+  const [releaseCounts, setReleaseCounts] = useState<Record<string, number>>({});
+
+  const {
+    data: artists,
+    isLoading: isLoadingArtists
+  } = useQuery<SpotifyArtist[]>({
+    queryKey: ['spotify-followed-artists'],
+    queryFn: fetchFollowedArtists,
+    onError: () =>
+      toast({
+        title: 'Artists konnten nicht geladen werden',
+        description: 'Bitte Backend-Verbindung prüfen.',
+        variant: 'destructive'
+      })
+  });
+
+  const {
+    data: preferences,
+    refetch: refetchPreferences
+  } = useQuery<ArtistPreferenceEntry[]>({
+    queryKey: ['artist-preferences'],
+    queryFn: fetchArtistPreferences,
+    onError: () =>
+      toast({
+        title: 'Artist-Präferenzen fehlgeschlagen',
+        description: 'Die Auswahl konnte nicht geladen werden.',
+        variant: 'destructive'
+      })
+  });
+
+  const {
+    data: releases,
+    isLoading: isLoadingReleases,
+    refetch: refetchReleases
+  } = useQuery<SpotifyArtistRelease[]>({
+    queryKey: ['artist-releases', selectedArtistId ?? 'none'],
+    queryFn: () => {
+      if (!selectedArtistId) {
+        return Promise.resolve<SpotifyArtistRelease[]>([]);
+      }
+      return fetchArtistReleases(selectedArtistId);
+    },
+    onError: () =>
+      toast({
+        title: 'Releases konnten nicht geladen werden',
+        description: 'Bitte versuchen Sie es erneut.',
+        variant: 'destructive'
+      })
+  });
+
+  const baseSelection = useMemo(() => {
+    if (!selectedArtistId) {
+      return {};
+    }
+    const relevantPreferences = (preferences ?? []).filter((entry) => entry.artist_id === selectedArtistId);
+    const preferenceMap = new Map(relevantPreferences.map((entry) => [entry.release_id, entry.selected]));
+    const nextSelection: Record<string, boolean> = {};
+    (releases ?? []).forEach((release) => {
+      if (release.id) {
+        nextSelection[release.id] = preferenceMap.get(release.id) ?? false;
+      }
+    });
+    return nextSelection;
+  }, [preferences, releases, selectedArtistId]);
+
+  useEffect(() => {
+    if (!selectedArtistId) {
+      setSelection({});
+      return;
+    }
+    setSelection((previous) => {
+      if (areSelectionsEqual(previous, baseSelection)) {
+        return previous;
+      }
+      return baseSelection;
+    });
+  }, [baseSelection, selectedArtistId]);
+
+  useEffect(() => {
+    if (!selectedArtistId) {
+      return;
+    }
+    const count = releases?.length ?? 0;
+    setReleaseCounts((prev) => {
+      if (prev[selectedArtistId] === count) {
+        return prev;
+      }
+      return { ...prev, [selectedArtistId]: count };
+    });
+  }, [releases, selectedArtistId]);
+
+  const savePreferencesMutation = useMutation({
+    mutationFn: saveArtistPreferences,
+    onSuccess: () => {
+      toast({
+        title: 'Präferenzen gespeichert',
+        description: 'Die Auswahl wurde erfolgreich aktualisiert.'
+      });
+      void refetchPreferences();
+      void refetchReleases();
+    },
+    onError: () => {
+      toast({
+        title: 'Speichern fehlgeschlagen',
+        description: 'Die Auswahl konnte nicht gespeichert werden.',
+        variant: 'destructive'
+      });
+    }
+  });
+
+  const sortedArtists = useMemo(() => {
+    return [...(artists ?? [])].sort((a, b) => {
+      const nameA = a.name ?? '';
+      const nameB = b.name ?? '';
+      return nameA.localeCompare(nameB);
+    });
+  }, [artists]);
+
+  const selectedArtist = useMemo(
+    () => sortedArtists.find((artist) => artist.id === selectedArtistId) ?? null,
+    [sortedArtists, selectedArtistId]
+  );
+
+  const releaseRows = useMemo(() => releases ?? [], [releases]);
+
+  const currentSelection = selection;
+  const isDirty = useMemo(
+    () => !areSelectionsEqual(currentSelection, baseSelection),
+    [baseSelection, currentSelection]
+  );
+
+  const handleToggle = (releaseId: string, value: boolean) => {
+    setSelection((prev) => ({ ...prev, [releaseId]: value }));
+  };
+
+  const handleSave = () => {
+    if (!selectedArtistId) {
+      return;
+    }
+    const payload = Object.entries(selection).map(([releaseId, selected]) => ({
+      artist_id: selectedArtistId,
+      release_id: releaseId,
+      selected
+    }));
+    if (payload.length === 0) {
+      toast({
+        title: 'Keine Releases zum Speichern',
+        description: 'Für diesen Artist liegen keine auswählbaren Releases vor.'
+      });
+      return;
+    }
+    void savePreferencesMutation.mutate(payload);
+  };
+
+  const renderArtistList = () => {
+    if (isLoadingArtists) {
+      return (
+        <div className="flex items-center justify-center py-8 text-muted-foreground">
+          <Loader2 className="h-5 w-5 animate-spin" />
+        </div>
+      );
+    }
+
+    if (!sortedArtists.length) {
+      return <p className="text-sm text-muted-foreground">Keine Artists gefunden.</p>;
+    }
+
+    return (
+      <ul className="space-y-2">
+        {sortedArtists.map((artist) => {
+          const isActive = artist.id === selectedArtistId;
+          const imageUrl = extractImageUrl(artist);
+          const count = releaseCounts[artist.id];
+          return (
+            <li key={artist.id}>
+              <button
+                type="button"
+                onClick={() => setSelectedArtistId(artist.id)}
+                className={`flex w-full items-center gap-3 rounded-md border px-3 py-2 text-left transition-colors hover:border-primary hover:bg-primary/5 ${
+                  isActive ? 'border-primary bg-primary/10' : 'border-border'
+                }`}
+              >
+                {imageUrl ? (
+                  <img src={imageUrl} alt="Artist Cover" className="h-10 w-10 rounded-md object-cover" />
+                ) : (
+                  <div className="flex h-10 w-10 items-center justify-center rounded-md bg-muted text-muted-foreground">
+                    <Users className="h-5 w-5" />
+                  </div>
+                )}
+                <div className="flex flex-1 flex-col">
+                  <span className="text-sm font-medium">{artist.name}</span>
+                  <span className="text-xs text-muted-foreground">
+                    {typeof count === 'number' ? `${count} Releases` : 'Releases unbekannt'}
+                  </span>
+                </div>
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+    );
+  };
+
+  const renderReleaseTable = () => {
+    if (!selectedArtistId) {
+      return <p className="text-sm text-muted-foreground">Bitte wählen Sie einen Artist aus.</p>;
+    }
+
+    if (isLoadingReleases) {
+      return (
+        <div className="flex items-center justify-center py-12 text-muted-foreground">
+          <Loader2 className="h-5 w-5 animate-spin" />
+        </div>
+      );
+    }
+
+    if (!releaseRows.length) {
+      return <p className="text-sm text-muted-foreground">Keine Releases verfügbar.</p>;
+    }
+
+    return (
+      <div className="overflow-hidden rounded-lg border">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Titel</TableHead>
+              <TableHead>Typ</TableHead>
+              <TableHead>Erscheinungsjahr</TableHead>
+              <TableHead>Tracks</TableHead>
+              <TableHead className="text-right">Für Sync aktivieren</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {releaseRows.map((release) => {
+              const isSelected = selection[release.id] ?? false;
+              return (
+                <TableRow key={release.id}>
+                  <TableCell className="font-medium">{release.name}</TableCell>
+                  <TableCell>{toTitleCase(release.album_type)}</TableCell>
+                  <TableCell>{getReleaseYear(release.release_date)}</TableCell>
+                  <TableCell>{release.total_tracks ?? '—'}</TableCell>
+                  <TableCell className="text-right">
+                    <Switch
+                      checked={isSelected}
+                      onCheckedChange={(value) => handleToggle(release.id, value)}
+                      aria-label={`Sync für ${release.name}`}
+                    />
+                  </TableCell>
+                </TableRow>
+              );
+            })}
+          </TableBody>
+        </Table>
+      </div>
+    );
+  };
+
+  return (
+    <div className="space-y-6">
+      <Card>
+        <CardHeader>
+          <CardTitle>Gefolgte Artists</CardTitle>
+          <CardDescription>Verwalten Sie, welche Releases automatisch synchronisiert werden sollen.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="grid gap-6 lg:grid-cols-[320px_minmax(0,1fr)]">
+            <ScrollArea className="max-h-[540px] rounded-lg border p-4">
+              {renderArtistList()}
+            </ScrollArea>
+            <div className="space-y-4">
+              <div>
+                <h2 className="text-lg font-semibold">
+                  {selectedArtist ? selectedArtist.name : 'Keine Auswahl'}
+                </h2>
+                <p className="text-sm text-muted-foreground">
+                  {selectedArtist
+                    ? 'Aktivieren Sie Releases, die vom AutoSync berücksichtigt werden sollen.'
+                    : 'Wählen Sie links einen Artist aus, um verfügbare Releases zu sehen.'}
+                </p>
+              </div>
+              {renderReleaseTable()}
+              <div className="flex justify-end gap-2">
+                <Button variant="outline" onClick={() => setSelection(baseSelection)} disabled={!isDirty}>
+                  Änderungen verwerfen
+                </Button>
+                <Button
+                  onClick={handleSave}
+                  disabled={!selectedArtistId || !isDirty || savePreferencesMutation.isPending}
+                >
+                  {savePreferencesMutation.isPending ? (
+                    <span className="inline-flex items-center gap-2">
+                      <Loader2 className="h-4 w-4 animate-spin" />
+                      Wird gespeichert...
+                    </span>
+                  ) : (
+                    'Änderungen speichern'
+                  )}
+                </Button>
+              </div>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export default ArtistsPage;


### PR DESCRIPTION
## Summary
- add an artists management view with loading/empty states, release toggles and persistence via artist preferences
- expose Spotify artist/release fetchers and settings helpers for the new UI
- cover the page with jest tests and extend documentation, changelog and todo list

## Testing
- npm run build
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d33e6129c08321a15739138077f143