### PR TITLE
feat: add dashboard download widget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Alle Änderungen an diesem Projekt werden in diesem Dokument festgehalten. Diese
 
 ## [Unreleased]
 ### Added
+- Added DownloadWidget to Dashboard.
 - Added GET endpoints for downloads.
 - Frontend-Downloads-Seite mit Start-Formular, Fortschrittsanzeige und Zeitstempeln.
 - Dokumentation des Endpunkts `GET /api/download` inkl. Response-Beispiel.

--- a/ToDo.md
+++ b/ToDo.md
@@ -7,6 +7,7 @@
 - [x] Aktivitätsfeed `/api/activity` als In-Memory-Queue bereitstellen.
 - [x] Downloads-Frontend mit Tabelle und Start-Formular bereitstellen.
 - [x] GET-Endpunkte für Downloads (`/api/downloads`, `/api/download/{id}`) ergänzen.
+- [x] Dashboard-Widget für aktive Downloads ergänzen.
 - [x] Activity-Feed-Widget im Dashboard mit Polling, Sortierung und Status-Badges finalisieren.
 - [x] AutoSyncWorker für Spotify↔Plex implementieren, Soulseek/Beets-Anbindung ergänzen und Dokumentation aktualisieren.
 - [x] Artist-Konfiguration für Spotify-Releases (API, DB, AutoSync) umsetzen.

--- a/docs/api.md
+++ b/docs/api.md
@@ -176,6 +176,23 @@ Content-Type: application/json
 }
 ```
 
+## Download-Widget im Dashboard
+
+Das Dashboard zeigt aktive Downloads in einem kompakten Widget an. Die Komponente nutzt `GET /api/downloads` und pollt den Endpunkt alle 15 Sekunden, um Fortschritte automatisch zu aktualisieren. Bei mehr als fünf aktiven Transfers blendet das Widget einen "Alle anzeigen" Button ein, der direkt zur vollständigen Downloads-Ansicht navigiert.
+
+**Beispielansicht:**
+
+```
+Aktive Downloads
+┌──────────────────────────────┬──────────┬─────────────┐
+│ Dateiname                    │ Status   │ Fortschritt │
+├──────────────────────────────┼──────────┼─────────────┤
+│ Track One.mp3                │ Running  │ 45 %        │
+│ Track Two.mp3                │ Queued   │ 10 %        │
+└──────────────────────────────┴──────────┴─────────────┘
+Alle anzeigen → /downloads
+```
+
 **Activity-Beispiel:**
 
 ```http

