### PR TITLE
feat: add cancel and retry controls to downloads UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Alle Änderungen an diesem Projekt werden in diesem Dokument festgehalten. Diese
 
 ## [Unreleased]
 ### Added
+- Added cancel and retry buttons for downloads in the frontend.
 - Added cancel and retry endpoints for downloads including worker cancellation support.
 - Added limit/offset support to GET /api/downloads.
 - Added DownloadWidget to Dashboard.

--- a/ToDo.md
+++ b/ToDo.md
@@ -10,6 +10,7 @@
 - [x] Dashboard-Widget für aktive Downloads ergänzen.
 - [x] Dashboard-DownloadWidget auf limitierte `/api/downloads`-Abfrage umstellen.
 - [x] Activity-Feed-Widget im Dashboard mit Polling, Sortierung und Status-Badges finalisieren.
+- [x] Cancel-/Retry-Buttons im Frontend (DownloadsPage & DownloadWidget) ergänzen.
 - [x] AutoSyncWorker für Spotify↔Plex implementieren, Soulseek/Beets-Anbindung ergänzen und Dokumentation aktualisieren.
 - [x] Artist-Konfiguration für Spotify-Releases (API, DB, AutoSync) umsetzen.
 - [x] Artists-Frontend zum Aktivieren einzelner Releases inkl. Tests und Dokumentation ergänzen.

--- a/docs/api.md
+++ b/docs/api.md
@@ -264,12 +264,12 @@ Das Dashboard zeigt aktive Downloads in einem kompakten Widget an. Die Komponent
 
 ```
 Aktive Downloads
-┌──────────────────────────────┬──────────┬─────────────┐
-│ Dateiname                    │ Status   │ Fortschritt │
-├──────────────────────────────┼──────────┼─────────────┤
-│ Track One.mp3                │ Running  │ 45 %        │
-│ Track Two.mp3                │ Queued   │ 10 %        │
-└──────────────────────────────┴──────────┴─────────────┘
+┌──────────────────────────────┬──────────┬─────────────┬──────────────┐
+│ Dateiname                    │ Status   │ Fortschritt │ Aktionen     │
+├──────────────────────────────┼──────────┼─────────────┼──────────────┤
+│ Track One.mp3                │ Running  │ 45 %        │ [Abbrechen]  │
+│ Track Two.mp3                │ Failed   │ 0 %         │ [Neu starten]│
+└──────────────────────────────┴──────────┴─────────────┴──────────────┘
 Alle anzeigen → /downloads
 ```
 
@@ -300,7 +300,7 @@ GET /api/activity HTTP/1.1
 
 ![Downloads-Verwaltung](downloads-page.svg)
 
-Die neue Downloads-Seite im Harmony-Frontend ermöglicht das Starten von Test-Downloads über eine beliebige Datei- oder Track-ID und zeigt aktive Transfers inklusive Status, Fortschrittsbalken und Erstellungszeitpunkt an. Über Tailwind- und shadcn/ui-Komponenten werden Ladezustände, Leerlaufmeldungen ("Keine Downloads aktiv") sowie Fehler-Toasts konsistent dargestellt. Jeder erfolgreich gestartete Download löst eine Bestätigungsmeldung aus, während fehlgeschlagene Anfragen klar hervorgehoben werden.
+Die neue Downloads-Seite im Harmony-Frontend ermöglicht das Starten von Test-Downloads über eine beliebige Datei- oder Track-ID und zeigt aktive Transfers inklusive Status, Fortschrittsbalken und Erstellungszeitpunkt an. Über Tailwind- und shadcn/ui-Komponenten werden Ladezustände, Leerlaufmeldungen ("Keine Downloads aktiv") sowie Fehler-Toasts konsistent dargestellt. Jeder erfolgreich gestartete Download löst eine Bestätigungsmeldung aus, während fehlgeschlagene Anfragen klar hervorgehoben werden. Zusätzlich stehen pro Zeile Buttons zum sofortigen Abbrechen laufender Jobs sowie zum erneuten Start fehlgeschlagener oder abgebrochener Transfers bereit.
 
 ![Activity-Feed-Widget](activity-feed-widget.svg)
 

--- a/frontend/src/__tests__/DownloadWidget.test.tsx
+++ b/frontend/src/__tests__/DownloadWidget.test.tsx
@@ -2,14 +2,18 @@ import userEvent from '@testing-library/user-event';
 import { screen, waitFor } from '@testing-library/react';
 import DownloadWidget from '../components/DownloadWidget';
 import { renderWithProviders } from '../test-utils';
-import { fetchDownloads } from '../lib/api';
+import { cancelDownload, fetchDownloads, retryDownload } from '../lib/api';
 
 jest.mock('../lib/api', () => ({
   ...jest.requireActual('../lib/api'),
-  fetchDownloads: jest.fn()
+  fetchDownloads: jest.fn(),
+  cancelDownload: jest.fn(),
+  retryDownload: jest.fn()
 }));
 
 const mockedFetchDownloads = fetchDownloads as jest.MockedFunction<typeof fetchDownloads>;
