### PR TITLE
feat: auto-populate default settings on startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Alle Änderungen an diesem Projekt werden in diesem Dokument festgehalten. Diese
 
 ## [Unreleased]
 ### Added
+- Added automatic defaults for worker-related settings at startup.
 - Added persistent Activity Feed with flexible event types.
 - Frontend: Cancel-/Retry-Buttons für Downloads (Downloads-Seite & Dashboard-Widget).
 - Added cancel and retry endpoints for downloads via slskd TransfersApi.

--- a/ToDo.md
+++ b/ToDo.md
@@ -16,6 +16,7 @@
 - [x] Artists-Frontend zum Aktivieren einzelner Releases inkl. Tests und Dokumentation ergänzen.
 - [x] Paging für `/api/downloads` mit Limit/Offset-Parametern ergänzen.
 - [x] Cancel- und Retry-Endpunkte für Downloads via TransfersApi finalisieren.
+- [x] Settings erhalten automatische Default-Werte beim Startup.
 - [ ] Streaming-Router für Audio-Features planen und implementieren (Frontend-Integration vorbereiten).
 - [ ] Frontend-Testlauf im CI wieder aktivieren, sobald npm-Registry-Zugriff verfügbar ist.
 - [ ] Prometheus-/StatsD-Exporter auf Basis der neuen `metrics.*` Settings anbinden.

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -1,0 +1,13 @@
+"""Static configuration defaults for Harmony settings."""
+from __future__ import annotations
+
+from typing import Mapping
+
+DEFAULT_SETTINGS: Mapping[str, str] = {
+    "sync_worker_concurrency": "1",
+    "matching_worker_batch_size": "10",
+    "autosync_min_bitrate": "192",
+    "autosync_preferred_formats": "mp3,flac",
+}
+
+__all__ = ["DEFAULT_SETTINGS"]

--- a/app/main.py
+++ b/app/main.py
@@ -7,6 +7,7 @@ import inspect
 
 from fastapi import FastAPI
 
+from app.core.config import DEFAULT_SETTINGS
 from app.core.beets_client import BeetsClient
 from app.dependencies import (
     get_app_config,
@@ -31,6 +32,7 @@ from app.routers import (
     spotify_router,
 )
 from app.utils.activity import activity_manager
+from app.utils.settings_store import ensure_default_settings
 from app.workers import (
     AutoSyncWorker,
     MatchingWorker,
@@ -63,6 +65,7 @@ async def startup_event() -> None:
     config = get_app_config()
     configure_logging(config.logging.level)
     init_db()
+    ensure_default_settings(DEFAULT_SETTINGS)
     logger.info("Database initialised")
     activity_manager.refresh_cache()
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -505,6 +505,19 @@ Content-Type: application/json
 | `GET` | `/settings/artist-preferences` | Gibt die markierten Releases pro Artist zurück. |
 | `POST` | `/settings/artist-preferences` | Persistiert die Auswahl (`{"preferences": [{"artist_id": ..., "release_id": ..., "selected": true}]}`). |
 
+### Default-Werte
+
+- Beim Start der Anwendung werden fehlende Settings automatisch mit sinnvollen Defaults ergänzt.
+- `GET /settings` liefert immer den effektiven Wert pro Key zurück – gesetzte Werte überschreiben Defaults.
+- Die History (`/settings/history`) bleibt unverändert und listet nur echte Änderungen.
+
+| Setting | Default | Beschreibung |
+|---------|---------|--------------|
+| `sync_worker_concurrency` | `1` | Maximale Anzahl paralleler SyncWorker-Tasks (ENV: `SYNC_WORKER_CONCURRENCY`). |
+| `matching_worker_batch_size` | `10` | Anzahl an Matching-Jobs pro Batch (ENV: `MATCHING_WORKER_BATCH_SIZE`). |
+| `autosync_min_bitrate` | `192` | Mindest-Bitrate für Soulseek-Downloads (ENV: `AUTOSYNC_MIN_BITRATE`). |
+| `autosync_preferred_formats` | `mp3,flac` | Bevorzugte Dateiformate für AutoSync (ENV: `AUTOSYNC_PREFERRED_FORMATS`). |
+
 **Neue Worker-relevante Settings:**
 
 - `sync_worker_concurrency` – Anzahl paralleler SyncWorker-Tasks (ENV: `SYNC_WORKER_CONCURRENCY`).

--- a/docs/workers.md
+++ b/docs/workers.md
@@ -2,6 +2,8 @@
 
 Harmony startet beim FastAPI-Startup mehrere Hintergrundprozesse, um langlaufende Aufgaben außerhalb des Request-Kontexts zu bearbeiten. Die Worker verwenden asynchrone Tasks (`asyncio`) und greifen über `session_scope()` auf die Datenbank zu.
 
+Alle workerrelevanten Settings werden beim Application-Startup automatisch mit Default-Werten befüllt (`sync_worker_concurrency`, `matching_worker_batch_size`, `autosync_min_bitrate`, `autosync_preferred_formats`). Dadurch stehen sinnvolle Parameter bereit, selbst wenn noch keine manuelle Konfiguration stattgefunden hat.
+
 ## SyncWorker
 
 - **Pfad:** `app/workers/sync_worker.py`

--- a/tests/test_settings_defaults.py
+++ b/tests/test_settings_defaults.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from sqlalchemy import select
+
+from app.core.config import DEFAULT_SETTINGS
+from app.db import session_scope
+from app.models import Setting
+
+
+def test_startup_populates_missing_defaults(client) -> None:
+    with session_scope() as session:
+        stored_settings = session.execute(select(Setting)).scalars().all()
+    keys = {setting.key for setting in stored_settings}
+    for key, value in DEFAULT_SETTINGS.items():
+        assert key in keys
+        stored = next(item for item in stored_settings if item.key == key)
+        assert stored.value == value
+
+
+def test_get_settings_returns_defaults(client) -> None:
+    response = client.get("/settings")
+    assert response.status_code == 200
+    payload = response.json()
+    assert "settings" in payload
+    settings = payload["settings"]
+    for key, value in DEFAULT_SETTINGS.items():
+        assert settings.get(key) == value
+
+
+def test_post_settings_overrides_defaults(client) -> None:
+    response = client.post(
+        "/settings",
+        json={"key": "sync_worker_concurrency", "value": "4"},
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    settings = payload["settings"]
+    assert settings["sync_worker_concurrency"] == "4"
+
+
+def test_history_tracks_actual_changes(client) -> None:
+    initial_history = client.get("/settings/history")
+    assert initial_history.status_code == 200
+    assert initial_history.json()["history"] == []
+
+    response = client.post(
+        "/settings",
+        json={"key": "matching_worker_batch_size", "value": "8"},
+    )
+    assert response.status_code == 200
+
+    history_response = client.get("/settings/history")
+    assert history_response.status_code == 200
+    history_entries = history_response.json()["history"]
+    assert len(history_entries) == 1
+    entry = history_entries[0]
+    assert entry["key"] == "matching_worker_batch_size"
+    assert entry["old_value"] == DEFAULT_SETTINGS["matching_worker_batch_size"]
+    assert entry["new_value"] == "8"


### PR DESCRIPTION
## Summary
- add static default settings map and populate missing entries during startup
- expose defaults through the settings API and document behaviour
- cover default propagation with dedicated tests and documentation updates

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d368a42d74832188da625ce6f00a6a