### PR TITLE
Integrate slskd TransfersApi cancel/retry flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Alle Änderungen an diesem Projekt werden in diesem Dokument festgehalten. Diese
 ## [Unreleased]
 ### Added
 - Added cancel and retry buttons for downloads in the frontend.
-- Added cancel and retry endpoints for downloads including worker cancellation support.
+- Added cancel and retry endpoints for downloads via slskd TransfersApi.
 - Added limit/offset support to GET /api/downloads.
 - Added DownloadWidget to Dashboard.
 - Added GET endpoints for downloads.

--- a/ToDo.md
+++ b/ToDo.md
@@ -15,7 +15,7 @@
 - [x] Artist-Konfiguration für Spotify-Releases (API, DB, AutoSync) umsetzen.
 - [x] Artists-Frontend zum Aktivieren einzelner Releases inkl. Tests und Dokumentation ergänzen.
 - [x] Paging für `/api/downloads` mit Limit/Offset-Parametern ergänzen.
-- [x] Cancel- und Retry-Endpunkte für Downloads inklusive Worker-Integration ergänzen.
+- [x] Cancel- und Retry-Endpunkte für Downloads via TransfersApi finalisieren.
 - [ ] Streaming-Router für Audio-Features planen und implementieren (Frontend-Integration vorbereiten).
 - [ ] Frontend-Testlauf im CI wieder aktivieren, sobald npm-Registry-Zugriff verfügbar ist.
 - [ ] Prometheus-/StatsD-Exporter auf Basis der neuen `metrics.*` Settings anbinden.

--- a/app/core/transfers_api.py
+++ b/app/core/transfers_api.py
@@ -1,0 +1,34 @@
+"""Wrapper around the slskd transfers endpoints."""
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable
+
+from app.core.soulseek_client import SoulseekClient, SoulseekClientError
+
+
+class TransfersApiError(RuntimeError):
+    """Raised when the slskd transfers API cannot fulfil a request."""
+
+
+class TransfersApi:
+    """Provide a small abstraction for download transfer operations."""
+
+    def __init__(self, client: SoulseekClient) -> None:
+        self._client = client
+
+    async def cancel_download(self, download_id: int | str) -> Dict[str, Any]:
+        """Cancel a download via slskd."""
+
+        try:
+            return await self._client.cancel_download(str(download_id))
+        except SoulseekClientError as exc:  # pragma: no cover - network failure path
+            raise TransfersApiError(str(exc)) from exc
+
+    async def enqueue(self, *, username: str, files: Iterable[Dict[str, Any]]) -> Dict[str, Any]:
+        """Enqueue a new download job for the given user and files."""
+
+        try:
+            file_list = list(files)
+            return await self._client.enqueue(username, file_list)
+        except SoulseekClientError as exc:  # pragma: no cover - network failure path
+            raise TransfersApiError(str(exc)) from exc

--- a/app/dependencies.py
+++ b/app/dependencies.py
@@ -11,6 +11,7 @@ from app.core.matching_engine import MusicMatchingEngine
 from app.core.plex_client import PlexClient
 from app.core.soulseek_client import SoulseekClient
 from app.core.spotify_client import SpotifyClient
+from app.core.transfers_api import TransfersApi
 from app.db import get_session
 
 
@@ -32,6 +33,11 @@ def get_plex_client() -> PlexClient:
 @lru_cache()
 def get_soulseek_client() -> SoulseekClient:
     return SoulseekClient(get_app_config().soulseek)
+
+
+@lru_cache()
+def get_transfers_api() -> TransfersApi:
+    return TransfersApi(get_soulseek_client())
 
 
 @lru_cache()


### PR DESCRIPTION
## Summary
- add a small TransfersApi wrapper around the slskd download endpoints and expose it via FastAPI dependencies
- update the download cancel and retry handlers to call the TransfersApi, persist state, and emit new activity details
- extend the download tests with a TransfersApi stub and new error scenarios, and refresh the docs/changelog/todo entries

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d35af59a708321988cac187d43e863