### PR TITLE
feat: enhance worker orchestration and monitoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,15 @@ Alle Änderungen an diesem Projekt werden in diesem Dokument festgehalten. Diese
 - AutoSyncWorker, der Spotify-Playlists und gespeicherte Tracks automatisch mit Plex abgleicht, fehlende Titel via Soulseek lädt und anschließend per Beets importiert (manuell triggerbar über `/api/sync`).
 - Artist-Konfiguration mit neuen Spotify- und Settings-Endpunkten sowie der Tabelle `artist_preferences`.
 - Artists-Seite im Frontend zur Verwaltung gefolgter Spotify-Artists und ihrer Releases inklusive Sync-Toggles.
+- Persistente Worker-Queues (`worker_jobs`) inkl. Health/Metric-Tracking (`worker.*`, `metrics.*`) für Sync-, Matching- und Scan-Worker.
+- Quality-/Priorisierungsregeln für den AutoSyncWorker (`autosync_min_bitrate`, `autosync_preferred_formats`, Skip-State in `auto_sync_skipped_tracks`).
 
 ### Changed
 - Dashboard-Aktivitätsfeed mit lokalisierten Typen, sortierten Einträgen und farbcodierten Status-Badges verfeinert.
 - AutoSyncWorker filtert Spotify-Tracks anhand gespeicherter Artist-Präferenzen.
+- SyncWorker parallelisiert Downloads und passt das Polling adaptiv an inaktive Phasen an.
+- MatchingWorker verarbeitet Jobs in Batches, speichert mehrere Treffer oberhalb des Confidence-Thresholds und schreibt Kennzahlen.
+- ScanWorker liest Intervall-/Incremental-Settings, löst optionale Plex-Incremental-Scans aus und meldet wiederholte Fehler im Activity Feed.
 
 ### Fixed
 - Noch keine Einträge.

--- a/ToDo.md
+++ b/ToDo.md
@@ -12,3 +12,4 @@
 - [x] Artists-Frontend zum Aktivieren einzelner Releases inkl. Tests und Dokumentation ergänzen.
 - [ ] Streaming-Router für Audio-Features planen und implementieren (Frontend-Integration vorbereiten).
 - [ ] Frontend-Testlauf im CI wieder aktivieren, sobald npm-Registry-Zugriff verfügbar ist.
+- [ ] Prometheus-/StatsD-Exporter auf Basis der neuen `metrics.*` Settings anbinden.

--- a/app/core/plex_client.py
+++ b/app/core/plex_client.py
@@ -143,6 +143,17 @@ class PlexClient:
 
         return await self._get(f"/library/sections/{section_id}/all", params=params)
 
+    async def refresh_library_section(self, section_id: str, *, full: bool = False) -> None:
+        """Trigger a Plex library scan for the given section."""
+
+        params = {"force": int(bool(full))}
+        await self._request(
+            "GET",
+            f"/library/sections/{section_id}/refresh",
+            params=params,
+            expect_json=False,
+        )
+
     async def get_metadata(self, item_id: str) -> Any:
         return await self._get(f"/library/metadata/{item_id}")
 

--- a/app/utils/settings_store.py
+++ b/app/utils/settings_store.py
@@ -1,0 +1,79 @@
+"""Utility helpers for reading and writing dynamic settings."""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Optional
+
+from sqlalchemy import select
+
+from app.db import session_scope
+from app.models import Setting
+
+
+def write_setting(key: str, value: str) -> None:
+    """Persist a string value to the settings table."""
+
+    now = datetime.utcnow()
+    with session_scope() as session:
+        setting = (
+            session.execute(select(Setting).where(Setting.key == key)).scalar_one_or_none()
+        )
+        if setting is None:
+            session.add(
+                Setting(
+                    key=key,
+                    value=value,
+                    created_at=now,
+                    updated_at=now,
+                )
+            )
+        else:
+            setting.value = value
+            setting.updated_at = now
+
+
+def read_setting(key: str) -> Optional[str]:
+    """Return the stored value for ``key`` if present."""
+
+    with session_scope() as session:
+        setting = (
+            session.execute(select(Setting).where(Setting.key == key)).scalar_one_or_none()
+        )
+        if setting is None:
+            return None
+        return setting.value
+
+
+def increment_counter(key: str, *, amount: int = 1) -> int:
+    """Increment an integer counter stored as a setting and return the new value."""
+
+    if amount == 0:
+        current = read_setting(key)
+        return int(current) if current and current.isdigit() else 0
+
+    with session_scope() as session:
+        setting = (
+            session.execute(select(Setting).where(Setting.key == key)).scalar_one_or_none()
+        )
+        now = datetime.utcnow()
+        if setting is None:
+            new_value = amount
+            session.add(
+                Setting(
+                    key=key,
+                    value=str(new_value),
+                    created_at=now,
+                    updated_at=now,
+                )
+            )
+            return new_value
+
+        try:
+            current_value = int(setting.value or 0)
+        except (TypeError, ValueError):
+            current_value = 0
+
+        new_value = current_value + amount
+        setting.value = str(new_value)
+        setting.updated_at = now
+        return new_value

--- a/app/workers/matching_worker.py
+++ b/app/workers/matching_worker.py
@@ -2,83 +2,235 @@
 from __future__ import annotations
 
 import asyncio
