### PR TITLE
Add cancel and retry support to download API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Alle Änderungen an diesem Projekt werden in diesem Dokument festgehalten. Diese
 
 ## [Unreleased]
 ### Added
+- Added cancel and retry endpoints for downloads including worker cancellation support.
 - Added limit/offset support to GET /api/downloads.
 - Added DownloadWidget to Dashboard.
 - Added GET endpoints for downloads.

--- a/ToDo.md
+++ b/ToDo.md
@@ -14,6 +14,7 @@
 - [x] Artist-Konfiguration für Spotify-Releases (API, DB, AutoSync) umsetzen.
 - [x] Artists-Frontend zum Aktivieren einzelner Releases inkl. Tests und Dokumentation ergänzen.
 - [x] Paging für `/api/downloads` mit Limit/Offset-Parametern ergänzen.
+- [x] Cancel- und Retry-Endpunkte für Downloads inklusive Worker-Integration ergänzen.
 - [ ] Streaming-Router für Audio-Features planen und implementieren (Frontend-Integration vorbereiten).
 - [ ] Frontend-Testlauf im CI wieder aktivieren, sobald npm-Registry-Zugriff verfügbar ist.
 - [ ] Prometheus-/StatsD-Exporter auf Basis der neuen `metrics.*` Settings anbinden.

--- a/app/models.py
+++ b/app/models.py
@@ -43,6 +43,8 @@ class Download(Base):
     filename = Column(String(1024), nullable=False)
     state = Column(String(50), nullable=False, default="queued")
     progress = Column(Float, nullable=False, default=0.0)
