### PR TITLE
feat: add activity history api and ui

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Alle Änderungen an diesem Projekt werden in diesem Dokument festgehalten. Diese
 - Added worker health info (heartbeats + queue size) to `/status`.
 - Added automatic defaults for worker-related settings at startup.
 - Added persistent Activity Feed with flexible event types.
+- Added persistent Activity History with paging & filters.
+- Frontend: Added Activity History page with paging and filters.
 - Frontend: Cancel-/Retry-Buttons für Downloads (Downloads-Seite & Dashboard-Widget).
 - Added cancel and retry endpoints for downloads via slskd TransfersApi.
 - Added limit/offset support to GET /api/downloads.

--- a/ToDo.md
+++ b/ToDo.md
@@ -13,6 +13,8 @@
 - [x] Frontend: ActivityFeed-Widget zeigt detaillierte Sync- und Search-Events mit Quellen & Kennzahlen an.
 - [x] Worker-Health-Events im Activity Feed persistieren und dokumentieren.
 - [x] Frontend: ActivityFeed-Widget visualisiert Worker-Events mit Icons und Health-Farben.
+- [x] Persistente Activity History mit Paging- und Filter-Endpunkt bereitstellen.
+- [x] Frontend: Activity-History-Seite mit Tabelle, Paging und Filtern ergänzen.
 - [x] Cancel-/Retry-Buttons im Frontend (DownloadsPage & DownloadWidget) inkl. Tests & Dokumentation ergänzen.
 - [x] AutoSyncWorker für Spotify↔Plex implementieren, Soulseek/Beets-Anbindung ergänzen und Dokumentation aktualisieren.
 - [x] Artist-Konfiguration für Spotify-Releases (API, DB, AutoSync) umsetzen.

--- a/docs/api.md
+++ b/docs/api.md
@@ -88,14 +88,27 @@ POST /api/metadata/update HTTP/1.1
 | `POST` | `/api/download` | Persistiert Downloads und übergibt sie an den Soulseek-Worker. |
 | `DELETE` | `/api/download/{id}` | Bricht einen laufenden Download ab und markiert ihn als `cancelled`. |
 | `POST` | `/api/download/{id}/retry` | Startet einen neuen Transfer für fehlgeschlagene oder abgebrochene Downloads. |
-| `GET` | `/api/activity` | Liefert den persistenten Aktivitätsfeed (default 50 Einträge, mit `limit`/`offset`). |
+| `GET` | `/api/activity` | Liefert die persistente Activity History (Paging + Filter). |
 
-**Activity Feed:**
+**Activity Feed / Activity History:**
 
 Unterstützte Query-Parameter:
 
-- `limit` (Default `50`, Maximum `500`): Anzahl der zurückgegebenen Events.
+- `limit` (Default `50`, Maximum `200`): Anzahl der zurückgegebenen Events pro Seite.
 - `offset` (Default `0`): Startindex für Paging.
+- `type` (optional): Filtert nach Eventtyp (`sync`, `download`, `search`, `metadata`, `worker`).
+- `status` (optional): Filtert nach Statuswert (z. B. `ok`, `failed`, `partial`).
+
+Antwortstruktur:
+
+```json
+{
+  "items": [
+    {"timestamp": "2025-03-18T12:15:00Z", "type": "sync", "status": "completed", "details": {"runs": 2}}
+  ],
+  "total_count": 128
+}
+```
 
 Event-Felder:
 
@@ -198,6 +211,24 @@ Event-Felder:
 ![Activity-Feed-Widget](activity-feed-widget.svg)
 
 Das Dashboard zeigt Worker-Events mit farbcodierten Status-Badges (grün = started, grau = stopped, gelb = stale, blau = restarted) und passenden Icons (▶️, ⏹, ⚠️, 🔄). Dadurch lassen sich Health-Änderungen der Worker sofort nachvollziehen.