-from typing import Any, Dict
+import os
+import statistics
+from datetime import datetime
+from typing import Any, Dict, Iterable, List, Tuple
 
 from app.core.matching_engine import MusicMatchingEngine
 from app.db import session_scope
 from app.logging import get_logger
 from app.models import Match
+from app.utils.activity import record_activity
+from app.utils.settings_store import (
+    increment_counter,
+    read_setting,
+    write_setting,
+)
+from app.workers.persistence import PersistentJobQueue, QueuedJob
 
 logger = get_logger(__name__)
 
+DEFAULT_BATCH_SIZE = 5
+DEFAULT_THRESHOLD = 0.65
+
 
 class MatchingWorker:
-    def __init__(self, engine: MusicMatchingEngine) -> None:
+    def __init__(
+        self,
+        engine: MusicMatchingEngine,
+        *,
+        batch_size: int | None = None,
+        confidence_threshold: float | None = None,
+        batch_wait_seconds: float = 0.1,
+    ) -> None:
         self._engine = engine
-        self._queue: asyncio.Queue[Dict[str, Any]] = asyncio.Queue()
-        self._task: asyncio.Task | None = None
+        self._job_store = PersistentJobQueue("matching")
+        self._queue: asyncio.Queue[QueuedJob | None] = asyncio.Queue()
+        self._manager_task: asyncio.Task | None = None
+        self._worker_task: asyncio.Task | None = None
         self._running = asyncio.Event()
+        self._stop_event = asyncio.Event()
+        self._batch_wait = batch_wait_seconds
+        self._batch_size = max(1, batch_size or self._resolve_batch_size())
+        self._confidence_threshold = confidence_threshold or self._resolve_threshold()
+
+    def _resolve_batch_size(self) -> int:
+        setting_value = read_setting("matching_worker_batch_size")
+        env_value = os.getenv("MATCHING_WORKER_BATCH_SIZE")
+        for value in (setting_value, env_value):
+            if not value:
+                continue
+            try:
+                parsed = int(value)
+            except (TypeError, ValueError):
+                continue
+            if parsed > 0:
+                return parsed
+        return DEFAULT_BATCH_SIZE
+
+    def _resolve_threshold(self) -> float:
+        setting_value = read_setting("matching_confidence_threshold")
+        env_value = os.getenv("MATCHING_CONFIDENCE_THRESHOLD")
+        for value in (setting_value, env_value):
+            if not value:
+                continue
+            try:
+                parsed = float(value)
+            except (TypeError, ValueError):
+                continue
+            if 0 < parsed <= 1:
+                return parsed
+        return DEFAULT_THRESHOLD
 
     async def start(self) -> None:
-        if self._task is None or self._task.done():
-            self._running.set()
-            self._task = asyncio.create_task(self._run())
+        if self._manager_task is not None and not self._manager_task.done():
+            return
+        self._running.set()
+        self._stop_event = asyncio.Event()
+        self._manager_task = asyncio.create_task(self._run())
 
     async def stop(self) -> None:
-        self._running.clear()
-        if self._task:
-            await self._queue.put({"_shutdown": True})
-            await self._task
+        if not self._running.is_set():
+            return
+        self._stop_event.set()
+        if self._manager_task is not None:
+            await self._manager_task
 
     @property
-    def queue(self) -> asyncio.Queue[Dict[str, Any]]:
+    def queue(self) -> asyncio.Queue[QueuedJob | None]:
         return self._queue
+
+    async def enqueue(self, payload: Dict[str, Any]) -> None:
+        job = self._job_store.enqueue(payload)
+        if self._running.is_set():
+            await self._queue.put(job)
+        else:
+            await self._process_batch([job])
 
     async def _run(self) -> None:
         logger.info("MatchingWorker started")
+        write_setting("worker.matching.last_start", datetime.utcnow().isoformat())
+        pending = self._job_store.list_pending()
+        for job in pending:
+            await self._queue.put(job)
+
+        self._worker_task = asyncio.create_task(self._worker_loop())
+
+        try:
+            await self._stop_event.wait()
+        finally:
+            await self._queue.put(None)
+            if self._worker_task:
+                await self._worker_task
+            self._job_store.requeue_incomplete()
+            self._running.clear()
+            write_setting("worker.matching.last_stop", datetime.utcnow().isoformat())
+            logger.info("MatchingWorker stopped")
+
+    async def _worker_loop(self) -> None:
         while self._running.is_set():
-            job = await self._queue.get()
-            try:
-                if job.get("_shutdown"):
+            first_job = await self._queue.get()
+            if first_job is None:
+                break
+            batch = [first_job]
+            while len(batch) < self._batch_size:
+                try:
+                    job = await asyncio.wait_for(
+                        self._queue.get(), timeout=self._batch_wait
+                    )
+                except asyncio.TimeoutError:
                     break
-                await self._process_job(job)
-            except Exception as exc:  # pragma: no cover
-                logger.error("Failed to process matching job: %s", exc)
-            finally:
+                if job is None:
+                    await self._queue.put(None)
+                    break
+                batch.append(job)
+
+            await self._process_batch(batch)
+            for _ in batch:
                 self._queue.task_done()
-        logger.info("MatchingWorker stopped")
 
