### PR TITLE
Add tests and docs for download cancel/retry UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Alle Änderungen an diesem Projekt werden in diesem Dokument festgehalten. Diese
 
 ## [Unreleased]
 ### Added
-- Added cancel and retry buttons for downloads in the frontend.
+- Frontend: Cancel-/Retry-Buttons für Downloads (Downloads-Seite & Dashboard-Widget).
 - Added cancel and retry endpoints for downloads via slskd TransfersApi.
 - Added limit/offset support to GET /api/downloads.
 - Added DownloadWidget to Dashboard.

--- a/ToDo.md
+++ b/ToDo.md
@@ -10,7 +10,7 @@
 - [x] Dashboard-Widget für aktive Downloads ergänzen.
 - [x] Dashboard-DownloadWidget auf limitierte `/api/downloads`-Abfrage umstellen.
 - [x] Activity-Feed-Widget im Dashboard mit Polling, Sortierung und Status-Badges finalisieren.
-- [x] Cancel-/Retry-Buttons im Frontend (DownloadsPage & DownloadWidget) ergänzen.
+- [x] Cancel-/Retry-Buttons im Frontend (DownloadsPage & DownloadWidget) inkl. Tests & Dokumentation ergänzen.
 - [x] AutoSyncWorker für Spotify↔Plex implementieren, Soulseek/Beets-Anbindung ergänzen und Dokumentation aktualisieren.
 - [x] Artist-Konfiguration für Spotify-Releases (API, DB, AutoSync) umsetzen.
 - [x] Artists-Frontend zum Aktivieren einzelner Releases inkl. Tests und Dokumentation ergänzen.

--- a/docs/api.md
+++ b/docs/api.md
@@ -212,6 +212,8 @@ DELETE /api/download/42 HTTP/1.1
 
 Harmony ruft bei jedem Abbruch die slskd-TransfersApi (`DELETE /transfers/downloads/{id}`) auf. Erst wenn der Daemon die Anfrage bestätigt, wird der Download in der Datenbank als `cancelled` markiert und der Activity Feed um einen Eintrag `download_cancelled` mit `download_id` und `filename` ergänzt. Sollte der Daemon nicht erreichbar sein, antwortet der Endpunkt mit `502 Bad Gateway` und der Status in der Datenbank bleibt unverändert.
 
+> **Frontend-Beispiel:** Auf der Downloads-Seite steht jetzt pro aktivem Job ein Button **Abbrechen** zur Verfügung. Nach dem Klick ruft das Frontend `DELETE /api/download/{id}` auf, zeigt ein Erfolgstoast an und lädt die Tabelle automatisch neu, sodass der Status in der UI unmittelbar auf „Cancelled“ springt (siehe aktualisierte Abbildung unten).
+
 **Download-Start:**
 
 ```http
@@ -255,6 +257,8 @@ POST /api/download/42/retry HTTP/1.1
 ```
 
 Der Endpunkt akzeptiert nur Downloads im Status `failed` oder `cancelled`. Vor dem erneuten Start wird der ursprüngliche Job über `TransfersApi.cancel_download` beendet, anschließend werden `username`, `filename` und `filesize` erneut via `TransfersApi.enqueue` eingereiht. Dadurch entsteht ein neuer Download-Datensatz mit eigener ID, der Activity Feed erhält einen Eintrag `download_retried` mit `original_download_id`, `retry_download_id` und `filename`. Wenn slskd nicht erreichbar ist, wird der Vorgang mit `502 Bad Gateway` abgebrochen und kein neuer Datensatz erzeugt.
+
+> **Frontend-Beispiel:** Fehlgeschlagene oder abgebrochene Transfers besitzen den Button **Neu starten**. Nach `POST /api/download/{id}/retry` erscheint der neue Job (inkl. neuer ID) sofort wieder in der Übersicht und im Dashboard-Widget, damit Operatorinnen Retries ohne manuelle API-Aufrufe auslösen können.
 
 ## Download-Widget im Dashboard
 
@@ -300,7 +304,7 @@ GET /api/activity HTTP/1.1
 
 ![Downloads-Verwaltung](downloads-page.svg)
 