--- a/frontend/src/__tests__/DownloadWidget.test.tsx
+++ b/frontend/src/__tests__/DownloadWidget.test.tsx
@@ -1,0 +1,81 @@
+import userEvent from '@testing-library/user-event';
+import { screen, waitFor } from '@testing-library/react';
+import DownloadWidget from '../components/DownloadWidget';
+import { renderWithProviders } from '../test-utils';
+import { fetchActiveDownloads } from '../lib/api';
+
+jest.mock('../lib/api', () => ({
+  ...jest.requireActual('../lib/api'),
+  fetchActiveDownloads: jest.fn()
+}));
+
+const mockedFetchDownloads = fetchActiveDownloads as jest.MockedFunction<typeof fetchActiveDownloads>;
+
+const toastMock = jest.fn();
+
+describe('DownloadWidget', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders active downloads', async () => {
+    mockedFetchDownloads.mockResolvedValue([
+      {
+        id: 1,
+        filename: 'Track One.mp3',
+        status: 'running',
+        progress: 45
+      },
+      {
+        id: 2,
+        filename: 'Track Two.mp3',
+        status: 'queued',
+        progress: 10
+      }
+    ]);
+
+    renderWithProviders(<DownloadWidget />, { toastFn: toastMock, route: '/dashboard' });
+
+    expect(await screen.findByText('Track One.mp3')).toBeInTheDocument();
+    expect(screen.getByText('Running')).toBeInTheDocument();
+    expect(screen.getByText('45%')).toBeInTheDocument();
+    expect(mockedFetchDownloads).toHaveBeenCalled();
+  });
+
+  it('shows empty state when no downloads are active', async () => {
+    mockedFetchDownloads.mockResolvedValue([]);
+
+    renderWithProviders(<DownloadWidget />, { toastFn: toastMock, route: '/dashboard' });
+
+    expect(await screen.findByText('Keine aktiven Downloads.')).toBeInTheDocument();
+  });
+
+  it('shows toast when the API call fails', async () => {
+    mockedFetchDownloads.mockRejectedValue(new Error('network error'));
+
+    renderWithProviders(<DownloadWidget />, { toastFn: toastMock, route: '/dashboard' });
+
+    await waitFor(() => expect(toastMock).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'Downloads konnten nicht geladen werden' })
+    ));
+    expect(screen.getByText('Downloads konnten nicht geladen werden.')).toBeInTheDocument();
+  });
+
+  it('navigates to downloads page when clicking show all', async () => {
+    mockedFetchDownloads.mockResolvedValue([
+      { id: 1, filename: 'A.mp3', status: 'running', progress: 60 },
+      { id: 2, filename: 'B.mp3', status: 'running', progress: 40 },
+      { id: 3, filename: 'C.mp3', status: 'running', progress: 20 },
+      { id: 4, filename: 'D.mp3', status: 'running', progress: 10 },
+      { id: 5, filename: 'E.mp3', status: 'running', progress: 5 },
+      { id: 6, filename: 'F.mp3', status: 'running', progress: 80 }
+    ]);
+
+    renderWithProviders(<DownloadWidget />, { toastFn: toastMock, route: '/dashboard' });
+
+    const button = await screen.findByRole('button', { name: 'Alle anzeigen' });
+    await userEvent.click(button);
+
+    await waitFor(() => expect(window.location.pathname).toBe('/downloads'));
+  });
+});

