### PR TITLE
feat: add worker health monitoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Alle Änderungen an diesem Projekt werden in diesem Dokument festgehalten. Diese
 
 ## [Unreleased]
 ### Added
+- Added worker health info (heartbeats + queue size) to `/status`.
 - Added automatic defaults for worker-related settings at startup.
 - Added persistent Activity Feed with flexible event types.
 - Frontend: Cancel-/Retry-Buttons für Downloads (Downloads-Seite & Dashboard-Widget).

--- a/ToDo.md
+++ b/ToDo.md
@@ -17,6 +17,7 @@
 - [x] Paging für `/api/downloads` mit Limit/Offset-Parametern ergänzen.
 - [x] Cancel- und Retry-Endpunkte für Downloads via TransfersApi finalisieren.
 - [x] Settings erhalten automatische Default-Werte beim Startup.
+- [x] Worker-Health-Infos (Heartbeats + Queue-Längen) im `/status`-Endpoint ergänzen.
 - [ ] Streaming-Router für Audio-Features planen und implementieren (Frontend-Integration vorbereiten).
 - [ ] Frontend-Testlauf im CI wieder aktivieren, sobald npm-Registry-Zugriff verfügbar ist.
 - [ ] Prometheus-/StatsD-Exporter auf Basis der neuen `metrics.*` Settings anbinden.