-Die neue Downloads-Seite im Harmony-Frontend ermöglicht das Starten von Test-Downloads über eine beliebige Datei- oder Track-ID und zeigt aktive Transfers inklusive Status, Fortschrittsbalken und Erstellungszeitpunkt an. Über Tailwind- und shadcn/ui-Komponenten werden Ladezustände, Leerlaufmeldungen ("Keine Downloads aktiv") sowie Fehler-Toasts konsistent dargestellt. Jeder erfolgreich gestartete Download löst eine Bestätigungsmeldung aus, während fehlgeschlagene Anfragen klar hervorgehoben werden. Zusätzlich stehen pro Zeile Buttons zum sofortigen Abbrechen laufender Jobs sowie zum erneuten Start fehlgeschlagener oder abgebrochener Transfers bereit.
+Die neue Downloads-Seite im Harmony-Frontend ermöglicht das Starten von Test-Downloads über eine beliebige Datei- oder Track-ID und zeigt aktive Transfers inklusive Status, Fortschrittsbalken und Erstellungszeitpunkt an. Über Tailwind- und shadcn/ui-Komponenten werden Ladezustände, Leerlaufmeldungen ("Keine Downloads aktiv") sowie Fehler-Toasts konsistent dargestellt. Jeder erfolgreich gestartete Download löst eine Bestätigungsmeldung aus, während fehlgeschlagene Anfragen klar hervorgehoben werden. Pro Zeile stehen nun deutlich sichtbare Buttons zum sofortigen Abbrechen laufender Jobs sowie zum erneuten Start fehlgeschlagener oder abgebrochener Transfers bereit – die UI bestätigt erfolgreiche Aktionen per Toast und aktualisiert die Tabelle automatisch.
 
 ![Activity-Feed-Widget](activity-feed-widget.svg)
 

--- a/docs/downloads-page.svg
+++ b/docs/downloads-page.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 360" role="img" aria-labelledby="title desc">
   <title id="title">Harmony Downloads Page Mockup</title>
-  <desc id="desc">Illustration der Download-Verwaltung mit Formular und Tabelle</desc>
+  <desc id="desc">Illustration der Download-Verwaltung mit Formular, Tabelle und Aktionsbuttons</desc>
   <rect width="640" height="360" fill="#0f172a" rx="24" />
   <rect x="24" y="24" width="592" height="312" fill="#111827" rx="18" />
   <rect x="48" y="52" width="544" height="96" fill="#1f2937" rx="12" />
@@ -18,4 +18,8 @@
   <rect x="64" y="252" width="512" height="28" fill="#111827" opacity="0.6" />
   <rect x="448" y="230" width="112" height="12" fill="#1d4ed8" rx="6" />
   <rect x="448" y="262" width="78" height="12" fill="#15803d" rx="6" />
+  <rect x="520" y="224" width="96" height="20" rx="8" fill="#ef4444" opacity="0.9" />
+  <text x="568" y="238" text-anchor="middle" fill="#f8fafc" font-size="10" font-family="'Inter', sans-serif">Abbrechen</text>
+  <rect x="520" y="256" width="96" height="20" rx="8" fill="#f8fafc" opacity="0.95" />
+  <text x="568" y="270" text-anchor="middle" fill="#0f172a" font-size="10" font-family="'Inter', sans-serif">Neu starten</text>
 </svg>