+const mockedCancelDownload = cancelDownload as jest.MockedFunction<typeof cancelDownload>;
+const mockedRetryDownload = retryDownload as jest.MockedFunction<typeof retryDownload>;
 
 const toastMock = jest.fn();
 
@@ -95,5 +99,55 @@ describe('DownloadWidget', () => {
 
     expect(await screen.findByText('A.mp3')).toBeInTheDocument();
     await waitFor(() => expect(screen.queryByRole('button', { name: 'Alle anzeigen' })).not.toBeInTheDocument());
+  });
+
+  it('cancels an active download', async () => {
+    mockedFetchDownloads.mockResolvedValueOnce([
+      { id: 1, filename: 'Cancelable Widget.mp3', status: 'running', progress: 40 }
+    ]);
+    mockedFetchDownloads.mockResolvedValue([
+      { id: 1, filename: 'Cancelable Widget.mp3', status: 'cancelled', progress: 40 }
+    ]);
+    mockedCancelDownload.mockResolvedValue();
+
+    renderWithProviders(<DownloadWidget />, { toastFn: toastMock, route: '/dashboard' });
+
+    const cancelButton = await screen.findByRole('button', { name: 'Abbrechen' });
+    await userEvent.click(cancelButton);
+
+    await waitFor(() => expect(mockedCancelDownload).toHaveBeenCalledWith('1'));
+    await waitFor(() => expect(mockedFetchDownloads).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(screen.getByText('Cancelled')).toBeInTheDocument());
+    expect(toastMock).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'Download abgebrochen' })
+    );
+  });
+
+  it('retries a failed download', async () => {
+    mockedFetchDownloads.mockResolvedValueOnce([
+      { id: 2, filename: 'Retry Widget.mp3', status: 'failed', progress: 0 }
+    ]);
+    mockedFetchDownloads.mockResolvedValue([
+      { id: 2, filename: 'Retry Widget.mp3', status: 'failed', progress: 0 },
+      { id: 3, filename: 'Retry Widget.mp3', status: 'queued', progress: 0 }
+    ]);
+    mockedRetryDownload.mockResolvedValue({
+      id: 3,
+      filename: 'Retry Widget.mp3',
+      status: 'queued',
+      progress: 0
+    });
+
+    renderWithProviders(<DownloadWidget />, { toastFn: toastMock, route: '/dashboard' });
+
+    const retryButton = await screen.findByRole('button', { name: 'Neu starten' });
+    await userEvent.click(retryButton);
+
+    await waitFor(() => expect(mockedRetryDownload).toHaveBeenCalledWith('2'));
+    await waitFor(() => expect(mockedFetchDownloads).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(screen.getAllByText('Retry Widget.mp3').length).toBeGreaterThan(1));
+    expect(toastMock).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'Download neu gestartet' })
+    );
   });
 });

--- a/frontend/src/__tests__/DownloadsPage.test.tsx
+++ b/frontend/src/__tests__/DownloadsPage.test.tsx
@@ -2,16 +2,20 @@ import userEvent from '@testing-library/user-event';
 import { screen, waitFor } from '@testing-library/react';
 import DownloadsPage from '../pages/DownloadsPage';
 import { renderWithProviders } from '../test-utils';
-import { fetchActiveDownloads, startDownload } from '../lib/api';
+import { cancelDownload, fetchActiveDownloads, retryDownload, startDownload } from '../lib/api';
 
 jest.mock('../lib/api', () => ({
   ...jest.requireActual('../lib/api'),
   fetchActiveDownloads: jest.fn(),
-  startDownload: jest.fn()
+  startDownload: jest.fn(),
+  cancelDownload: jest.fn(),
+  retryDownload: jest.fn()
 }));
 
 const mockedFetchDownloads = fetchActiveDownloads as jest.MockedFunction<typeof fetchActiveDownloads>;
 const mockedStartDownload = startDownload as jest.MockedFunction<typeof startDownload>;
+const mockedCancelDownload = cancelDownload as jest.MockedFunction<typeof cancelDownload>;
+const mockedRetryDownload = retryDownload as jest.MockedFunction<typeof retryDownload>;
 
 const toastMock = jest.fn();
 
@@ -104,6 +108,22 @@ describe('DownloadsPage', () => {
         created_at: '2024-02-01T09:00:00Z'
       }
     ]);
