### PR TITLE
fix: limit dashboard download widget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Alle Änderungen an diesem Projekt werden in diesem Dokument festgehalten. Diese
 - Quality-/Priorisierungsregeln für den AutoSyncWorker (`autosync_min_bitrate`, `autosync_preferred_formats`, Skip-State in `auto_sync_skipped_tracks`).
 
 ### Changed
+- Frontend: DownloadWidget uses limit param of /api/downloads.
 - Frontend: DownloadsPage nutzt jetzt `GET /api/downloads` für die Download-Übersicht.
 - Dashboard-Aktivitätsfeed mit lokalisierten Typen, sortierten Einträgen und farbcodierten Status-Badges verfeinert.
 - AutoSyncWorker filtert Spotify-Tracks anhand gespeicherter Artist-Präferenzen.

--- a/ToDo.md
+++ b/ToDo.md
@@ -8,6 +8,7 @@
 - [x] Downloads-Frontend mit Tabelle und Start-Formular bereitstellen.
 - [x] GET-Endpunkte für Downloads (`/api/downloads`, `/api/download/{id}`) ergänzen.
 - [x] Dashboard-Widget für aktive Downloads ergänzen.
+- [x] Dashboard-DownloadWidget auf limitierte `/api/downloads`-Abfrage umstellen.
 - [x] Activity-Feed-Widget im Dashboard mit Polling, Sortierung und Status-Badges finalisieren.
 - [x] AutoSyncWorker für Spotify↔Plex implementieren, Soulseek/Beets-Anbindung ergänzen und Dokumentation aktualisieren.
 - [x] Artist-Konfiguration für Spotify-Releases (API, DB, AutoSync) umsetzen.

--- a/docs/api.md
+++ b/docs/api.md
@@ -115,6 +115,27 @@ GET /api/downloads HTTP/1.1
 }
 ```
 
+**Limitierte Übersicht (z. B. für Widgets):**
+
+```http
+GET /api/downloads?limit=5 HTTP/1.1
+```
+
+```json
+{
+  "downloads": [
+    {
+      "id": 7,
+      "filename": "Daft Punk - One More Time.mp3",
+      "status": "running",
+      "progress": 65.0,
+      "created_at": "2024-03-18T12:06:00Z",
+      "updated_at": "2024-03-18T12:06:10Z"
+    }
+  ]
+}
+```
+
 **Alle Downloads inklusive abgeschlossener/fehlgeschlagener Transfers:**
 
 ```http

--- a/frontend/src/components/DownloadWidget.tsx
+++ b/frontend/src/components/DownloadWidget.tsx
@@ -6,7 +6,7 @@ import { Card, CardContent, CardHeader, CardTitle } from './ui/card';
 import { Progress } from './ui/progress';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from './ui/table';
 import { useToast } from '../hooks/useToast';
-import { fetchActiveDownloads, DownloadEntry } from '../lib/api';
+import { fetchDownloads, DownloadEntry } from '../lib/api';
 import { useQuery } from '../lib/query';
 import { mapProgressToPercent } from '../lib/utils';
 
@@ -31,7 +31,7 @@ const DownloadWidget = () => {
 
   const { data, isLoading, isError } = useQuery<DownloadEntry[]>({
     queryKey: ['downloads', 'active-widget'],
-    queryFn: () => fetchActiveDownloads({ limit: DISPLAY_LIMIT }),
+    queryFn: () => fetchDownloads(DISPLAY_LIMIT),
     refetchInterval: 15000,
     onError: () =>
       toast({
@@ -41,8 +41,8 @@ const DownloadWidget = () => {
       })
   });
 
-  const entries = useMemo(() => data ?? [], [data]);
-  const hasMore = (data?.length ?? 0) >= DISPLAY_LIMIT;
+  const entries = useMemo(() => (data ?? []).slice(0, DISPLAY_LIMIT), [data]);
+  const hasMore = (data?.length ?? 0) > DISPLAY_LIMIT;
 
   const handleNavigate = () => {
     navigate('/downloads');

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -326,6 +326,32 @@ const mapDownloadEntry = (entry: SoulseekDownloadEntry | DownloadEntry): Downloa
   };
 };
 
+const requestDownloads = async (
+  params?: Record<string, number | boolean>
+): Promise<DownloadEntry[]> => {
+  const { data } = await api.get<SoulseekDownloadsResponse>('/api/downloads', {
+    params: params && Object.keys(params).length > 0 ? params : undefined
+  });
+  return extractDownloadEntries(data).map(mapDownloadEntry);
+};
+
+export const fetchDownloads = async (
+  limit = 5,
+  offset = 0,
+  all = false
+): Promise<DownloadEntry[]> => {
+  const params: Record<string, number | boolean> = {
+    limit,
+    offset
+  };
+
+  if (all) {
+    params.all = true;
+  }
+
+  return requestDownloads(params);
+};
+
 export const fetchActiveDownloads = async (
   options: FetchDownloadsOptions = {}
 ): Promise<DownloadEntry[]> => {
@@ -342,10 +368,7 @@ export const fetchActiveDownloads = async (
     params.offset = offset;
   }
 
-  const { data } = await api.get<SoulseekDownloadsResponse>('/api/downloads', {
-    params: Object.keys(params).length > 0 ? params : undefined
-  });
-  return extractDownloadEntries(data).map(mapDownloadEntry);
+  return requestDownloads(params);
 };
 
 export const fetchDownloadById = async (id: string): Promise<DownloadEntry> => {


### PR DESCRIPTION
## Summary
- add fetchDownloads helper using the limit/offset/all parameters of GET /api/downloads
- update the dashboard DownloadWidget to request a five-item slice and surface a show-all link only when more items exist
- document limited download queries and note the widget change in the changelog and ToDo list

## Testing
- npm run build
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d354ec12588321b9d9c89861482364