--- a/frontend/tests/__tests__/DownloadWidget.test.tsx
+++ b/frontend/tests/__tests__/DownloadWidget.test.tsx
@@ -1,0 +1,90 @@
+import { screen, userEvent, waitFor } from '../../src/testing/dom-testing';
+import DownloadWidget from '../../src/components/DownloadWidget';
+import { renderWithProviders } from '../../src/test-utils';
+import type { DownloadEntry } from '../../src/lib/api';
+
+const downloadsState: DownloadEntry[] = [];
+
+const cloneState = () => downloadsState.map((entry) => ({ ...entry }));
+
+const cancelDownloadMock = jest.fn(async (id: string) => {
+  const entry = downloadsState.find((item) => String(item.id) === id);
+  if (entry) {
+    entry.status = 'cancelled';
+  }
+});
+
+const retryDownloadMock = jest.fn(async (id: string) => {
+  const original = downloadsState.find((item) => String(item.id) === id);
+  const retryEntry: DownloadEntry = {
+    id: `${id}-retry`,
+    filename: original?.filename ? `${original.filename} (Retry)` : 'Retry.mp3',
+    status: 'queued',
+    progress: 0
+  };
+  downloadsState.push(retryEntry);
+  return retryEntry;
+});
+
+const fetchDownloadsMock = jest.fn(async () => cloneState());
+
+jest.mock('../../src/lib/api', () => ({
+  fetchDownloads: (...args: unknown[]) => fetchDownloadsMock(...args),
+  cancelDownload: (...args: unknown[]) => cancelDownloadMock(...(args as [string])),
+  retryDownload: (...args: unknown[]) => retryDownloadMock(...(args as [string]))
+}));
+
+describe('DownloadWidget cancel and retry actions', () => {
+  beforeEach(() => {
+    downloadsState.splice(0, downloadsState.length);
+    fetchDownloadsMock.mockClear();
+    cancelDownloadMock.mockClear();
+    retryDownloadMock.mockClear();
+  });
+
+  it('cancels an active download and updates the status', async () => {
+    downloadsState.push({
+      id: 5,
+      filename: 'Widget Track.mp3',
+      status: 'running',
+      progress: 50
+    });
+
+    renderWithProviders(<DownloadWidget />);
+
+    await screen.findByText('Widget Track.mp3');
+
+    const cancelButton = await screen.findByRole('button', { name: 'Abbrechen' });
+    await userEvent.click(cancelButton);
+
+    expect(cancelDownloadMock).toHaveBeenCalledWith('5');
+
+    await waitFor(() => {
+      expect(screen.getByText('Cancelled')).toBeInTheDocument();
+    });
+    expect(fetchDownloadsMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('retries a cancelled download and shows the retried entry', async () => {
+    downloadsState.push({
+      id: 9,
+      filename: 'Cancelled Track.mp3',
+      status: 'cancelled',
+      progress: 0
+    });
+
+    renderWithProviders(<DownloadWidget />);
+
+    await screen.findByText('Cancelled Track.mp3');
+
+    const retryButton = await screen.findByRole('button', { name: 'Neu starten' });
+    await userEvent.click(retryButton);
+
+    expect(retryDownloadMock).toHaveBeenCalledWith('9');
+
+    await waitFor(() => {
+      expect(screen.getByText('9-retry')).toBeInTheDocument();
+    });
+    expect(fetchDownloadsMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/frontend/tests/__tests__/DownloadsPage.test.tsx
+++ b/frontend/tests/__tests__/DownloadsPage.test.tsx
@@ -1,0 +1,93 @@
+import { screen, userEvent, waitFor } from '../../src/testing/dom-testing';
+import DownloadsPage from '../../src/pages/DownloadsPage';
+import { renderWithProviders } from '../../src/test-utils';
+import type { DownloadEntry } from '../../src/lib/api';
+
+const downloadsState: DownloadEntry[] = [];
+
+const cloneState = () => downloadsState.map((entry) => ({ ...entry }));
+
+const startDownloadMock = jest.fn();
+
+const cancelDownloadMock = jest.fn(async (id: string) => {
+  const entry = downloadsState.find((item) => String(item.id) === id);
+  if (entry) {
+    entry.status = 'cancelled';
+  }
+});
+
+const retryDownloadMock = jest.fn(async (id: string) => {
+  const original = downloadsState.find((item) => String(item.id) === id);
+  const retryEntry: DownloadEntry = {
+    id: `${id}-retry`,
+    filename: original?.filename ? `${original.filename} (Retry)` : 'Retry.mp3',
+    status: 'queued',
+    progress: 0
+  };
+  downloadsState.push(retryEntry);
+  return retryEntry;
+});
+
+const fetchActiveDownloadsMock = jest.fn(async () => cloneState());
+
+jest.mock('../../src/lib/api', () => ({
+  fetchActiveDownloads: (...args: unknown[]) => fetchActiveDownloadsMock(...args),
+  cancelDownload: (...args: unknown[]) => cancelDownloadMock(...(args as [string])),
+  retryDownload: (...args: unknown[]) => retryDownloadMock(...(args as [string])),
+  startDownload: (...args: unknown[]) => startDownloadMock(...args)
+}));
+
+describe('DownloadsPage cancel and retry actions', () => {
+  beforeEach(() => {
+    downloadsState.splice(0, downloadsState.length);
+    fetchActiveDownloadsMock.mockClear();
+    cancelDownloadMock.mockClear();
+    retryDownloadMock.mockClear();
+  });
+
+  it('cancels a running download and refreshes the status', async () => {
+    downloadsState.push({
+      id: 1,
+      filename: 'Running Track.mp3',
+      status: 'running',
+      progress: 25
+    });
+
+    renderWithProviders(<DownloadsPage />);
+
+    await screen.findByText('Running Track.mp3');
+
+    const cancelButton = await screen.findByRole('button', { name: 'Abbrechen' });
+    await userEvent.click(cancelButton);
+
+    expect(cancelDownloadMock).toHaveBeenCalledWith('1');
+
+    await waitFor(() => {
+      expect(screen.getByText('Cancelled')).toBeInTheDocument();
+    });
+    expect(fetchActiveDownloadsMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('retries a failed download and shows the new job in the list', async () => {
+    downloadsState.push({
+      id: 10,
+      filename: 'Failed Track.mp3',
+      status: 'failed',
+      progress: 0
+    });
+
+    renderWithProviders(<DownloadsPage />);
+
+    await screen.findByText('Failed Track.mp3');
+
+    const retryButton = await screen.findByRole('button', { name: 'Neu starten' });
+    await userEvent.click(retryButton);
+
+    expect(retryDownloadMock).toHaveBeenCalledWith('10');
+
+    await waitFor(() => {
+      expect(screen.getByText('10-retry')).toBeInTheDocument();
+    });
+    expect(fetchActiveDownloadsMock).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Summary
- add Jest coverage for cancel and retry flows on DownloadsPage and DownloadWidget
- update API documentation and downloads mockup to describe the new cancel/retry actions
- refresh changelog and ToDo entries to reflect the UI support

## Testing
- npm run build
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d35faa5fcc8321b4df460c7399e2e0