+    mockedFetchDownloads.mockResolvedValue([
+      {
+        id: 3,
+        filename: 'Running File.mp3',
+        status: 'running',
+        progress: 50,
+        created_at: '2024-02-01T10:00:00Z'
+      },
+      {
+        id: 4,
+        filename: 'Completed File.mp3',
+        status: 'completed',
+        progress: 100,
+        created_at: '2024-02-01T09:00:00Z'
+      }
+    ]);
 
     renderWithProviders(<DownloadsPage />, { toastFn: toastMock, route: '/downloads' });
 
@@ -118,5 +138,86 @@ describe('DownloadsPage', () => {
     );
     expect(await screen.findByText('Completed File.mp3')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Nur aktive' })).toBeInTheDocument();
+  });
+
+  it('cancels a running download', async () => {
+    mockedFetchDownloads.mockResolvedValueOnce([
+      {
+        id: 5,
+        filename: 'Cancelable File.mp3',
+        status: 'running',
+        progress: 30,
+        created_at: '2024-03-01T12:00:00Z'
+      }
+    ]);
+    mockedFetchDownloads.mockResolvedValue([
+      {
+        id: 5,
+        filename: 'Cancelable File.mp3',
+        status: 'cancelled',
+        progress: 30,
+        created_at: '2024-03-01T12:00:00Z'
+      }
+    ]);
+    mockedCancelDownload.mockResolvedValue();
+
+    renderWithProviders(<DownloadsPage />, { toastFn: toastMock, route: '/downloads' });
+
+    const cancelButton = await screen.findByRole('button', { name: 'Abbrechen' });
+    await userEvent.click(cancelButton);
+
+    await waitFor(() => expect(mockedCancelDownload).toHaveBeenCalledWith('5'));
+    await waitFor(() => expect(mockedFetchDownloads).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(screen.getByText(/cancelled/i)).toBeInTheDocument());
+    expect(toastMock).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'Download abgebrochen' })
+    );
+  });
+
+  it('retries a failed download', async () => {
+    mockedFetchDownloads.mockResolvedValueOnce([
+      {
+        id: 6,
+        filename: 'Broken File.mp3',
+        status: 'failed',
+        progress: 0,
+        created_at: '2024-03-02T09:00:00Z'
+      }
+    ]);
+    mockedFetchDownloads.mockResolvedValue([
+      {
+        id: 6,
+        filename: 'Broken File.mp3',
+        status: 'failed',
+        progress: 0,
+        created_at: '2024-03-02T09:00:00Z'
+      },
+      {
+        id: 7,
+        filename: 'Broken File.mp3',
+        status: 'queued',
+        progress: 0,
+        created_at: '2024-03-02T09:05:00Z'
+      }
+    ]);
+    mockedRetryDownload.mockResolvedValue({
+      id: 7,
+      filename: 'Broken File.mp3',
+      status: 'queued',
+      progress: 0
+    });
+
+    renderWithProviders(<DownloadsPage />, { toastFn: toastMock, route: '/downloads' });
+
+    const retryButton = await screen.findByRole('button', { name: 'Neu starten' });
+    await userEvent.click(retryButton);
+
+    await waitFor(() => expect(mockedRetryDownload).toHaveBeenCalledWith('6'));
+    await waitFor(() => expect(mockedFetchDownloads).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(screen.getAllByText(/queued/i).length).toBeGreaterThan(0));
+    await waitFor(() => expect(screen.getAllByText('Broken File.mp3').length).toBeGreaterThan(1));
+    expect(toastMock).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'Download neu gestartet' })
+    );
   });
 });

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -376,6 +376,10 @@ export const fetchDownloadById = async (id: string): Promise<DownloadEntry> => {
   return mapDownloadEntry(data);
 };
 
+export const cancelDownload = async (id: string): Promise<void> => {
+  await api.delete(`/api/download/${id}`);
+};
+
 export const startDownload = async (payload: StartDownloadPayload): Promise<DownloadEntry> => {
   const { data } = await api.post('/api/download', payload);
   const downloads = extractDownloadEntries(data);
@@ -385,6 +389,21 @@ export const startDownload = async (payload: StartDownloadPayload): Promise<Down
       id: '',
       filename: '',
       status: 'unknown',
+      progress: 0
+    };
+  }
+  return mapDownloadEntry(first);
+};
+
+export const retryDownload = async (id: string): Promise<DownloadEntry> => {
+  const { data } = await api.post(`/api/download/${id}/retry`);
+  const downloads = extractDownloadEntries(data);
+  const first = downloads[0] ?? (data as SoulseekDownloadEntry | DownloadEntry | undefined);
+  if (!first) {
+    return {
+      id: id,
+      filename: '',
+      status: 'queued',
       progress: 0
     };
   }


### PR DESCRIPTION
## Summary
- add API helpers for cancelling and retrying downloads
- show cancel/retry buttons on the downloads page and dashboard widget with toast feedback
- extend frontend tests, changelog, todo list and API docs for the new controls

## Testing
- npm run build
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d3584da39483218e5eb6d1baeeb781