--- a/app/utils/worker_health.py
+++ b/app/utils/worker_health.py
@@ -1,0 +1,103 @@
+"""Helper utilities for tracking worker heartbeat information."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Optional
+
+from app.utils.settings_store import read_setting, write_setting
+
+HEARTBEAT_PREFIX = "worker:"
+STATUS_SUFFIX = ":status"
+LAST_SEEN_SUFFIX = ":last_seen"
+STALE_TIMEOUT_SECONDS = 60
+
+
+def _utcnow_iso() -> str:
+    """Return an ISO8601 timestamp in UTC."""
+
+    return datetime.now(timezone.utc).isoformat()
+
+
+def heartbeat_key(name: str) -> str:
+    """Return the settings key storing the last heartbeat timestamp."""
+
+    return f"{HEARTBEAT_PREFIX}{name}{LAST_SEEN_SUFFIX}"
+
+
+def status_key(name: str) -> str:
+    """Return the settings key storing the worker status."""
+
+    return f"{HEARTBEAT_PREFIX}{name}{STATUS_SUFFIX}"
+
+
+def record_worker_heartbeat(name: str, *, status: str = "running") -> str:
+    """Persist a heartbeat and optional status for ``name``."""
+
+    timestamp = _utcnow_iso()
+    write_setting(heartbeat_key(name), timestamp)
+    mark_worker_status(name, status)
+    return timestamp
+
+
+def mark_worker_status(name: str, status: str) -> None:
+    """Persist the current status for ``name``."""
+
+    write_setting(status_key(name), status)
+
+
+def read_worker_status(name: str) -> tuple[Optional[str], Optional[str]]:
+    """Return the stored ``(last_seen, status)`` tuple for ``name``."""
+
+    return read_setting(heartbeat_key(name)), read_setting(status_key(name))
+
+
+def parse_timestamp(value: Optional[str]) -> Optional[datetime]:
+    """Parse an ISO8601 timestamp if possible."""
+
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(value)
+    except ValueError:
+        return None
+
+
+def resolve_status(
+    stored_status: Optional[str],
+    last_seen: Optional[datetime],
+    *,
+    now: Optional[datetime] = None,
+    stale_after: float = STALE_TIMEOUT_SECONDS,
+) -> str:
+    """Determine the effective worker status based on stored data."""
+
+    status = (stored_status or "unknown").lower()
+    if status == "stopped":
+        return "stopped"
+
+    reference = now or datetime.now(timezone.utc)
+    if last_seen is not None and last_seen.tzinfo is None:
+        last_seen = last_seen.replace(tzinfo=timezone.utc)
+
+    if last_seen is None:
+        return status
+
+    if (reference - last_seen).total_seconds() > stale_after and status != "stopped":
+        return "stale"
+
+    return status or "unknown"
+
+
+__all__ = [
+    "HEARTBEAT_PREFIX",
+    "LAST_SEEN_SUFFIX",
+    "STALE_TIMEOUT_SECONDS",
+    "heartbeat_key",
+    "status_key",
+    "record_worker_heartbeat",
+    "mark_worker_status",
+    "read_worker_status",
+    "parse_timestamp",
+    "resolve_status",
+]
+

--- a/docs/api.md
+++ b/docs/api.md
@@ -22,11 +22,18 @@ GET /status HTTP/1.1
   "version": "1.4.0",
   "uptime_seconds": 12.5,
   "workers": {
-    "soulseek_sync": {"state": "idle", "queue_size": 0},
-    "matching": {"state": "running"}
+    "sync": {"status": "running", "last_seen": "2025-01-01T12:00:00+00:00", "queue_size": 3},
+    "matching": {"status": "running", "last_seen": "2025-01-01T12:00:00+00:00", "queue_size": 0},
+    "scan": {"status": "stale", "last_seen": "2024-12-31T23:58:00+00:00", "queue_size": "n/a"},
+    "playlist": {"status": "running", "last_seen": "2025-01-01T11:59:45+00:00", "queue_size": "n/a"},
+    "autosync": {"status": "stopped", "last_seen": null, "queue_size": {"scheduled": 0, "running": 0}}
   }
 }
 ```
+
+- `status`: Aggregierter Zustand des Workers. `running` signalisiert einen aktiven Heartbeat, `stopped` stammt aus einem kontrollierten Shutdown, `stale` bedeutet, dass länger als 60 s kein Heartbeat eingegangen ist.
+- `last_seen`: UTC-Timestamp des letzten Heartbeats (`worker:<name>:last_seen`). Bei unbekanntem Zustand bleibt der Wert `null`.
+- `queue_size`: Anzahl offener Aufgaben. Für AutoSync wird zwischen geplanten (`scheduled`) und aktuell laufenden (`running`) Zyklen unterschieden. Worker ohne Queue liefern `"n/a"`.
 
 ## Metadata (`/api/metadata`)
 

--- a/docs/workers.md
+++ b/docs/workers.md
@@ -12,7 +12,7 @@ Alle workerrelevanten Settings werden beim Application-Startup automatisch mit D
   - Jobs werden in der Tabelle `worker_jobs` persistiert und beim Start wieder eingereiht. Angefangene Downloads überstehen dadurch Neustarts.
   - Mehrere Worker-Tasks ziehen parallel Jobs aus der Queue. Die Parallelität ist über Setting/ENV (`sync_worker_concurrency` bzw. `SYNC_WORKER_CONCURRENCY`) konfigurierbar.
   - Ein separater Poll-Loop ruft `refresh_downloads()` auf. Läuft kein aktiver Download, wird das Polling-Intervall automatisch auf den Idle-Wert hochgesetzt.
-  - Health-/Monitoring-Informationen landen in der Settings-Tabelle (`worker.sync.last_seen`, `metrics.sync.*`).
+  - Health-/Monitoring-Informationen landen in der Settings-Tabelle (`worker:sync:last_seen`, `worker:sync:status`, `metrics.sync.*`).
 - **Fehlerhandling:**
   - Fehlschläge beim Download markieren die betroffenen DB-Einträge als `failed` und werden im Activity Feed dokumentiert.
   - Unerwartete Statuswerte oder Fortschritte werden korrigiert; Netzwerkfehler beim Status-Polling erzeugen Warnungen, der Worker bleibt aktiv.
@@ -25,7 +25,7 @@ Alle workerrelevanten Settings werden beim Application-Startup automatisch mit D
 - **Arbeitsweise:**
   - Jobs werden persistent in `worker_jobs` gespeichert. Beim Start lädt der Worker offene Jobs nach und verarbeitet sie in konfigurierbaren Batches (`matching_worker_batch_size`).
   - Jeder Kandidat wird gescored; alle Treffer oberhalb des Confidence-Thresholds (`matching_confidence_threshold`/`MATCHING_CONFIDENCE_THRESHOLD`) werden als `Match` gespeichert.
-  - Nach jeder Charge entstehen Kennzahlen in der Settings-Tabelle (`metrics.matching.*`) sowie Activity-Einträge (`matching_batch`). Heartbeats stehen in `worker.matching.last_seen`.
+  - Nach jeder Charge entstehen Kennzahlen in der Settings-Tabelle (`metrics.matching.*`) sowie Activity-Einträge (`matching_batch`). Heartbeats stehen in `worker:matching:last_seen`, der Status in `worker:matching:status`.
 - **API-Integration:** Neben den Worker-Jobs kann das Album-Matching (`POST /matching/spotify-to-plex-album?persist=true`) die berechneten Treffer je Track direkt in der `matches`-Tabelle ablegen und dabei die Spotify-Album-ID als Kontext speichern.
 - **Fehlerhandling:**
   - Ungültige Jobs werden mit `invalid_payload` markiert. Laufzeitfehler erzeugen Activity-Logs und setzen den Jobstatus in der DB auf `failed`.
@@ -38,7 +38,7 @@ Alle workerrelevanten Settings werden beim Application-Startup automatisch mit D
 - **Arbeitsweise:**
   - Intervall und Inkrementalscan lassen sich zur Laufzeit über Settings/ENV (`scan_worker_interval_seconds`, `scan_worker_incremental`) steuern.
   - Vor dem Statistikenlesen wird optional ein inkrementeller Plex-Scan per `refresh_library_section` ausgelöst.
-  - Ergebnisse werden als Settings aktualisiert (`plex_*`) und mit Metriken versehen (`metrics.scan.interval`, `metrics.scan.duration_ms`). Heartbeats sowie Start/Stop-Zeitpunkte landen ebenfalls in der Settings-Tabelle.
+  - Ergebnisse werden als Settings aktualisiert (`plex_*`) und mit Metriken versehen (`metrics.scan.interval`, `metrics.scan.duration_ms`). Heartbeats sowie Start/Stop-Zeitpunkte landen ebenfalls in der Settings-Tabelle (`worker:scan:last_seen`, `worker:scan:status`).
 - **Fehlerhandling:**
   - Wiederholte Scan-Fehler werden gezählt; nach drei Versuchen erzeugt der Worker einen Activity-Eintrag `scan_failed`. Netzwerkfehler verhindern keine späteren Läufe.
 - **Activity Feed / Eventtypen:** Meldet über den Typ `metadata` kritische Zustände (`scan_failed`) inklusive Fehlermeldung und Fehlerzähler.
@@ -51,7 +51,7 @@ Alle workerrelevanten Settings werden beim Application-Startup automatisch mit D
   - Artist-Filter greifen weiterhin auf `artist_preferences` zurück. Tracks erhalten Prioritäten (Saved-Tracks/Favoriten, Popularität), womit Downloads bevorzugt nach Wichtigkeit gestartet werden.
   - Qualitätsregeln sind konfigurierbar (`autosync_min_bitrate`, `autosync_preferred_formats`). Nur Kandidaten, die diese Kriterien erfüllen, werden heruntergeladen – anderenfalls entsteht ein Activity-Eintrag `soulseek_low_quality`.
   - Fehlgeschlagene Soulseek-Suchen werden in `auto_sync_skipped_tracks` persistiert. Ab einer konfigurierbaren Anzahl (`skip_threshold`) werden Titel automatisch übersprungen.
-  - Während des Laufs werden Teilfortschritte als Status zusammengefasst (z. B. Spotify ok, Plex ok, Soulseek failed). Metriken (`metrics.autosync.*`) und Heartbeats (`worker.autosync.last_seen`) landen in der Settings-Tabelle.
+  - Während des Laufs werden Teilfortschritte als Status zusammengefasst (z. B. Spotify ok, Plex ok, Soulseek failed). Metriken (`metrics.autosync.*`) sowie Heartbeats (`worker:autosync:last_seen`) und Status (`worker:autosync:status`) landen in der Settings-Tabelle.
 - **Fehlerhandling & Logging:**
   - Spotify/Plex-Ausfälle beenden den Lauf mit `status="partial"`; Soulseek-Probleme werden granular unterschieden (Suchfehler, Qualitätsfilter, Download-/Importfehler) und im Activity Feed protokolliert.
   - Erfolgreiche Downloads löschen den Skip-State, damit spätere Läufe nicht hängen bleiben.
@@ -59,6 +59,11 @@ Alle workerrelevanten Settings werden beim Application-Startup automatisch mit D
 
 ## Zusammenspiel der Worker
 
-- **Heartbeats & Monitoring:** Jeder Worker aktualisiert `worker.<name>.last_seen` sowie Start-/Stop-Timestamps. Ergänzende Kennzahlen (z. B. `metrics.sync.jobs_completed`, `metrics.matching.saved_total`, `metrics.autosync.duration_ms`) dienen als Einstiegspunkt für externe Monitoring-Lösungen.
+- **Heartbeats & Monitoring:** Jeder Worker aktualisiert `worker:<name>:last_seen` und `worker:<name>:status` sowie Start-/Stop-Timestamps. Ergänzende Kennzahlen (z. B. `metrics.sync.jobs_completed`, `metrics.matching.saved_total`, `metrics.autosync.duration_ms`) dienen als Einstiegspunkt für externe Monitoring-Lösungen.
+- **Queue-Transparenz:**
+  - `SyncWorker`: Queue-Größe basiert auf Downloads mit Status `queued` oder `downloading`.
+  - `MatchingWorker`: Zählt Jobs in `worker_jobs` mit Status `queued` oder `running`.
+  - `AutoSyncWorker`: Meldet geplante Zyklen (`scheduled`) und aktuell laufende (`running`).
+  - `ScanWorker` und `PlaylistSyncWorker` liefern `"n/a"`, da keine klassische Queue existiert.
 - **Graceful Restart:** Persistente Job-Queues (`worker_jobs`) gewährleisten, dass laufende Matching-/Sync-Aufgaben bei einem Neustart fortgesetzt werden.
 - **Konfiguration:** Neue Settings erlauben Laufzeit-Tuning ohne Codeänderungen (z. B. Polling-Intervalle, Quality Rules, Confidence-Thresholds). Änderungen greifen unmittelbar bei den nächsten Worker-Zyklen.

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -18,8 +18,9 @@ def test_status_endpoint_reports_workers(client) -> None:
 
     workers = payload["workers"]
     assert isinstance(workers, dict)
-    assert "soulseek_sync" in workers
+    assert "sync" in workers
     assert "matching" in workers
+    assert "scan" in workers
 
 
 def test_system_stats_endpoint_uses_psutil(monkeypatch, client) -> None:

--- a/tests/test_worker_health.py
+++ b/tests/test_worker_health.py
@@ -1,0 +1,60 @@
+from datetime import datetime, timedelta, timezone
+
+from app.utils.settings_store import read_setting, write_setting
+from app.utils.worker_health import (
+    heartbeat_key,
+    mark_worker_status,
+    record_worker_heartbeat,
+    status_key,
+)
+
+
+def test_worker_heartbeat_persists_setting(client) -> None:
+    worker = client.app.state.sync_worker
+    worker._record_heartbeat()
+
+    stored = read_setting(heartbeat_key("sync"))
+    assert stored is not None
+
+
+def test_status_endpoint_reports_worker_health(client) -> None:
+    record_worker_heartbeat("sync")
+    record_worker_heartbeat("matching")
+    mark_worker_status("scan", "running")
+
+    response = client.get("/status")
+    assert response.status_code == 200
+
+    workers = response.json()["workers"]
+
+    sync_info = workers["sync"]
+    assert sync_info["status"] == "running"
+    assert sync_info["queue_size"] == 0
+
+    matching_info = workers["matching"]
+    assert matching_info["status"] == "running"
+    assert matching_info["queue_size"] == 0
+
+    scan_info = workers["scan"]
+    assert scan_info["queue_size"] == "n/a"
+
+
+def test_worker_stop_sets_status_stopped(client) -> None:
+    record_worker_heartbeat("matching")
+    mark_worker_status("matching", "stopped")
+
+    response = client.get("/status")
+    assert response.status_code == 200
+
+    assert response.json()["workers"]["matching"]["status"] == "stopped"
+
+
+def test_worker_without_recent_heartbeat_is_stale(client) -> None:
+    old_timestamp = (datetime.now(timezone.utc) - timedelta(seconds=120)).isoformat()
+    write_setting(heartbeat_key("sync"), old_timestamp)
+    write_setting(status_key("sync"), "running")
+
+    response = client.get("/status")
+    assert response.status_code == 200
+
+    assert response.json()["workers"]["sync"]["status"] == "stale"


### PR DESCRIPTION
## Summary
- track worker heartbeats and status information via shared helper utilities
- extend the /status endpoint to expose worker health, last-seen timestamps, and queue sizes
- cover the behaviour with worker health tests and update API/worker documentation

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d36ad5e6ec8321862deef1e3216976