+    username = Column(String(255), nullable=True)
+    request_payload = Column(JSON, nullable=True)
     created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
     updated_at = Column(
         DateTime,

--- a/app/routers/download_router.py
+++ b/app/routers/download_router.py
@@ -1,6 +1,7 @@
 """Download management endpoints for Harmony."""
 from __future__ import annotations
 
+import inspect
 from datetime import datetime
 from typing import Any, Dict, List
 
@@ -19,6 +20,12 @@ from app.utils.activity import record_activity
 
 router = APIRouter(prefix="/api", tags=["Download"])
 logger = get_logger(__name__)
+
+
+async def _maybe_await(result: Any) -> Any:
+    if inspect.isawaitable(result):
+        return await result
+    return result
 
 
 @router.get("/downloads", response_model=DownloadListResponse)
@@ -103,13 +110,19 @@ async def start_download(
     try:
         for file_info in payload.files:
             filename = str(file_info.get("filename") or file_info.get("name") or "unknown")
-            download = Download(filename=filename, state="queued", progress=0.0)
+            download = Download(
+                filename=filename,
+                state="queued",
+                progress=0.0,
+                username=payload.username,
+            )
             session.add(download)
             session.flush()
 
             payload_copy = dict(file_info)
             payload_copy.setdefault("filename", filename)
             payload_copy["download_id"] = download.id
+            download.request_payload = payload_copy
             job_files.append(payload_copy)
 
             download_records.append(download)
@@ -161,4 +174,194 @@ async def start_download(
     }
     if primary_id is not None:
         response["download_id"] = primary_id
+    return response
+
+
+@router.delete("/download/{download_id}")
+async def cancel_download(
+    download_id: int,
+    request: Request,
+    session: Session = Depends(get_db),
+) -> Dict[str, Any]:
+    """Cancel a queued or running download."""
+
+    logger.info("Cancellation requested for download id=%s", download_id)
+    try:
+        download = session.get(Download, download_id)
+    except HTTPException:
+        raise
+    except Exception as exc:  # pragma: no cover - defensive database failure handling
+        logger.exception("Failed to load download %s for cancellation: %s", download_id, exc)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to cancel download",
+        ) from exc
+
+    if download is None:
+        logger.warning("Cancellation failed: download %s not found", download_id)
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Download not found")
+
+    if download.state not in {"queued", "running", "downloading"}:
+        logger.warning(
+            "Cancellation rejected for download %s due to invalid state %s",
+            download_id,
+            download.state,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Download cannot be cancelled in its current state",
+        )
+
+    download.state = "cancelled"
+    download.updated_at = datetime.utcnow()
+
+    try:
+        session.commit()
+    except Exception as exc:  # pragma: no cover - defensive persistence handling
+        session.rollback()
+        logger.exception("Failed to persist cancellation for download %s: %s", download_id, exc)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to cancel download",
+        ) from exc
+
+    worker = getattr(request.app.state, "sync_worker", None)
+    cancel_func = getattr(worker, "request_cancel", None)
+    if cancel_func is not None:
+        try:
+            await _maybe_await(cancel_func(download_id))
+        except Exception as exc:  # pragma: no cover - defensive worker error handling
+            logger.warning("Failed to signal cancellation for download %s: %s", download_id, exc)
+
+    record_activity(
+        "download",
+        "download_cancelled",
+        details={"download_id": download_id, "filename": download.filename},
+    )
+
+    return {"status": "cancelled", "download_id": download_id}
+
+
+@router.post("/download/{download_id}/retry", status_code=status.HTTP_202_ACCEPTED)
+async def retry_download(
+    download_id: int,
+    request: Request,
+    session: Session = Depends(get_db),
+) -> Dict[str, Any]:
+    """Retry a failed or cancelled download by creating a new entry."""
+
+    logger.info("Retry requested for download id=%s", download_id)
+    try:
+        original = session.get(Download, download_id)
+    except HTTPException:
+        raise
+    except Exception as exc:  # pragma: no cover - defensive database failure handling
+        logger.exception("Failed to load download %s for retry: %s", download_id, exc)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to retry download",
+        ) from exc
+
+    if original is None:
+        logger.warning("Retry failed: download %s not found", download_id)
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Download not found")
+
+    if original.state not in {"failed", "cancelled"}:
+        logger.warning(
+            "Retry rejected for download %s due to invalid state %s",
+            download_id,
+            original.state,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Download cannot be retried in its current state",
+        )
+
+    if not original.username or not original.request_payload:
+        logger.error("Retry rejected for download %s due to missing payload", download_id)
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Download cannot be retried because original request data is missing",
+        )
+
+    payload_copy = dict(original.request_payload or {})
+
+    new_download = Download(
+        filename=original.filename,
+        state="queued",
+        progress=0.0,
+        username=original.username,
+    )
+    session.add(new_download)
+    session.flush()
+
+    payload_copy["download_id"] = new_download.id
+    payload_copy.setdefault("filename", new_download.filename)
+    new_download.request_payload = payload_copy
+
+    try:
+        session.commit()
+    except Exception as exc:  # pragma: no cover - defensive persistence handling
+        session.rollback()
+        logger.exception("Failed to persist retry download for %s: %s", download_id, exc)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to retry download",
+        ) from exc
+
+    worker = getattr(request.app.state, "sync_worker", None)
+    enqueue = getattr(worker, "enqueue", None)
+    if enqueue is None:
+        logger.error("Retry failed for %s: download worker unavailable", download_id)
+        record_activity(
+            "download",
+            "download_retried",
+            details={
+                "original_download_id": download_id,
+                "retry_download_id": new_download.id,
+                "status": "worker_unavailable",
+            },
+        )
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Download worker unavailable",
+        )
+
+    job = {"username": original.username, "files": [payload_copy]}
+    try:
+        await enqueue(job)
+    except Exception as exc:  # pragma: no cover - defensive worker error
+        logger.exception("Failed to enqueue retry for download %s: %s", download_id, exc)
+        now = datetime.utcnow()
+        new_download.state = "failed"
+        new_download.updated_at = now
+        session.commit()
+        record_activity(
+            "download",
+            "download_retried",
+            details={
+                "original_download_id": download_id,
+                "retry_download_id": new_download.id,
+                "status": "enqueue_error",
+            },
+        )
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="Failed to enqueue download",
+        ) from exc
+
+    record_activity(
+        "download",
+        "download_retried",
+        details={
+            "original_download_id": download_id,
+            "retry_download_id": new_download.id,
+            "username": original.username,
+        },
+    )
+
+    response: Dict[str, Any] = {
+        "status": "queued",
+        "download_id": new_download.id,
+    }
     return response


### PR DESCRIPTION
## Summary
- add DELETE /api/download/{id} to cancel active downloads and record activity
- add POST /api/download/{id}/retry to recreate failed downloads with stored payload data
- extend SyncWorker to handle cancellation flags and ensure retries persist metadata
- document new endpoints and cover cancel/retry flows with tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d356896f1083218bf1cbac50714b90