-    async def _process_job(self, job: Dict[str, Any]) -> None:
-        job_type = job.get("type")
-        spotify_track = job.get("spotify_track")
-        candidates = job.get("candidates", [])
+    async def _process_batch(self, jobs: List[QueuedJob]) -> None:
+        stored_scores: List[float] = []
+        discarded = 0
+
+        for job in jobs:
+            try:
+                matches, rejected = await self._execute_job(job)
+                discarded += rejected
+                stored_scores.extend(score for _, score in matches)
+            except Exception as exc:  # pragma: no cover - defensive
+                logger.error("Failed to process matching job %s: %s", job.id, exc)
+                record_activity(
+                    "metadata",
+                    "matching_job_failed",
+                    details={"job_id": job.id, "error": str(exc)},
+                )
+
+        average_confidence = statistics.mean(stored_scores) if stored_scores else 0.0
+        write_setting(
+            "metrics.matching.last_average_confidence",
+            f"{average_confidence:.4f}",
+        )
+        write_setting("metrics.matching.last_discarded", str(discarded))
+        increment_counter("metrics.matching.discarded_total", amount=discarded)
+        increment_counter("metrics.matching.saved_total", amount=len(stored_scores))
+        record_activity(
+            "metadata",
+            "matching_batch",
+            details={
+                "batch_size": len(jobs),
+                "stored": len(stored_scores),
+                "discarded": discarded,
+                "average_confidence": round(average_confidence, 4),
+            },
+        )
+        self._record_heartbeat()
+
+    async def _execute_job(self, job: QueuedJob) -> Tuple[List[Tuple[Dict[str, Any], float]], int]:
+        self._job_store.mark_running(job.id)
+        payload = job.payload
+        job_type = payload.get("type")
+        spotify_track = payload.get("spotify_track")
+        candidates = payload.get("candidates", [])
         if not spotify_track or not candidates:
-            logger.warning("Invalid matching job received: %s", job)
-            return
-        if job_type == "spotify-to-plex":
-            best_match, confidence = self._engine.find_best_match(spotify_track, candidates)
-        else:
-            best_match = None
-            confidence = 0.0
-            for candidate in candidates:
-                score = self._engine.calculate_slskd_match_confidence(spotify_track, candidate)
-                if score > confidence:
-                    confidence = score
-                    best_match = candidate
-        self._store_match(job_type, spotify_track, best_match, confidence)
+            logger.warning("Invalid matching job received: %s", payload)
+            self._job_store.mark_failed(job.id, "invalid_payload")
+            return [], 0
 
