### PR TITLE
feat: add detailed sync and search activity events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Alle Änderungen an diesem Projekt werden in diesem Dokument festgehalten. Diese
 
 ## [Unreleased]
 ### Added
+- Added detailed Sync/Search events to Activity Feed.
 - Frontend: Added Worker Health cards to Dashboard.
 - Added worker health info (heartbeats + queue size) to `/status`.
 - Added automatic defaults for worker-related settings at startup.

--- a/ToDo.md
+++ b/ToDo.md
@@ -10,6 +10,7 @@
 - [x] Dashboard-Widget für aktive Downloads ergänzen.
 - [x] Dashboard-DownloadWidget auf limitierte `/api/downloads`-Abfrage umstellen.
 - [x] Activity-Feed-Widget im Dashboard mit Polling, Sortierung und Status-Badges finalisieren.
+- [x] Activity Feed um detaillierte Sync- und Search-Events erweitern.
 - [x] Cancel-/Retry-Buttons im Frontend (DownloadsPage & DownloadWidget) inkl. Tests & Dokumentation ergänzen.
 - [x] AutoSyncWorker für Spotify↔Plex implementieren, Soulseek/Beets-Anbindung ergänzen und Dokumentation aktualisieren.
 - [x] Artist-Konfiguration für Spotify-Releases (API, DB, AutoSync) umsetzen.

--- a/docs/api.md
+++ b/docs/api.md
@@ -104,6 +104,21 @@ Event-Felder:
 - `status` (Status des Events, z. B. `completed`, `failed`, `queued`)
 - `details` (optional, JSON-Objekt mit Zusatzinformationen)
 
+### Detaillierte Sync-/Search-Events
+
+| Status | Beschreibung | Beispiel-Details |
+| --- | --- | --- |
+| `sync_started` | Beginn eines manuellen oder automatischen Sync-Laufs inkl. Quellen. | `{"mode": "manual", "sources": ["spotify", "plex", "soulseek"]}` |
+| `sync_completed` | Abschluss eines Sync-Laufs mit Zählerwerten. | `{"trigger": "scheduled", "sources": ["spotify", "plex", "soulseek", "beets"], "counters": {"tracks_synced": 12, "tracks_skipped": 2, "errors": 1}}` |
+| `sync_partial` | Teil-Erfolg bei Sync, enthält Fehlerliste (z. B. pro Quelle). | `{"trigger": "scheduled", "errors": [{"source": "plex", "message": "plex offline"}]}` |
+| `spotify_loaded` | Spotify-Daten für AutoSync geladen (Playlists/Saved Tracks). | `{"trigger": "scheduled", "playlists": 4, "tracks": 250, "saved_tracks": 40}` |
+| `plex_checked` | Plex-Bibliothek untersucht, Anzahl bekannter Tracks. | `{"trigger": "scheduled", "tracks": 230}` |
+| `downloads_requested` | Anzahl fehlender Titel, die Soulseek/Downloads benötigen. | `{"trigger": "scheduled", "count": 18}` |
+| `beets_imported` | Ergebnis der Beets-Imports inkl. Erfolgs-/Fehleranzahl. | `{"trigger": "scheduled", "imported": 10, "skipped": 3, "errors": ["quality"]}` |
+| `search_started` | Start einer plattformübergreifenden Suche mit Quellen. | `{"query": "Boards of Canada", "sources": ["spotify", "plex"]}` |
+| `search_completed` | Trefferanzahl pro Quelle nach erfolgreicher Suche. | `{"query": "Boards of Canada", "matches": {"spotify": 9, "plex": 2}}` |
+| `search_failed` | Aufgetretene Fehler während der Suche. | `{"query": "Boards", "errors": [{"source": "plex", "message": "plex offline"}]}` |
+
 **Beispiel:**
 
 ```http

--- a/docs/workers.md
+++ b/docs/workers.md
@@ -55,7 +55,7 @@ Alle workerrelevanten Settings werden beim Application-Startup automatisch mit D
 - **Fehlerhandling & Logging:**
   - Spotify/Plex-Ausfälle beenden den Lauf mit `status="partial"`; Soulseek-Probleme werden granular unterschieden (Suchfehler, Qualitätsfilter, Download-/Importfehler) und im Activity Feed protokolliert.
   - Erfolgreiche Downloads löschen den Skip-State, damit spätere Läufe nicht hängen bleiben.
-- **Activity Feed / Eventtypen:** Schreibt ausführliche `sync`-Events wie `autosync_started`, `spotify_loaded`, `downloads_requested`, `partial` oder `completed` samt Kontext (`source`, `count`, `missing`). Ergänzende Details dokumentieren Plex-Updates (`plex_updated`) und Soulseek-/Beets-Ergebnisse.
+- **Activity Feed / Eventtypen:** Dokumentiert jeden Lauf mit `sync_started` → `sync_completed` (inkl. `counters` für synchronisierte/übersprungene Tracks). Zwischenstände kommen als `spotify_loaded`, `plex_checked`, `downloads_requested` und `beets_imported`. Bei Fehlern erscheint zusätzlich `sync_partial` mit Fehlerliste; Soulseek-/Plex-Sonderfälle werden weiterhin separat geloggt (`soulseek_no_results`, `plex_update_failed`, ...).
 
 ## Zusammenspiel der Worker
 

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+import importlib
+
+from app.utils.activity import activity_manager
+
+
+def test_search_records_activity_success(client) -> None:
+    response = client.post("/api/search", json={"query": "Test"})
+    assert response.status_code == 200
+
+    entries = activity_manager.list()
+    statuses = [entry["status"] for entry in entries]
+    assert "search_started" in statuses
+    assert "search_completed" in statuses
+
+    started = next(entry for entry in entries if entry["status"] == "search_started")
+    assert started["details"]["query"] == "Test"
+    assert set(started["details"]["sources"]) == {"spotify", "plex", "soulseek"}
+
+    completed = next(entry for entry in entries if entry["status"] == "search_completed")
+    matches = completed["details"]["matches"]
+    assert set(matches.keys()) == {"spotify", "plex", "soulseek"}
+    assert all(isinstance(count, int) for count in matches.values())
+
+
+def test_search_records_activity_failure(monkeypatch, client) -> None:
+    def _raise_plex_error():
+        raise RuntimeError("plex offline")
+
+    deps = importlib.import_module("app.dependencies")
+    monkeypatch.setattr(deps, "get_plex_client", _raise_plex_error)
+
+    response = client.post("/api/search", json={"query": "Test", "sources": ["plex"]})
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload.get("errors", {}).get("plex") == "Plex client unavailable"
+
+    entries = activity_manager.list()
+    statuses = [entry["status"] for entry in entries]
+    assert statuses.count("search_started") == 1
+    assert "search_completed" in statuses
+    assert "search_failed" in statuses
+
+    failed = next(entry for entry in entries if entry["status"] == "search_failed")
+    errors = failed["details"]["errors"]
+    assert errors
+    assert any(item.get("source") == "plex" for item in errors)


### PR DESCRIPTION
## Summary
- emit structured `sync_*` and search events with JSON-safe detail payloads via the activity manager and REST endpoints
- add per-phase AutoSyncWorker logging (Spotify/Plex/download/import) including aggregate counters
- document and test the new sync/search activity events across manual sync, autosync, and search APIs

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d37814b7188321abc75c2c3fa11531