+
+**Activity-History-Seite (Frontend-Beispiel):**
+
+```text
+┌────────────────────────────────────────────────────────────┐
+│ Activity History                                           │
+│ Typ: [Alle Typen v]  Status: [Alle Stati v]                │
+│ ---------------------------------------------------------- │
+│ Timestamp           │ Typ      │ Status   │ Details        │
+│ 18.03.2025 13:15:42 │ sync     │ completed│ {"runs": 2}    │
+│ 18.03.2025 13:14:10 │ download │ failed   │ {"id": 42}    │
+│ 18.03.2025 13:13:01 │ worker   │ started  │ {"worker":"sync"}
+│ ...                                                      │
+│ Seite 1 von 7  [Zurück] [Weiter]                          │
+└────────────────────────────────────────────────────────────┘
+```
+
+Die dedizierte Seite nutzt dieselben Events aus `/api/activity`, zeigt jedoch die vollständige History mit Paging, Dropdown-Filtern und JSON-Details in einer Tabelle an.
 
 Neben diesen Health-Meldungen visualisiert das Dashboard weiterhin Quellen, Kennzahlen (z. B. `tracks_synced`) sowie Trefferzahlen pro Quelle direkt im ActivityFeed-Widget. Fehlerlisten werden rot markiert und als Tooltip hinterlegt.
 

--- a/docs/workers.md
+++ b/docs/workers.md
@@ -1,6 +1,6 @@
 # Hintergrund-Worker
 
-Harmony startet beim FastAPI-Startup mehrere Hintergrundprozesse, um langlaufende Aufgaben außerhalb des Request-Kontexts zu bearbeiten. Die Worker verwenden asynchrone Tasks (`asyncio`) und greifen über `session_scope()` auf die Datenbank zu.
+Harmony startet beim FastAPI-Startup mehrere Hintergrundprozesse, um langlaufende Aufgaben außerhalb des Request-Kontexts zu bearbeiten. Die Worker verwenden asynchrone Tasks (`asyncio`) und greifen über `session_scope()` auf die Datenbank zu. Sämtliche Worker schreiben ihre Status- und Fortschrittsmeldungen als persistente Events in die Tabelle `activity_events`, sodass die Activity History auch nach Neustarts vollständig nachvollzogen werden kann.
 
 Alle workerrelevanten Settings werden beim Application-Startup automatisch mit Default-Werten befüllt (`sync_worker_concurrency`, `matching_worker_batch_size`, `autosync_min_bitrate`, `autosync_preferred_formats`). Dadurch stehen sinnvolle Parameter bereit, selbst wenn noch keine manuelle Konfiguration stattgefunden hat.
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -11,6 +11,7 @@ import DownloadsPage from './pages/DownloadsPage';
 import { ThemeProvider } from './components/theme-provider';
 import ToastProvider from './components/ToastProvider';
 import ArtistsPage from './pages/ArtistsPage';
