### PR TITLE
Persist activity feed events in database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Alle Änderungen an diesem Projekt werden in diesem Dokument festgehalten. Diese
 
 ## [Unreleased]
 ### Added
+- Added persistent Activity Feed with flexible event types.
 - Frontend: Cancel-/Retry-Buttons für Downloads (Downloads-Seite & Dashboard-Widget).
 - Added cancel and retry endpoints for downloads via slskd TransfersApi.
 - Added limit/offset support to GET /api/downloads.

--- a/ToDo.md
+++ b/ToDo.md
@@ -4,7 +4,7 @@
 - [x] Metadaten-Workflow für Dashboard-Portierung abschließen.
 - [x] Sync- und Suchfunktionen zwischen Spotify/Plex/Soulseek vereinheitlichen.
 - [x] Download-Management via `/api/downloads` und `/api/download` inkl. Worker-Integration fertigstellen.
-- [x] Aktivitätsfeed `/api/activity` als In-Memory-Queue bereitstellen.
+- [x] Aktivitätsfeed `/api/activity` mit Persistenz, Paging und flexiblen Eventtypen erweitern.
 - [x] Downloads-Frontend mit Tabelle und Start-Formular bereitstellen.
 - [x] GET-Endpunkte für Downloads (`/api/downloads`, `/api/download/{id}`) ergänzen.
 - [x] Dashboard-Widget für aktive Downloads ergänzen.

--- a/app/main.py
+++ b/app/main.py
@@ -30,6 +30,7 @@ from app.routers import (
     soulseek_router,
     spotify_router,
 )