-    def _store_match(
+        matches, discarded = self._evaluate_candidates(job_type, spotify_track, candidates)
+        if matches:
+            self._store_matches(job_type or "unknown", spotify_track, matches)
+            self._job_store.mark_completed(job.id)
+        else:
+            self._job_store.mark_failed(job.id, "no_match")
+        return matches, discarded
+
+    def _evaluate_candidates(
+        self, job_type: str | None, spotify_track: Dict[str, Any], candidates: Iterable[Dict[str, Any]]
+    ) -> Tuple[List[Tuple[Dict[str, Any], float]], int]:
+        matches: List[Tuple[Dict[str, Any], float]] = []
+        rejected = 0
+        for candidate in candidates:
+            if not isinstance(candidate, dict):
+                rejected += 1
+                continue
+            if job_type == "spotify-to-plex":
+                score = self._engine.calculate_match_confidence(spotify_track, candidate)
+            else:
+                score = self._engine.calculate_slskd_match_confidence(spotify_track, candidate)
+            if score >= self._confidence_threshold:
+                matches.append((candidate, score))
+            else:
+                rejected += 1
+        matches.sort(key=lambda item: item[1], reverse=True)
+        return matches, rejected
+
+    def _store_matches(
         self,
         job_type: str,
         spotify_track: Dict[str, Any],
-        best_match: Dict[str, Any] | None,
-        confidence: float,
+        matches: List[Tuple[Dict[str, Any], float]],
     ) -> None:
         with session_scope() as session:
-            match = Match(
-                source=job_type,
-                spotify_track_id=str(spotify_track.get("id")),
-                target_id=str(best_match.get("id")) if best_match and best_match.get("id") else None,
-                confidence=confidence,
-            )
-            session.add(match)
+            for candidate, score in matches:
+                match = Match(
+                    source=job_type,
+                    spotify_track_id=str(spotify_track.get("id")),
+                    target_id=str(candidate.get("id")) if candidate.get("id") else None,
+                    confidence=score,
+                )
+                session.add(match)
+
+    def _record_heartbeat(self) -> None:
+        write_setting("worker.matching.last_seen", datetime.utcnow().isoformat())

--- a/app/workers/persistence.py
+++ b/app/workers/persistence.py
@@ -1,0 +1,113 @@
+"""Persistence helpers for worker job queues."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Iterable, List
+
+from sqlalchemy import select
+
+from app.db import session_scope
+from app.models import WorkerJob
+
+
+@dataclass(slots=True)
+class QueuedJob:
+    """In-memory representation of a worker job stored in the database."""
+
+    id: int
+    payload: dict
+
+
+class PersistentJobQueue:
+    """Provide simple CRUD helpers for worker job persistence."""
+
+    def __init__(self, worker_name: str) -> None:
+        self._worker = worker_name
+
+    def enqueue(self, payload: dict) -> QueuedJob:
+        with session_scope() as session:
+            job = WorkerJob(worker=self._worker, payload=payload)
+            session.add(job)
+            session.flush()
+            return QueuedJob(id=job.id, payload=dict(payload))
+
+    def enqueue_many(self, payloads: Iterable[dict]) -> List[QueuedJob]:
+        jobs: List[QueuedJob] = []
+        with session_scope() as session:
+            now = datetime.utcnow()
+            for payload in payloads:
+                job = WorkerJob(
+                    worker=self._worker,
+                    payload=payload,
+                    scheduled_at=now,
+                )
+                session.add(job)
+                session.flush()
+                jobs.append(QueuedJob(id=job.id, payload=dict(payload)))
+        return jobs
+
+    def list_pending(self) -> List[QueuedJob]:
+        with session_scope() as session:
+            jobs = (
+                session.execute(
+                    select(WorkerJob)
+                    .where(
+                        WorkerJob.worker == self._worker,
+                        WorkerJob.state.in_(["queued", "running"]),
+                    )
+                    .order_by(WorkerJob.created_at.asc())
+                )
+                .scalars()
+                .all()
+            )
+            results: List[QueuedJob] = []
+            for job in jobs:
+                job.state = "queued"
+                job.updated_at = datetime.utcnow()
+                results.append(QueuedJob(id=job.id, payload=dict(job.payload)))
+            return results
+
+    def mark_running(self, job_id: int) -> None:
+        with session_scope() as session:
+            job = session.get(WorkerJob, job_id)
+            if job is None:
+                return
+            job.state = "running"
+            job.attempts += 1
+            job.updated_at = datetime.utcnow()
+
+    def mark_completed(self, job_id: int) -> None:
+        with session_scope() as session:
+            job = session.get(WorkerJob, job_id)
+            if job is None:
+                return
+            job.state = "completed"
+            job.last_error = None
+            job.updated_at = datetime.utcnow()
+
+    def mark_failed(self, job_id: int, error: str) -> None:
+        with session_scope() as session:
+            job = session.get(WorkerJob, job_id)
+            if job is None:
+                return
+            job.state = "failed"
+            job.last_error = error
+            job.updated_at = datetime.utcnow()
+
+    def requeue_incomplete(self) -> None:
+        with session_scope() as session:
+            jobs = (
+                session.execute(
+                    select(WorkerJob).where(
+                        WorkerJob.worker == self._worker,
+                        WorkerJob.state == "running",
+                    )
+                )
+                .scalars()
+                .all()
+            )
+            now = datetime.utcnow()
+            for job in jobs:
+                job.state = "queued"
+                job.updated_at = now

--- a/app/workers/scan_worker.py
+++ b/app/workers/scan_worker.py
@@ -2,6 +2,8 @@
 from __future__ import annotations
 
 import asyncio
+import os
+import time
 from datetime import datetime
 
 from sqlalchemy import select
@@ -10,50 +12,79 @@ from app.core.plex_client import PlexClient
 from app.db import session_scope
 from app.logging import get_logger
 from app.models import Setting
+from app.utils.activity import record_activity
+from app.utils.settings_store import read_setting, write_setting
 
 logger = get_logger(__name__)
 
+DEFAULT_INTERVAL = 600
+
 
 class ScanWorker:
-    def __init__(self, plex_client: PlexClient, interval_seconds: int = 600) -> None:
+    def __init__(self, plex_client: PlexClient, interval_seconds: int = DEFAULT_INTERVAL) -> None:
         self._client = plex_client
         self._interval = interval_seconds
         self._task: asyncio.Task | None = None
         self._running = asyncio.Event()
+        self._stop_event = asyncio.Event()
+        self._failure_count = 0
 
     async def start(self) -> None:
         if self._task is None or self._task.done():
             self._running.set()
+            self._stop_event = asyncio.Event()
             self._task = asyncio.create_task(self._run())
 
     async def stop(self) -> None:
+        if not self._running.is_set():
+            return
         self._running.clear()
+        self._stop_event.set()
         if self._task:
-            self._task.cancel()
-            try:
-                await self._task
-            except asyncio.CancelledError:  # pragma: no cover
-                pass
+            await self._task
 
     async def _run(self) -> None:
         logger.info("ScanWorker started")
-        while self._running.is_set():
-            await self._perform_scan()
-            await asyncio.sleep(self._interval)
-        logger.info("ScanWorker stopped")
+        write_setting("worker.scan.last_start", datetime.utcnow().isoformat())
+        try:
+            while self._running.is_set():
+                self._interval = self._resolve_interval()
+                await self._perform_scan()
+                self._record_heartbeat()
+                try:
+                    await asyncio.wait_for(self._stop_event.wait(), timeout=self._interval)
+                except asyncio.TimeoutError:
+                    continue
+        finally:
+            write_setting("worker.scan.last_stop", datetime.utcnow().isoformat())
+            logger.info("ScanWorker stopped")
 
     async def run_once(self) -> None:
         """Execute a single scan cycle on demand."""
 
         await self._perform_scan()
+        self._record_heartbeat()
 
     async def _perform_scan(self) -> None:
+        start = time.perf_counter()
+        incremental = False
+        if self._is_incremental_enabled():
+            incremental = await self._trigger_incremental_scan()
+
         try:
             stats = await self._client.get_library_statistics()
         except Exception as exc:  # pragma: no cover
+            self._failure_count += 1
             logger.error("Failed to scan Plex library: %s", exc)
+            if self._failure_count >= 3:
+                record_activity(
+                    "metadata",
+                    "scan_failed",
+                    details={"error": str(exc), "consecutive": self._failure_count},
+                )
             return
 
+        self._failure_count = 0
         artist_count = stats.get("artists", 0)
         album_count = stats.get("albums", 0)
         track_count = stats.get("tracks", 0)
@@ -66,12 +97,63 @@ class ScanWorker:
             self._upsert_setting(
                 session, "plex_last_scan", now.isoformat(timespec="seconds"), now
             )
+        duration_ms = int((time.perf_counter() - start) * 1000)
+        write_setting("metrics.scan.duration_ms", str(duration_ms))
+        write_setting("metrics.scan.incremental", "1" if incremental else "0")
         logger.info(
-            "Plex scan complete: %d artists, %d albums, %d tracks",
+            "Plex scan complete: %d artists, %d albums, %d tracks (incremental=%s)",
             artist_count,
             album_count,
             track_count,
+            incremental,
         )
+
+    def _resolve_interval(self) -> int:
+        setting_value = read_setting("scan_worker_interval_seconds")
+        env_value = os.getenv("SCAN_WORKER_INTERVAL_SECONDS")
+        for value in (setting_value, env_value):
+            if not value:
+                continue
+            try:
+                parsed = int(value)
+            except (TypeError, ValueError):
+                continue
+            if parsed > 0:
+                write_setting("metrics.scan.interval", str(parsed))
+                return parsed
+        write_setting("metrics.scan.interval", str(DEFAULT_INTERVAL))
+        return DEFAULT_INTERVAL
+
+    def _is_incremental_enabled(self) -> bool:
+        setting_value = read_setting("scan_worker_incremental")
+        if setting_value is not None:
+            return setting_value.lower() in {"1", "true", "yes"}
+        env_value = os.getenv("SCAN_WORKER_INCREMENTAL", "0")
+        return env_value.lower() in {"1", "true", "yes"}
+
+    async def _trigger_incremental_scan(self) -> bool:
+        try:
+            libraries = await self._client.get_libraries()
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.warning("Unable to list Plex libraries for incremental scan: %s", exc)
+            return False
+
+        triggered = False
+        container = libraries.get("MediaContainer", {}) if isinstance(libraries, dict) else {}
+        for section in container.get("Directory", []) or []:
+            if not isinstance(section, dict):
+                continue
+            if section.get("type") != "artist":
+                continue
+            section_id = section.get("key")
+            if not section_id:
+                continue
+            try:
+                await self._client.refresh_library_section(str(section_id), full=False)
+                triggered = True
+            except Exception as exc:  # pragma: no cover - defensive
+                logger.debug("Failed to trigger incremental scan for section %s: %s", section_id, exc)
+        return triggered
 
     @staticmethod
     def _upsert_setting(session, key: str, value: str, timestamp: datetime) -> None:
@@ -90,3 +172,6 @@ class ScanWorker:
         else:
             setting.value = value
             setting.updated_at = timestamp
+
+    def _record_heartbeat(self) -> None:
+        write_setting("worker.scan.last_seen", datetime.utcnow().isoformat())

--- a/app/workers/sync_worker.py
+++ b/app/workers/sync_worker.py
@@ -2,77 +2,172 @@
 from __future__ import annotations
 
 import asyncio
+import os
 from datetime import datetime
-from typing import Any, Dict, Iterable
+from typing import Any, Dict, Iterable, List, Optional
 
 from app.core.soulseek_client import SoulseekClient
 from app.db import session_scope
 from app.logging import get_logger
 from app.models import Download
+from app.utils.activity import record_activity
+from app.utils.settings_store import increment_counter, read_setting, write_setting
+from app.workers.persistence import PersistentJobQueue, QueuedJob
 
 logger = get_logger(__name__)
 
 ALLOWED_STATES = {"queued", "downloading", "completed", "failed"}
 
+DEFAULT_CONCURRENCY = 2
+DEFAULT_IDLE_POLL = 15.0
+
 
 class SyncWorker:
-    def __init__(self, soulseek_client: SoulseekClient) -> None:
+    def __init__(
+        self,
+        soulseek_client: SoulseekClient,
+        *,
+        base_poll_interval: float = 2.0,
+        idle_poll_interval: Optional[float] = None,
+        concurrency: Optional[int] = None,
+    ) -> None:
         self._client = soulseek_client
-        self._queue: asyncio.Queue[Dict[str, Any]] = asyncio.Queue()
-        self._task: asyncio.Task | None = None
+        self._job_store = PersistentJobQueue("sync")
+        self._queue: asyncio.Queue[QueuedJob | None] = asyncio.Queue()
+        self._manager_task: asyncio.Task | None = None
+        self._worker_tasks: List[asyncio.Task] = []
+        self._poll_task: asyncio.Task | None = None
         self._running = asyncio.Event()
-        self._poll_interval = 2.0
+        self._stop_event = asyncio.Event()
+        self._base_poll_interval = base_poll_interval
+        self._idle_poll_interval = idle_poll_interval or DEFAULT_IDLE_POLL
+        self._current_poll_interval = base_poll_interval
+        self._concurrency = max(1, concurrency or self._resolve_concurrency())
+
+    def _resolve_concurrency(self) -> int:
+        setting_value = read_setting("sync_worker_concurrency")
+        env_value = os.getenv("SYNC_WORKER_CONCURRENCY")
+        for value in (setting_value, env_value):
+            if not value:
+                continue
+            try:
+                parsed = int(value)
+            except (TypeError, ValueError):
+                continue
+            if parsed > 0:
+                return parsed
+        return DEFAULT_CONCURRENCY
 
     @property
-    def queue(self) -> asyncio.Queue[Dict[str, Any]]:
+    def queue(self) -> asyncio.Queue[QueuedJob | None]:
         return self._queue
 
     def is_running(self) -> bool:
-        return self._running.is_set() and self._task is not None and not self._task.done()
+        return self._running.is_set()
 
     async def start(self) -> None:
-        if self._task is None or self._task.done():
-            self._running.set()
-            self._task = asyncio.create_task(self._run())
+        if self._manager_task is not None and not self._manager_task.done():
+            return
+        self._running.set()
+        self._stop_event = asyncio.Event()
+        self._manager_task = asyncio.create_task(self._run())
 
     async def stop(self) -> None:
-        self._running.clear()
-        if self._task:
-            await self._queue.put({"_shutdown": True})
-            await self._task
+        if not self._running.is_set():
+            return
+        self._stop_event.set()
+        if self._manager_task is not None:
+            await self._manager_task
 
     async def enqueue(self, job: Dict[str, Any]) -> None:
         """Submit a download job for processing."""
 
+        record = self._job_store.enqueue(job)
         if self.is_running():
-            await self._queue.put(job)
+            await self._queue.put(record)
             return
-        await self._process_job(job)
+
+        await self._execute_job(record)
         await self.refresh_downloads()
 
     async def _run(self) -> None:
         logger.info("SyncWorker started")
-        try:
-            while self._running.is_set():
-                job: Dict[str, Any] | None = None
-                try:
-                    job = await asyncio.wait_for(self._queue.get(), timeout=self._poll_interval)
-                except asyncio.TimeoutError:
-                    await self.refresh_downloads()
-                    continue
+        write_setting("worker.sync.last_start", datetime.utcnow().isoformat())
+        pending = self._job_store.list_pending()
+        for job in pending:
+            await self._queue.put(job)
 
-                try:
-                    if job.get("_shutdown"):
-                        break
-                    await self._process_job(job)
-                    await self.refresh_downloads()
-                except Exception as exc:  # pragma: no cover - defensive
-                    logger.error("Failed to process sync job: %s", exc)
-                finally:
-                    self._queue.task_done()
+        self._worker_tasks = [
+            asyncio.create_task(self._worker_loop(index))
+            for index in range(self._concurrency)
+        ]
+        self._poll_task = asyncio.create_task(self._poll_loop())
+
+        try:
+            await self._stop_event.wait()
         finally:
+            for _ in self._worker_tasks:
+                await self._queue.put(None)
+            await asyncio.gather(*self._worker_tasks, return_exceptions=True)
+            if self._poll_task:
+                self._poll_task.cancel()
+                try:
+                    await self._poll_task
+                except asyncio.CancelledError:  # pragma: no cover - lifecycle cleanup
+                    pass
+            self._job_store.requeue_incomplete()
+            write_setting("worker.sync.last_stop", datetime.utcnow().isoformat())
             self._running.clear()
             logger.info("SyncWorker stopped")
+
+    async def _worker_loop(self, index: int) -> None:
+        logger.debug("SyncWorker task %d started", index)
+        while self._running.is_set():
+            job = await self._queue.get()
+            if job is None:
+                break
+            try:
+                await self._execute_job(job)
+                await self.refresh_downloads()
+            except Exception as exc:  # pragma: no cover - defensive
+                logger.error("Failed to process sync job %s: %s", job.id, exc)
+                record_activity(
+                    "download",
+                    "sync_job_failed",
+                    details={"job_id": job.id, "error": str(exc)},
+                )
+            finally:
+                self._queue.task_done()
+        logger.debug("SyncWorker task %d stopped", index)
+
+    async def _poll_loop(self) -> None:
+        while self._running.is_set():
+            try:
+                active_downloads = await self.refresh_downloads()
+            except Exception as exc:  # pragma: no cover - defensive
+                logger.warning("Download refresh failed: %s", exc)
+                active_downloads = False
+
+            interval = self._base_poll_interval if active_downloads else min(
+                self._idle_poll_interval, max(self._current_poll_interval * 1.5, self._base_poll_interval)
+            )
+            self._current_poll_interval = interval
+            try:
+                await asyncio.wait_for(self._stop_event.wait(), timeout=interval)
+            except asyncio.TimeoutError:
+                continue
+
+    async def _execute_job(self, job: QueuedJob) -> None:
+        self._job_store.mark_running(job.id)
+        try:
+            await self._process_job(job.payload)
+        except Exception as exc:
+            self._job_store.mark_failed(job.id, str(exc))
+            raise
+        else:
+            self._job_store.mark_completed(job.id)
+            increment_counter("metrics.sync.jobs_completed")
+            self._record_heartbeat()
 
     async def _process_job(self, job: Dict[str, Any]) -> None:
         username = job.get("username")
@@ -88,14 +183,14 @@ class SyncWorker:
             self._mark_failed(files)
             raise
 
-    async def refresh_downloads(self) -> None:
+    async def refresh_downloads(self) -> bool:
         """Poll Soulseek for download progress and persist it."""
 
         try:
             response = await self._client.get_download_status()
         except Exception as exc:  # pragma: no cover - defensive
             logger.warning("Unable to obtain Soulseek download status: %s", exc)
-            return
+            return False
 
         downloads: Iterable[Dict[str, Any]]
         if isinstance(response, dict):
@@ -105,9 +200,7 @@ class SyncWorker:
         else:  # pragma: no cover - defensive
             downloads = []
 
-        if not downloads:
-            return
-
+        active = False
         with session_scope() as session:
             for payload in downloads:
                 download_id = payload.get("download_id") or payload.get("id")
@@ -137,10 +230,19 @@ class SyncWorker:
                     state = "downloading"
                 elif state == "completed":
                     progress = 100.0
+                elif state in {"queued", "downloading"}:
+                    active = True
 
                 download.state = state
                 download.progress = progress
                 download.updated_at = datetime.utcnow()
+
+        if active:
+            write_setting("metrics.sync.active_downloads", "1")
+        else:
+            write_setting("metrics.sync.active_downloads", "0")
+        self._record_heartbeat()
+        return active
 
     def _mark_failed(self, files: Iterable[Dict[str, Any]]) -> None:
         download_ids = []
@@ -159,3 +261,6 @@ class SyncWorker:
                     continue
                 download.state = "failed"
                 download.updated_at = datetime.utcnow()
+
+    def _record_heartbeat(self) -> None:
+        write_setting("worker.sync.last_seen", datetime.utcnow().isoformat())

--- a/docs/api.md
+++ b/docs/api.md
@@ -319,6 +319,14 @@ Content-Type: application/json
 | `GET` | `/settings/artist-preferences` | Gibt die markierten Releases pro Artist zurück. |
 | `POST` | `/settings/artist-preferences` | Persistiert die Auswahl (`{"preferences": [{"artist_id": ..., "release_id": ..., "selected": true}]}`). |
 
+**Neue Worker-relevante Settings:**
+
+- `sync_worker_concurrency` – Anzahl paralleler SyncWorker-Tasks (ENV: `SYNC_WORKER_CONCURRENCY`).
+- `matching_worker_batch_size` & `matching_confidence_threshold` – Batch-Größe und Confidence-Grenze für den MatchingWorker (ENV: `MATCHING_WORKER_BATCH_SIZE`, `MATCHING_CONFIDENCE_THRESHOLD`).
+- `scan_worker_interval_seconds` & `scan_worker_incremental` – Polling-Intervall und Inkrementalscan für den ScanWorker (ENV: `SCAN_WORKER_INTERVAL_SECONDS`, `SCAN_WORKER_INCREMENTAL`).
+- `autosync_min_bitrate` & `autosync_preferred_formats` – Qualitätsregeln für Soulseek-Downloads (ENV: `AUTOSYNC_MIN_BITRATE`, `AUTOSYNC_PREFERRED_FORMATS`).
+- `metrics.*` und `worker.*` – werden automatisch durch die Worker gepflegt (Herzschläge, Laufzeiten, Erfolgszähler). Sie dienen zur Auswertung durch Monitoring/Prometheus.
+
 ## Beets (`/beets`)
 
 | Methode | Pfad | Beschreibung |

--- a/tests/test_workers.py
+++ b/tests/test_workers.py
@@ -1,0 +1,229 @@
+import pytest
+from sqlalchemy import select
+
+from app.core.matching_engine import MusicMatchingEngine
+from app.db import init_db, reset_engine_for_tests, session_scope
+from app.models import AutoSyncSkippedTrack, Match, WorkerJob
+from app.utils.settings_store import read_setting, write_setting
+from app.workers.auto_sync_worker import AutoSyncWorker, TrackInfo
+from app.workers.matching_worker import MatchingWorker
+from app.workers.scan_worker import ScanWorker
+from app.workers.sync_worker import SyncWorker
+
+
+class DummySoulseekClient:
+    def __init__(self) -> None:
+        self.downloads: list[dict] = []
+
+    async def download(self, payload: dict) -> None:
+        self.downloads.append(payload)
+
+    async def get_download_status(self) -> list[dict]:
+        return []
+
+
+@pytest.mark.asyncio
+async def test_sync_worker_persists_jobs() -> None:
+    reset_engine_for_tests()
+    init_db()
+    client = DummySoulseekClient()
+    worker = SyncWorker(client, concurrency=1)
+
+    await worker.enqueue({"username": "tester", "files": [{"id": 1, "download_id": 1}]})
+
+    assert client.downloads, "Download should be triggered even when worker is stopped"
+
+    with session_scope() as session:
+        job = session.execute(select(WorkerJob)).scalar_one()
+        assert job.state == "completed"
+        assert job.attempts == 1
+
+    assert read_setting("metrics.sync.jobs_completed") == "1"
+
+
+@pytest.mark.asyncio
+async def test_matching_worker_batch_processing() -> None:
+    reset_engine_for_tests()
+    init_db()
+    engine = MusicMatchingEngine()
+    worker = MatchingWorker(engine, batch_size=2, confidence_threshold=0.3)
+
+    job_payload = {
+        "type": "spotify-to-plex",
+        "spotify_track": {
+            "id": "track-1",
+            "name": "Sample Song",
+            "artists": [{"name": "Sample Artist"}],
+        },
+        "candidates": [
+            {"id": "cand-1", "title": "Sample Song", "artist": "Sample Artist"},
+            {"id": "cand-2", "title": "Sample Song", "artist": "Sample Artist"},
+        ],
+    }
+
+    await worker.enqueue(job_payload)
+
+    with session_scope() as session:
+        matches = session.execute(select(Match)).scalars().all()
+        assert len(matches) == 2
+
+    assert read_setting("metrics.matching.last_discarded") == "0"
+
+
+class StubPlexClient:
+    def __init__(self) -> None:
+        self.refresh_calls: list[tuple[str, bool]] = []
+
+    async def get_libraries(self) -> dict:
+        return {
+            "MediaContainer": {
+                "Directory": [
+                    {"key": "1", "type": "artist", "title": "Music"},
+                ]
+            }
+        }
+
+    async def refresh_library_section(self, section_id: str, *, full: bool = False) -> None:
+        self.refresh_calls.append((section_id, full))
+
+    async def get_library_statistics(self) -> dict:
+        return {"artists": 1, "albums": 1, "tracks": 1}
+
+
+@pytest.mark.asyncio
+async def test_scan_worker_uses_incremental_and_dynamic_interval() -> None:
+    reset_engine_for_tests()
+    init_db()
+    write_setting("scan_worker_incremental", "1")
+    write_setting("scan_worker_interval_seconds", "1")
+    plex = StubPlexClient()
+    worker = ScanWorker(plex)
+
+    await worker._perform_scan()
+
+    assert plex.refresh_calls == [("1", False)]
+    assert read_setting("metrics.scan.incremental") == "1"
+
+
+class StubSoulseekSearchClient:
+    def __init__(self) -> None:
+        self.results: dict[str, dict] = {}
+        self.search_calls: list[str] = []
+        self.download_calls: list[dict] = []
+
+    async def search(self, query: str) -> dict:
+        self.search_calls.append(query)
+        return self.results.get(query, {"results": []})
+
+    async def download(self, payload: dict) -> None:
+        self.download_calls.append(payload)
+
+    async def get_download_status(self) -> list[dict]:  # pragma: no cover - unused
+        return []
+
+
+class StubSpotifyClient:
+    def get_user_playlists(self) -> dict:
+        return {"items": []}
+
+    def get_playlist_items(self, playlist_id: str) -> dict:  # pragma: no cover - unused
+        return {"items": []}
+
+    def get_saved_tracks(self) -> dict:
+        return {"items": []}
+
+
+class StubPlexLibraryClient:
+    async def get_libraries(self) -> dict:
+        return {"MediaContainer": {"Directory": []}}
+
+    async def get_library_statistics(self) -> dict:
+        return {"artists": 0, "albums": 0, "tracks": 0}
+
+
+class StubBeetsClient:
+    def __init__(self) -> None:
+        self.imports: list[str] = []
+
+    def import_file(self, path: str, quiet: bool = True) -> str:
+        self.imports.append(path)
+        return path
+
+
+@pytest.mark.asyncio
+async def test_autosync_worker_quality_and_skip_behaviour() -> None:
+    reset_engine_for_tests()
+    init_db()
+    write_setting("autosync_min_bitrate", "320")
+    write_setting("autosync_preferred_formats", "flac")
+    spotify = StubSpotifyClient()
+    plex = StubPlexLibraryClient()
+    soulseek = StubSoulseekSearchClient()
+    beets = StubBeetsClient()
+    worker = AutoSyncWorker(
+        spotify_client=spotify,
+        plex_client=plex,
+        soulseek_client=soulseek,
+        beets_client=beets,
+        skip_threshold=2,
+    )
+
+    track_a = TrackInfo(title="Track A", artist="Artist A", spotify_id="a")
+    track_b = TrackInfo(title="Track B", artist="Artist B", spotify_id="b")
+
+    soulseek.results = {
+        "Artist A Track A": {
+            "results": [
+                {"username": "low", "files": [{"filename": "a.mp3", "bitrate": 128}]}
+            ]
+        },
+        "Artist B Track B": {
+            "results": [
+                {
+                    "username": "flac-user",
+                    "files": [
+                        {
+                            "filename": "b.flac",
+                            "bitrate": 320,
+                            "format": "flac",
+                            "size": 1024,
+                        }
+                    ],
+                },
+                {
+                    "username": "mp3-user",
+                    "files": [
+                        {
+                            "filename": "b.mp3",
+                            "bitrate": 320,
+                            "format": "mp3",
+                            "size": 800,
+                        }
+                    ],
+                },
+            ]
+        },
+    }
+
+    downloaded, skipped, failures = await worker._download_missing_tracks(
+        {track_a, track_b}, "test"
+    )
+
+    assert track_b in [entry[0] for entry in downloaded]
+    assert track_a in skipped
+    assert "quality" in failures
+    assert beets.imports == ["b.flac"]
+    assert soulseek.download_calls[0]["username"] == "flac-user"
+
+    with session_scope() as session:
+        record = session.execute(
+            select(AutoSyncSkippedTrack).where(AutoSyncSkippedTrack.track_key == "a")
+        ).scalar_one()
+        assert record.failure_count == 1
+
+    downloaded, skipped, failures = await worker._download_missing_tracks({track_a}, "test")
+    assert "quality" in failures
+
+    downloaded, skipped, failures = await worker._download_missing_tracks({track_a}, "test")
+    assert track_a in skipped
+    assert soulseek.search_calls.count("Artist A Track A") == 2


### PR DESCRIPTION
## Summary
- add persistent worker job queue with adaptive sync polling, batch matching, and configurable scan interval
- extend autosync with quality rules, skip-state persistence, and richer status reporting
- document new configuration options, metrics, and add regression tests for worker flows

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d34269068083219db806e2ba111df6