+import ActivityHistoryPage from './pages/ActivityHistoryPage';
 
 const App = () => (
   <ThemeProvider>
@@ -24,6 +25,7 @@ const App = () => (
           <Route path="/plex" element={<PlexPage />} />
           <Route path="/soulseek" element={<SoulseekPage />} />
           <Route path="/downloads" element={<DownloadsPage />} />
+          <Route path="/activity" element={<ActivityHistoryPage />} />
           <Route path="/beets" element={<BeetsPage />} />
           <Route path="/matching" element={<MatchingPage />} />
           <Route path="/settings" element={<SettingsPage />} />

--- a/frontend/src/__tests__/ActivityHistoryPage.test.tsx
+++ b/frontend/src/__tests__/ActivityHistoryPage.test.tsx
@@ -1,0 +1,93 @@
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ActivityHistoryPage from '../pages/ActivityHistoryPage';
+import { renderWithProviders } from '../test-utils';
+import { fetchActivityHistory } from '../lib/api';
+
+jest.mock('../lib/api', () => ({
+  ...jest.requireActual('../lib/api'),
+  fetchActivityHistory: jest.fn()
+}));
+
+const mockedFetchActivityHistory = fetchActivityHistory as jest.MockedFunction<typeof fetchActivityHistory>;
+
+describe('ActivityHistoryPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders activity entries and supports pagination', async () => {
+    mockedFetchActivityHistory
+      .mockResolvedValueOnce({
+        items: [
+          { timestamp: '2024-03-18T12:00:00Z', type: 'sync', status: 'completed', details: { runs: 2 } },
+          { timestamp: '2024-03-18T11:55:00Z', type: 'download', status: 'ok', details: { id: 42 } }
+        ],
+        total_count: 45
+      })
+      .mockResolvedValueOnce({
+        items: [
+          { timestamp: '2024-03-18T11:50:00Z', type: 'worker', status: 'started', details: { worker: 'sync' } }
+        ],
+        total_count: 45
+      });
+
+    const user = userEvent.setup();
+    renderWithProviders(<ActivityHistoryPage />);
+
+    await waitFor(() => expect(mockedFetchActivityHistory).toHaveBeenCalledTimes(1));
+    expect(mockedFetchActivityHistory).toHaveBeenCalledWith(20, 0, undefined, undefined);
+    expect(await screen.findByText('sync')).toBeInTheDocument();
+
+    const nextButton = screen.getByRole('button', { name: 'Weiter' });
+    await user.click(nextButton);
+
+    await waitFor(() => expect(mockedFetchActivityHistory).toHaveBeenCalledTimes(2));
+    expect(mockedFetchActivityHistory).toHaveBeenLastCalledWith(20, 20, undefined, undefined);
+    await waitFor(() => expect(screen.getByText('worker')).toBeInTheDocument());
+  });
+
+  it('applies type and status filters', async () => {
+    mockedFetchActivityHistory
+      .mockResolvedValueOnce({
+        items: [
+          { timestamp: '2024-03-18T12:00:00Z', type: 'sync', status: 'completed' },
+          { timestamp: '2024-03-18T11:59:00Z', type: 'download', status: 'failed' }
+        ],
+        total_count: 2
+      })
+      .mockResolvedValueOnce({
+        items: [{ timestamp: '2024-03-18T11:58:00Z', type: 'download', status: 'failed' }],
+        total_count: 1
+      })
+      .mockResolvedValueOnce({
+        items: [{ timestamp: '2024-03-18T11:57:00Z', type: 'download', status: 'failed' }],
+        total_count: 1
+      });
+
+    const user = userEvent.setup();
+    renderWithProviders(<ActivityHistoryPage />);
+
+    const typeSelect = await screen.findByLabelText('Activity-Typ filtern');
+    await user.selectOptions(typeSelect, 'download');
+    await waitFor(() => expect(mockedFetchActivityHistory).toHaveBeenLastCalledWith(20, 0, 'download', undefined));
+
+    const statusSelect = screen.getByLabelText('Activity-Status filtern');
+    await user.selectOptions(statusSelect, 'failed');
+    await waitFor(() => expect(mockedFetchActivityHistory).toHaveBeenLastCalledWith(20, 0, 'download', 'failed'));
+    expect(await screen.findAllByText('download')).toHaveLength(1);
+  });
+
+  it('shows toast and inline message on error', async () => {
+    const toastMock = jest.fn();
+    mockedFetchActivityHistory.mockRejectedValue(new Error('network error'));
+
+    renderWithProviders(<ActivityHistoryPage />, { toastFn: toastMock });
+
+    await waitFor(() => expect(toastMock).toHaveBeenCalled());
+    expect(toastMock).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'Activity History nicht erreichbar' })
+    );
+    expect(await screen.findByText('Die Activity History konnte nicht geladen werden.')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -7,6 +7,7 @@ import {
   Disc,
   Download,
   ListMusic,
+  History,
   Menu,
   Moon,
   Music,
@@ -33,6 +34,7 @@ const navItems = [
   { to: '/plex', label: 'Plex', icon: Disc },
   { to: '/soulseek', label: 'Soulseek', icon: Radio },
   { to: '/downloads', label: 'Downloads', icon: Download },
+  { to: '/activity', label: 'Activity History', icon: History },
   { to: '/beets', label: 'Beets', icon: ListMusic },
   { to: '/matching', label: 'Matching', icon: ChevronRight },
   { to: '/settings', label: 'Settings', icon: Settings }

--- a/frontend/src/components/ui/select.tsx
+++ b/frontend/src/components/ui/select.tsx
@@ -1,0 +1,21 @@
+import { forwardRef } from 'react';
+import { cn } from '../../lib/utils';
+
+export interface SelectProps extends React.SelectHTMLAttributes<HTMLSelectElement> {}
+
+export const Select = forwardRef<HTMLSelectElement, SelectProps>(({ className, children, ...props }, ref) => (
+  <select
+    ref={ref}
+    className={cn(
+      'flex h-9 w-full appearance-none rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background transition-colors placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
+      className
+    )}
+    {...props}
+  >
+    {children}
+  </select>
+));
+
+Select.displayName = 'Select';
+
+export default Select;

--- a/frontend/src/pages/ActivityHistoryPage.tsx
+++ b/frontend/src/pages/ActivityHistoryPage.tsx
@@ -1,0 +1,192 @@
+import { useCallback, useMemo, useState } from 'react';
+import { Loader2 } from 'lucide-react';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../components/ui/card';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../components/ui/table';
+import { Button } from '../components/ui/button';
+import Select from '../components/ui/select';
+import { ActivityHistoryResponse, fetchActivityHistory } from '../lib/api';
+import { useQuery } from '../lib/query';
+import { useToast } from '../hooks/useToast';
+
+const PAGE_SIZE = 20;
+
+const typeOptions = [
+  { value: 'all', label: 'Alle Typen' },
+  { value: 'sync', label: 'Sync' },
+  { value: 'download', label: 'Download' },
+  { value: 'search', label: 'Suche' },
+  { value: 'metadata', label: 'Metadaten' },
+  { value: 'worker', label: 'Worker' }
+] as const;
+
+const statusOptions = [
+  { value: 'all', label: 'Alle Stati' },
+  { value: 'ok', label: 'OK' },
+  { value: 'failed', label: 'Fehlgeschlagen' },
+  { value: 'partial', label: 'Teilweise' }
+] as const;
+
+const ActivityHistoryPage = () => {
+  const { toast } = useToast();
+  const [offset, setOffset] = useState(0);
+  const [typeFilter, setTypeFilter] = useState<string | null>(null);
+  const [statusFilter, setStatusFilter] = useState<string | null>(null);
+
+  const queryFn = useCallback(
+    () => fetchActivityHistory(PAGE_SIZE, offset, typeFilter ?? undefined, statusFilter ?? undefined),
+    [offset, statusFilter, typeFilter]
+  );
+
+  const { data, isLoading, isError } = useQuery<ActivityHistoryResponse>({
+    queryKey: ['activity-history', PAGE_SIZE, offset, typeFilter ?? 'all', statusFilter ?? 'all'],
+    queryFn,
+    onError: () =>
+      toast({
+        title: 'Activity History nicht erreichbar',
+        description: 'Bitte Backend-Logs prüfen.',
+        variant: 'destructive'
+      })
+  });
+
+  const items = data?.items ?? [];
+  const totalCount = data?.total_count ?? 0;
+
+  const canGoBack = offset > 0;
+  const canGoForward = offset + PAGE_SIZE < totalCount;
+
+  const currentPage = Math.floor(offset / PAGE_SIZE) + 1;
+  const totalPages = totalCount === 0 ? 1 : Math.ceil(totalCount / PAGE_SIZE);
+
+  const dateFormatter = useMemo(
+    () =>
+      new Intl.DateTimeFormat(undefined, {
+        dateStyle: 'short',
+        timeStyle: 'medium'
+      }),
+    []
+  );
+
+  const handleNext = () => {
+    if (canGoForward) {
+      setOffset((value) => value + PAGE_SIZE);
+    }
+  };
+
+  const handlePrev = () => {
+    if (canGoBack) {
+      setOffset((value) => Math.max(0, value - PAGE_SIZE));
+    }
+  };
+
+  const handleTypeChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    const value = event.target.value;
+    setOffset(0);
+    setTypeFilter(value === 'all' ? null : value);
+  };
+
+  const handleStatusChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    const value = event.target.value;
+    setOffset(0);
+    setStatusFilter(value === 'all' ? null : value);
+  };
+
+  return (
+    <div className="space-y-6">
+      <Card>
+        <CardHeader>
+          <CardTitle>Activity History</CardTitle>
+          <CardDescription>
+            Persistente Ereignisliste mit Paging und Filtern. Insgesamt {totalCount} Einträge gespeichert.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+            <label className="flex flex-col gap-2 text-sm font-medium">
+              Typ
+              <Select value={typeFilter ?? 'all'} onChange={handleTypeChange} aria-label="Activity-Typ filtern">
+                {typeOptions.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </Select>
+            </label>
+            <label className="flex flex-col gap-2 text-sm font-medium">
+              Status
+              <Select value={statusFilter ?? 'all'} onChange={handleStatusChange} aria-label="Activity-Status filtern">
+                {statusOptions.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </Select>
+            </label>
+          </div>
+
+          <div className="overflow-hidden rounded-lg border">
+            {isLoading ? (
+              <div className="flex items-center justify-center py-10 text-muted-foreground">
+                <Loader2 className="h-5 w-5 animate-spin" aria-label="Lade Activity History" />
+              </div>
+            ) : isError ? (
+              <div className="py-10 text-center text-sm text-destructive">
+                Die Activity History konnte nicht geladen werden.
+              </div>
+            ) : items.length === 0 ? (
+              <div className="py-10 text-center text-sm text-muted-foreground">Keine Events gefunden.</div>
+            ) : (
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Timestamp</TableHead>
+                    <TableHead>Typ</TableHead>
+                    <TableHead>Status</TableHead>
+                    <TableHead>Details</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {items.map((entry) => (
+                    <TableRow key={`${entry.timestamp}-${entry.type}-${entry.status}`}>
+                      <TableCell>{dateFormatter.format(new Date(entry.timestamp))}</TableCell>
+                      <TableCell className="font-medium">{entry.type}</TableCell>
+                      <TableCell>
+                        <span className="inline-flex rounded-full bg-muted px-2 py-1 text-xs font-semibold uppercase tracking-wide">
+                          {entry.status}
+                        </span>
+                      </TableCell>
+                      <TableCell>
+                        {entry.details ? (
+                          <pre className="max-h-48 overflow-auto whitespace-pre-wrap break-words text-xs text-muted-foreground">
+                            {JSON.stringify(entry.details, null, 2)}
+                          </pre>
+                        ) : (
+                          <span className="text-xs text-muted-foreground">—</span>
+                        )}
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            )}
+          </div>
+
+          <div className="flex flex-col items-center justify-between gap-3 border-t pt-4 text-sm text-muted-foreground sm:flex-row">
+            <div>
+              Seite {currentPage} von {totalPages}
+            </div>
+            <div className="flex items-center gap-2">
+              <Button variant="outline" size="sm" onClick={handlePrev} disabled={!canGoBack}>
+                Zurück
+              </Button>
+              <Button variant="outline" size="sm" onClick={handleNext} disabled={!canGoForward}>
+                Weiter
+              </Button>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export default ActivityHistoryPage;

--- a/tests/test_activity.py
+++ b/tests/test_activity.py
@@ -10,7 +10,9 @@ def test_activity_endpoint_returns_latest_entries(client) -> None:
     response = client.get("/api/activity")
     assert response.status_code == 200
 
-    entries = response.json()
+    payload = response.json()
+    entries = payload["items"]
+    assert payload["total_count"] == 2
     assert isinstance(entries, list)
     assert len(entries) == 2
     assert entries[0]["type"] == "search"
@@ -25,7 +27,9 @@ def test_activity_endpoint_limits_to_fifty_entries(client) -> None:
     response = client.get("/api/activity")
     assert response.status_code == 200
 
-    entries = response.json()
+    payload = response.json()
+    entries = payload["items"]
+    assert payload["total_count"] == 60
     assert len(entries) == 50
     assert entries[0]["details"]["index"] == 59
     assert entries[-1]["details"]["index"] == 10

--- a/tests/test_activity_history.py
+++ b/tests/test_activity_history.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from app.utils import activity_manager, record_activity
+
+
+def test_activity_history_paging_and_total_count(client) -> None:
+    activity_manager.clear()
+    for index in range(5):
+        record_activity("download", "queued", details={"index": index})
+
+    first_page = client.get("/api/activity", params={"limit": 2, "offset": 0})
+    assert first_page.status_code == 200
+    payload = first_page.json()
+    assert payload["total_count"] == 5
+    assert [entry["details"]["index"] for entry in payload["items"]] == [4, 3]
+
+    second_page = client.get("/api/activity", params={"limit": 2, "offset": 2})
+    assert second_page.status_code == 200
+    payload_next = second_page.json()
+    assert payload_next["total_count"] == 5
+    assert [entry["details"]["index"] for entry in payload_next["items"]] == [2, 1]
+
+    last_page = client.get("/api/activity", params={"limit": 2, "offset": 4})
+    assert last_page.status_code == 200
+    payload_last = last_page.json()
+    assert payload_last["total_count"] == 5
+    assert [entry["details"]["index"] for entry in payload_last["items"]] == [0]
+
+
+def test_activity_history_filtering(client) -> None:
+    activity_manager.clear()
+    record_activity("sync", "ok")
+    record_activity("download", "failed")
+    record_activity("search", "failed")
+    record_activity("download", "ok")
+
+    downloads = client.get("/api/activity", params={"type": "download"})
+    assert downloads.status_code == 200
+    download_items = downloads.json()["items"]
+    assert len(download_items) == 2
+    assert all(entry["type"] == "download" for entry in download_items)
+
+    failed = client.get("/api/activity", params={"status": "failed"})
+    assert failed.status_code == 200
+    failed_items = failed.json()["items"]
+    assert len(failed_items) == 2
+    assert all(entry["status"] == "failed" for entry in failed_items)
+
+    failed_downloads = client.get(
+        "/api/activity",
+        params={"type": "download", "status": "failed"},
+    )
+    assert failed_downloads.status_code == 200
+    combination = failed_downloads.json()["items"]
+    assert len(combination) == 1
+    assert combination[0]["type"] == "download"
+    assert combination[0]["status"] == "failed"
+
+
+def test_activity_history_persists_after_cache_clear(client) -> None:
+    activity_manager.clear()
+    record_activity("metadata", "partial", details={"batch": 1})
+
+    # Simulate application restart by clearing the in-memory cache only
+    activity_manager.clear()
+
+    response = client.get("/api/activity")
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["total_count"] == 1
+    assert payload["items"][0]["type"] == "metadata"
+    assert payload["items"][0]["status"] == "partial"

--- a/tests/test_activity_persistence.py
+++ b/tests/test_activity_persistence.py
@@ -36,11 +36,13 @@ def test_activity_endpoint_supports_paging(client) -> None:
     response = client.get("/api/activity", params={"limit": 10, "offset": 5})
     assert response.status_code == 200
 
-    entries = response.json()
+    payload = response.json()
+    entries = payload["items"]
+    assert payload["total_count"] == 30
     assert len(entries) == 10
 
     returned_indices = [entry["details"]["index"] for entry in entries]
-    expected_indices = list(range(30 - 5 - 1, 30 - 5 - 10 - 1, -1))
+    expected_indices = list(range(29 - 5, 29 - 5 - 10, -1))
     assert returned_indices == expected_indices
 
 
@@ -50,7 +52,9 @@ def test_activity_accepts_flexible_types(client) -> None:
     response = client.get("/api/activity")
     assert response.status_code == 200
 
-    entries = response.json()
+    payload = response.json()
+    entries = payload["items"]
+    assert payload["total_count"] >= 1
     assert entries
     assert entries[0]["type"] == "autosync"
     assert entries[0]["details"]["source"] == "playlist"


### PR DESCRIPTION
## Summary
- extend the activity API with paging, filtering and total counts backed by the database
- cover the new behaviour with backend tests, documentation updates and changelog/todo entries
- implement an Activity History page in the frontend with pagination, filters, API client support and unit tests

## Testing
- pytest
- npm run build
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d3e995ab5083218fdefd04c2269623