+from app.utils.activity import activity_manager
 from app.workers import (
     AutoSyncWorker,
     MatchingWorker,
@@ -63,6 +64,7 @@ async def startup_event() -> None:
     configure_logging(config.logging.level)
     init_db()
     logger.info("Database initialised")
+    activity_manager.refresh_cache()
 
     if os.getenv("HARMONY_DISABLE_WORKERS") not in {"1", "true", "TRUE"}:
         soulseek_client = get_soulseek_client()

--- a/app/models.py
+++ b/app/models.py
@@ -85,6 +85,16 @@ class SettingHistory(Base):
     changed_at = Column(DateTime, default=datetime.utcnow, nullable=False)
 
 
+class ActivityEvent(Base):
+    __tablename__ = "activity_events"
+
+    id = Column(Integer, primary_key=True, index=True)
+    timestamp = Column(DateTime, default=datetime.utcnow, nullable=False, index=True)
+    type = Column(String(128), nullable=False)
+    status = Column(String(128), nullable=False)
+    details = Column(JSON, nullable=True)
+
+
 class ArtistPreference(Base):
     __tablename__ = "artist_preferences"
 

--- a/app/routers/activity_router.py
+++ b/app/routers/activity_router.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from typing import Any, Dict, List
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Query
 
 from app.logging import get_logger
 from app.utils.activity import activity_manager
@@ -13,9 +13,16 @@ logger = get_logger(__name__)
 
 
 @router.get("/activity", response_model=list[dict[str, Any]])
-def list_activity() -> List[Dict[str, Any]]:
-    """Return the most recent activity entries."""
+def list_activity(
+    limit: int = Query(50, ge=1, le=500), offset: int = Query(0, ge=0)
+) -> List[Dict[str, Any]]:
+    """Return the most recent activity entries from persistent storage."""
 
-    entries = activity_manager.list()
-    logger.debug("Returning %d activity entries", len(entries))
+    entries = activity_manager.fetch(limit=limit, offset=offset)
+    logger.debug(
+        "Returning %d activity entries (limit=%d, offset=%d)",
+        len(entries),
+        limit,
+        offset,
+    )
     return entries

--- a/docs/workers.md
+++ b/docs/workers.md
@@ -14,6 +14,7 @@ Harmony startet beim FastAPI-Startup mehrere Hintergrundprozesse, um langlaufend
 - **Fehlerhandling:**
   - Fehlschläge beim Download markieren die betroffenen DB-Einträge als `failed` und werden im Activity Feed dokumentiert.
   - Unerwartete Statuswerte oder Fortschritte werden korrigiert; Netzwerkfehler beim Status-Polling erzeugen Warnungen, der Worker bleibt aktiv.
+- **Activity Feed / Eventtypen:** Persistiert `download`-Events wie `queued`, `failed`, `download_cancelled` (inkl. Fehlergründen) sowie `sync_job_failed` aus dem Worker. Details enthalten Job-IDs oder beteiligte Nutzer:innen.
 
 ## MatchingWorker
 
@@ -25,6 +26,7 @@ Harmony startet beim FastAPI-Startup mehrere Hintergrundprozesse, um langlaufend
   - Nach jeder Charge entstehen Kennzahlen in der Settings-Tabelle (`metrics.matching.*`) sowie Activity-Einträge (`matching_batch`). Heartbeats stehen in `worker.matching.last_seen`.
 - **Fehlerhandling:**
   - Ungültige Jobs werden mit `invalid_payload` markiert. Laufzeitfehler erzeugen Activity-Logs und setzen den Jobstatus in der DB auf `failed`.
+- **Activity Feed / Eventtypen:** Nutzt den Typ `metadata` mit Statusmeldungen wie `matching_batch` (inkl. Batch-Größe, Treffer, Confidence) oder `matching_job_failed` bei Ausnahmen.
 
 ## ScanWorker
 
@@ -36,6 +38,7 @@ Harmony startet beim FastAPI-Startup mehrere Hintergrundprozesse, um langlaufend
   - Ergebnisse werden als Settings aktualisiert (`plex_*`) und mit Metriken versehen (`metrics.scan.interval`, `metrics.scan.duration_ms`). Heartbeats sowie Start/Stop-Zeitpunkte landen ebenfalls in der Settings-Tabelle.
 - **Fehlerhandling:**
   - Wiederholte Scan-Fehler werden gezählt; nach drei Versuchen erzeugt der Worker einen Activity-Eintrag `scan_failed`. Netzwerkfehler verhindern keine späteren Läufe.
+- **Activity Feed / Eventtypen:** Meldet über den Typ `metadata` kritische Zustände (`scan_failed`) inklusive Fehlermeldung und Fehlerzähler.
 
 ## AutoSyncWorker
 
@@ -49,6 +52,7 @@ Harmony startet beim FastAPI-Startup mehrere Hintergrundprozesse, um langlaufend
 - **Fehlerhandling & Logging:**
   - Spotify/Plex-Ausfälle beenden den Lauf mit `status="partial"`; Soulseek-Probleme werden granular unterschieden (Suchfehler, Qualitätsfilter, Download-/Importfehler) und im Activity Feed protokolliert.
   - Erfolgreiche Downloads löschen den Skip-State, damit spätere Läufe nicht hängen bleiben.
+- **Activity Feed / Eventtypen:** Schreibt ausführliche `sync`-Events wie `autosync_started`, `spotify_loaded`, `downloads_requested`, `partial` oder `completed` samt Kontext (`source`, `count`, `missing`). Ergänzende Details dokumentieren Plex-Updates (`plex_updated`) und Soulseek-/Beets-Ergebnisse.
 
 ## Zusammenspiel der Worker
 

--- a/tests/test_activity_persistence.py
+++ b/tests/test_activity_persistence.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from app.db import session_scope
+from app.models import ActivityEvent
+from app.utils.activity import activity_manager, record_activity
+
+
+def test_activity_events_are_persisted_in_db(client) -> None:
+    record_activity("sync", "completed", details={"runs": 1})
+
+    with session_scope() as session:
+        stored = session.query(ActivityEvent).order_by(ActivityEvent.id.desc()).first()
+
+    assert stored is not None
+    assert stored.type == "sync"
+    assert stored.status == "completed"
+    assert stored.details == {"runs": 1}
+
+
+def test_activity_cache_can_reload_from_database(client) -> None:
+    record_activity("matching", "batch_saved", details={"count": 5})
+
+    activity_manager.clear()
+    activity_manager.refresh_cache()
+
+    entries = activity_manager.list()
+    assert entries
+    assert entries[0]["type"] == "matching"
+    assert entries[0]["details"]["count"] == 5
+
+
+def test_activity_endpoint_supports_paging(client) -> None:
+    for index in range(30):
+        record_activity("download", "queued", details={"index": index})
+
+    response = client.get("/api/activity", params={"limit": 10, "offset": 5})
+    assert response.status_code == 200
+
+    entries = response.json()
+    assert len(entries) == 10
+
+    returned_indices = [entry["details"]["index"] for entry in entries]
+    expected_indices = list(range(30 - 5 - 1, 30 - 5 - 10 - 1, -1))
+    assert returned_indices == expected_indices
+
+
+def test_activity_accepts_flexible_types(client) -> None:
+    record_activity("autosync", "started", details={"source": "playlist"})
+
+    response = client.get("/api/activity")
+    assert response.status_code == 200
+
+    entries = response.json()
+    assert entries
+    assert entries[0]["type"] == "autosync"
+    assert entries[0]["details"]["source"] == "playlist"


### PR DESCRIPTION
## Summary
- persist activity feed events in the new `activity_events` table while keeping a 50-entry cache for fast reads
- update the activity API to page over stored events and refresh the cache during application startup
- cover the persistent feed with new tests and refresh the documentation, changelog, and todo list

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d3620402b88321a5aa9463e4811e72