### PR TITLE
feat: add optional album match persistence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Alle Änderungen an diesem Projekt werden in diesem Dokument festgehalten. Diese
 - Artists-Seite im Frontend zur Verwaltung gefolgter Spotify-Artists und ihrer Releases inklusive Sync-Toggles.
 - Persistente Worker-Queues (`worker_jobs`) inkl. Health/Metric-Tracking (`worker.*`, `metrics.*`) für Sync-, Matching- und Scan-Worker.
 - Quality-/Priorisierungsregeln für den AutoSyncWorker (`autosync_min_bitrate`, `autosync_preferred_formats`, Skip-State in `auto_sync_skipped_tracks`).
+- Added optional persistence for album matching (`persist=true` on `/matching/spotify-to-plex-album`).
 
 ### Changed
 - Frontend: DownloadWidget uses limit param of /api/downloads.

--- a/app/models.py
+++ b/app/models.py
@@ -61,6 +61,7 @@ class Match(Base):
     source = Column(String(50), nullable=False)
     spotify_track_id = Column(String(128), index=True, nullable=False)
     target_id = Column(String(128), nullable=True)
+    context_id = Column(String(128), nullable=True)
     confidence = Column(Float, nullable=False)
     created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -468,7 +468,11 @@ Content-Type: application/json
 | --- | --- | --- |
 | `POST` | `/matching/spotify-to-plex` | Matcht einen Spotify-Track gegen Plex-Kandidaten und speichert das Ergebnis. |
 | `POST` | `/matching/spotify-to-soulseek` | Bewertet Spotify vs. Soulseek-Kandidaten. |
-| `POST` | `/matching/spotify-to-plex-album` | Liefert das beste Album-Match. |
+| `POST` | `/matching/spotify-to-plex-album` | Liefert das beste Album-Match; optional mit `persist=true` zur Speicherung. |
+
+**Parameter:**
+
+- `persist` (Query, optional, Default `false`): Speichert pro Track des Spotify-Albums einen `Match`-Eintrag mit dem gefundenen Plex-Album als Ziel und der Spotify-Album-ID als Kontext.
 
 **Beispiel:**
 

--- a/docs/workers.md
+++ b/docs/workers.md
@@ -24,6 +24,7 @@ Harmony startet beim FastAPI-Startup mehrere Hintergrundprozesse, um langlaufend
   - Jobs werden persistent in `worker_jobs` gespeichert. Beim Start lädt der Worker offene Jobs nach und verarbeitet sie in konfigurierbaren Batches (`matching_worker_batch_size`).
   - Jeder Kandidat wird gescored; alle Treffer oberhalb des Confidence-Thresholds (`matching_confidence_threshold`/`MATCHING_CONFIDENCE_THRESHOLD`) werden als `Match` gespeichert.
   - Nach jeder Charge entstehen Kennzahlen in der Settings-Tabelle (`metrics.matching.*`) sowie Activity-Einträge (`matching_batch`). Heartbeats stehen in `worker.matching.last_seen`.
+- **API-Integration:** Neben den Worker-Jobs kann das Album-Matching (`POST /matching/spotify-to-plex-album?persist=true`) die berechneten Treffer je Track direkt in der `matches`-Tabelle ablegen und dabei die Spotify-Album-ID als Kontext speichern.
 - **Fehlerhandling:**
   - Ungültige Jobs werden mit `invalid_payload` markiert. Laufzeitfehler erzeugen Activity-Logs und setzen den Jobstatus in der DB auf `failed`.
 - **Activity Feed / Eventtypen:** Nutzt den Typ `metadata` mit Statusmeldungen wie `matching_batch` (inkl. Batch-Größe, Treffer, Confidence) oder `matching_job_failed` bei Ausnahmen.

--- a/tests/simple_client.py
+++ b/tests/simple_client.py
@@ -55,9 +55,12 @@ class SimpleTestClient:
         path: str,
         json_body: Optional[Dict[str, Any]] = None,
         json: Optional[Dict[str, Any]] = None,
+        params: Optional[Dict[str, Any]] = None,
     ) -> SimpleResponse:
         payload = json_body if json_body is not None else json
-        return self._loop.run_until_complete(self._request("POST", path, json_body=payload))
+        return self._loop.run_until_complete(
+            self._request("POST", path, params=params, json_body=payload)
+        )
 
     def put(self, path: str, json: Optional[Dict[str, Any]] = None) -> SimpleResponse:
         return self._loop.run_until_complete(self._request("PUT", path, json_body=json))


### PR DESCRIPTION
## Summary
- add optional `persist` query flag to `/matching/spotify-to-plex-album` and store per-track matches with album context
- extend database schema and tests to cover persisted album matching and failure handling
- document the new option in API and worker docs and note the change in the changelog

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d365b1a4c4832180d2d6b3a8379aaa