--- a/frontend/src/components/DownloadWidget.tsx
+++ b/frontend/src/components/DownloadWidget.tsx
@@ -1,0 +1,110 @@
+import { useMemo } from 'react';
+import { Loader2 } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
+import { Button } from './ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from './ui/card';
+import { Progress } from './ui/progress';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from './ui/table';
+import { useToast } from '../hooks/useToast';
+import { fetchActiveDownloads, DownloadEntry } from '../lib/api';
+import { useQuery } from '../lib/query';
+import { mapProgressToPercent } from '../lib/utils';
+
+const formatStatus = (status: string | undefined) => {
+  if (!status) {
+    return 'Unbekannt';
+  }
+  return status
+    .toString()
+    .replace(/[_-]+/g, ' ')
+    .split(' ')
+    .filter(Boolean)
+    .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
+    .join(' ');
+};
+
+const DownloadWidget = () => {
+  const { toast } = useToast();
+  const navigate = useNavigate();
+
+  const { data, isLoading, isError } = useQuery<DownloadEntry[]>({
+    queryKey: ['downloads', 'active-widget'],
+    queryFn: () => fetchActiveDownloads(),
+    refetchInterval: 15000,
+    onError: () =>
+      toast({
+        title: 'Downloads konnten nicht geladen werden',
+        description: 'Bitte versuchen Sie es später erneut.',
+        variant: 'destructive'
+      })
+  });
+
+  const entries = useMemo(() => (data ?? []).slice(0, 5), [data]);
+  const hasMore = (data?.length ?? 0) > 5;
+
+  const handleNavigate = () => {
+    navigate('/downloads');
+  };
+
+  return (
+    <Card>
+      <CardHeader className="space-y-1 pb-2">
+        <CardTitle className="text-base">Aktive Downloads</CardTitle>
+        <p className="text-sm text-muted-foreground">
+          Übersicht der zuletzt gestarteten Transfers.
+        </p>
+      </CardHeader>
+      <CardContent>
+        {isLoading ? (
+          <div className="flex items-center justify-center py-6 text-muted-foreground">
+            <Loader2 className="h-5 w-5 animate-spin" aria-label="Lade Downloads" />
+          </div>
+        ) : isError ? (
+          <p className="text-sm text-destructive">Downloads konnten nicht geladen werden.</p>
+        ) : entries.length === 0 ? (
+          <p className="text-sm text-muted-foreground">Keine aktiven Downloads.</p>
+        ) : (
+          <div className="overflow-hidden rounded-lg border">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Dateiname</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead>Fortschritt</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {entries.map((download) => {
+                  const progressValue = mapProgressToPercent(download.progress);
+                  return (
+                    <TableRow key={download.id}>
+                      <TableCell className="text-sm font-medium">{download.filename}</TableCell>
+                      <TableCell className="text-sm text-muted-foreground">
+                        {formatStatus(download.status)}
+                      </TableCell>
+                      <TableCell className="w-48">
+                        <div className="space-y-1">
+                          <Progress value={progressValue} aria-label={`Fortschritt ${progressValue}%`} />
+                          <span className="text-xs text-muted-foreground">{progressValue}%</span>
+                        </div>
+                      </TableCell>
+                    </TableRow>
+                  );
+                })}
+              </TableBody>
+            </Table>
+          </div>
+        )}
+      </CardContent>
+      {hasMore ? (
+        <div className="flex justify-end border-t px-6 py-3">
+          <Button type="button" variant="outline" size="sm" onClick={handleNavigate}>
+            Alle anzeigen
+          </Button>
+        </div>
+      ) : null}
+    </Card>
+  );
+};
+
+export default DownloadWidget;

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -4,3 +4,19 @@ import { twMerge } from 'tailwind-merge';
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
+
+export const mapProgressToPercent = (value: number) => {
+  if (Number.isNaN(value)) {
+    return 0;
+  }
+  if (value < 0) {
+    return 0;
+  }
+  if (value <= 1) {
+    return Math.round(value * 100);
+  }
+  if (value <= 100) {
+    return Math.round(value);
+  }
+  return 100;
+};

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -7,6 +7,7 @@ import {
   CardTitle
 } from '../components/ui/card';
 import ActivityFeed from '../components/ActivityFeed';
+import DownloadWidget from '../components/DownloadWidget';
 import { useToast } from '../hooks/useToast';
 import { useQuery } from '../lib/query';
 import {
@@ -224,7 +225,10 @@ const Dashboard = () => {
         </Card>
       </div>
 
-      <ActivityFeed />
+      <div className="grid gap-4 lg:grid-cols-[2fr_1fr]">
+        <ActivityFeed />
+        <DownloadWidget />
+      </div>
 
       <Card>
         <CardHeader>

--- a/frontend/src/pages/DownloadsPage.tsx
+++ b/frontend/src/pages/DownloadsPage.tsx
@@ -8,19 +8,7 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '.
 import { useToast } from '../hooks/useToast';
 import { fetchActiveDownloads, startDownload, DownloadEntry } from '../lib/api';
 import { useMutation, useQuery } from '../lib/query';
-
-const mapProgressToPercent = (value: number) => {
-  if (value < 0) {
-    return 0;
-  }
-  if (value <= 1) {
-    return Math.round(value * 100);
-  }
-  if (value <= 100) {
-    return Math.round(value);
-  }
-  return 100;
-};
+import { mapProgressToPercent } from '../lib/utils';
 
 const DownloadsPage = () => {
   const { toast } = useToast();


### PR DESCRIPTION
## Summary
- add a DownloadWidget component that lists the five most recent active downloads with loading, empty and error states
- embed the widget on the dashboard next to the activity feed and reuse the shared progress formatter in the downloads page
- document the widget, extend regression tests and update project metadata

## Testing
- npm run test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d350c10da08321b05813cd8d8652fd