### PR TITLE
feat: improve download flow with retries, priorities and export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Alle Änderungen an diesem Projekt werden in diesem Dokument festgehalten. Diese
 
 ## [Unreleased]
 ### Added
+- Improved Download Flow (auto-retry, priority queueing, status filters).
+- Added download export endpoint (CSV/JSON) with filters.
+- Frontend: Enhanced DownloadsPage with filters, priority controls and export buttons.
+- Frontend: Download widget now shows priorities and only active transfers.
 - Added Activity History export (CSV/JSON).
 - Frontend: Added export for Activity History.
 - Added worker health events (started/stopped/stale/restarted) to the Activity Feed.
@@ -30,7 +34,7 @@ Alle Änderungen an diesem Projekt werden in diesem Dokument festgehalten. Diese
 - Added optional persistence for album matching (`persist=true` on `/matching/spotify-to-plex-album`).
 
 ### Changed
-- Frontend: DownloadWidget uses limit param of /api/downloads.
+- Download widgets filter out completed/cancelled items and expose priority labels.
 - Frontend: DownloadsPage nutzt jetzt `GET /api/downloads` für die Download-Übersicht.
 - Dashboard-Aktivitätsfeed mit lokalisierten Typen, sortierten Einträgen und farbcodierten Status-Badges verfeinert.
 - AutoSyncWorker filtert Spotify-Tracks anhand gespeicherter Artist-Präferenzen.

--- a/app/models.py
+++ b/app/models.py
@@ -43,6 +43,7 @@ class Download(Base):
     filename = Column(String(1024), nullable=False)
     state = Column(String(50), nullable=False, default="queued")
     progress = Column(Float, nullable=False, default=0.0)
+    priority = Column(Integer, nullable=False, default=0)
     username = Column(String(255), nullable=True)
     request_payload = Column(JSON, nullable=True)
     created_at = Column(DateTime, default=datetime.utcnow, nullable=False)

--- a/app/routers/download_router.py
+++ b/app/routers/download_router.py
@@ -1,10 +1,14 @@
 """Download management endpoints for Harmony."""
 from __future__ import annotations
 
-from datetime import datetime
-from typing import Any, Dict, List
+import csv
+import io
+import json
+from datetime import datetime, timezone
+from typing import Any, Dict, Iterable, List, MutableMapping, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
+from fastapi.responses import Response
 from sqlalchemy.orm import Session
 
 from app.core.transfers_api import TransfersApi, TransfersApiError
@@ -14,6 +18,7 @@ from app.models import Download
 from app.schemas import (
     DownloadEntryResponse,
     DownloadListResponse,
+    DownloadPriorityUpdate,
     SoulseekDownloadRequest,
 )
 from app.utils.activity import record_activity
@@ -22,23 +27,165 @@ router = APIRouter(prefix="/api", tags=["Download"])
 logger = get_logger(__name__)
 
 
+STATUS_FILTERS: Dict[str, set[str]] = {
+    "running": {"running", "downloading"},
+    "queued": {"queued"},
+    "completed": {"completed"},
+    "failed": {"failed"},
+    "cancelled": {"cancelled"},
+}
+
+ACTIVE_STATES = STATUS_FILTERS["running"] | STATUS_FILTERS["queued"]
+
+
+def _normalise_status(value: str) -> str:
+    return value.strip().lower()
+
+
+def _resolve_status_filter(value: str) -> set[str]:
+    normalised = _normalise_status(value)
+    states = STATUS_FILTERS.get(normalised)
+    if states is None:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="Invalid status filter",
+        )
+    return states
+
+
+def _parse_iso8601(value: str) -> datetime:
+    candidate = value.strip()
+    if candidate.endswith("Z"):
+        candidate = candidate[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(candidate)
+    except ValueError as exc:  # pragma: no cover - defensive validation
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="Invalid datetime parameter",
+        ) from exc
+    if parsed.tzinfo is not None:
+        parsed = parsed.astimezone(timezone.utc).replace(tzinfo=None)
+    return parsed
+
+
+def _build_download_query(
+    session: Session,
+    *,
+    include_all: bool,
+    status_filter: Optional[str] = None,
+    created_from: Optional[datetime] = None,
+    created_to: Optional[datetime] = None,
+) -> Any:
+    query = session.query(Download)
+    if status_filter:
+        states = _resolve_status_filter(status_filter)
+        query = query.filter(Download.state.in_(tuple(states)))
+    elif not include_all:
+        query = query.filter(Download.state.in_(tuple(ACTIVE_STATES)))
+
+    if created_from:
+        query = query.filter(Download.created_at >= created_from)
+    if created_to:
+        query = query.filter(Download.created_at <= created_to)
+
+    return query.order_by(Download.priority.desc(), Download.created_at.desc())
+
+
+def _coerce_int(value: Any) -> Optional[int]:
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, (int, float)):
+        return int(value)
+    if isinstance(value, str):
+        try:
+            return int(value.strip())
+        except ValueError:
+            return None
+    return None
+
+
+def _is_truthy(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return value != 0
+    if isinstance(value, str):
+        normalised = value.strip().lower()
+        return normalised in {"1", "true", "yes", "y"}
+    return False
+
+
+def _determine_priority(file_info: MutableMapping[str, Any]) -> int:
+    explicit = _coerce_int(file_info.get("priority"))
+    if explicit is not None:
+        return explicit
+
+    favorite_keys = (
+        "is_favorite",
+        "favorite",
+        "liked",
+        "is_saved_track",
+        "spotify_saved",
+        "spotify_like",
+    )
+    if any(_is_truthy(file_info.get(key)) for key in favorite_keys):
+        return 10
+
+    source = str(file_info.get("source") or "").lower()
+    if source in {"spotify_likes", "spotify_saved", "favorites"}:
+        return 10
+
+    return 0
+
+
+def _serialise_download(download: Download) -> Dict[str, Any]:
+    response = DownloadEntryResponse.model_validate(download).model_dump()
+    response["username"] = download.username
+    response["priority"] = download.priority
+    created_at = download.created_at
+    updated_at = download.updated_at
+    response["created_at"] = created_at.isoformat() if created_at else None
+    response["updated_at"] = updated_at.isoformat() if updated_at else None
+    return response
+
+
+CSV_HEADERS = [
+    "id",
+    "filename",
+    "status",
+    "progress",
+    "username",
+    "created_at",
+    "updated_at",
+]
+
+
 @router.get("/downloads", response_model=DownloadListResponse)
 def list_downloads(
     limit: int = Query(20, ge=1, le=100),
     offset: int = Query(0, ge=0),
     all: bool = False,  # noqa: A002 - query parameter name mandated by API contract
+    status_filter: Optional[str] = Query(None, alias="status"),
     session: Session = Depends(get_db),
 ) -> DownloadListResponse:
-    """Return downloads, optionally including completed or failed entries."""
+    """Return downloads with optional status filtering."""
 
-    logger.info("Download list requested (all=%s, limit=%s, offset=%s)", all, limit, offset)
+    status_label = status_filter.strip() if status_filter else None
+    logger.info(
+        "Download list requested (all=%s, status=%s, limit=%s, offset=%s)",
+        all,
+        status_label,
+        limit,
+        offset,
+    )
     try:
-        query = session.query(Download)
-        if not all:
-            query = query.filter(Download.state.in_(("queued", "running")))
-        downloads = (
-            query.order_by(Download.created_at.desc()).offset(offset).limit(limit).all()
+        query = _build_download_query(
+            session,
+            include_all=all,
+            status_filter=status_label,
         )
+        downloads = query.offset(offset).limit(limit).all()
     except HTTPException:
         raise
     except Exception as exc:  # pragma: no cover - defensive database failure handling
@@ -77,6 +224,42 @@ def get_download(
     return DownloadEntryResponse.model_validate(download)
 
 
+@router.patch("/download/{download_id}/priority", response_model=DownloadEntryResponse)
+def update_download_priority(
+    download_id: int,
+    payload: DownloadPriorityUpdate,
+    session: Session = Depends(get_db),
+) -> DownloadEntryResponse:
+    """Update the priority of a persisted download."""
+
+    logger.info("Priority update requested for download %s", download_id)
+    try:
+        download = session.get(Download, download_id)
+    except HTTPException:
+        raise
+    except Exception as exc:  # pragma: no cover - defensive database failure handling
+        logger.exception("Failed to load download %s for priority update: %s", download_id, exc)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to update download priority",
+        ) from exc
+
+    if download is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Download not found")
+
+    download.priority = int(payload.priority)
+    download.updated_at = datetime.utcnow()
+    session.add(download)
+    session.commit()
+
+    logger.debug(
+        "Updated priority for download %s to %s",
+        download_id,
+        download.priority,
+    )
+    return DownloadEntryResponse.model_validate(download)
+
+
 @router.post("/download", status_code=status.HTTP_202_ACCEPTED)
 async def start_download(
     payload: SoulseekDownloadRequest,
@@ -102,13 +285,16 @@ async def start_download(
     download_records: List[Download] = []
     job_files: List[Dict[str, Any]] = []
     try:
+        job_priorities: List[int] = []
         for file_info in payload.files:
             filename = str(file_info.get("filename") or file_info.get("name") or "unknown")
+            priority = _determine_priority(file_info)
             download = Download(
                 filename=filename,
                 state="queued",
                 progress=0.0,
                 username=payload.username,
+                priority=priority,
             )
             session.add(download)
             session.flush()
@@ -116,10 +302,12 @@ async def start_download(
             payload_copy = dict(file_info)
             payload_copy.setdefault("filename", filename)
             payload_copy["download_id"] = download.id
+            payload_copy["priority"] = priority
             download.request_payload = payload_copy
             job_files.append(payload_copy)
 
             download_records.append(download)
+            job_priorities.append(priority)
         session.commit()
     except Exception as exc:  # pragma: no cover - defensive persistence handling
         session.rollback()
@@ -127,7 +315,8 @@ async def start_download(
         record_activity("download", "failed", details={"reason": "persistence_error"})
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to queue download") from exc
 
-    job = {"username": payload.username, "files": job_files}
+    job_priority = max(job_priorities or [0])
+    job = {"username": payload.username, "files": job_files, "priority": job_priority}
     try:
         await enqueue(job)
     except Exception as exc:  # pragma: no cover - defensive worker error
@@ -146,6 +335,8 @@ async def start_download(
             "filename": download.filename,
             "state": download.state,
             "progress": download.progress,
+            "priority": download.priority,
+            "username": download.username,
         }
         for download in download_records
     ]
@@ -237,6 +428,70 @@ async def cancel_download(
     return {"status": "cancelled", "download_id": download_id}
 
 
+@router.get("/downloads/export")
+def export_downloads(
+    format: str = Query("json"),
+    status_filter: Optional[str] = Query(None, alias="status"),
+    from_time: Optional[str] = Query(None, alias="from"),
+    to_time: Optional[str] = Query(None, alias="to"),
+    session: Session = Depends(get_db),
+) -> Response:
+    """Export downloads as JSON or CSV without paging limits."""
+
+    fmt = (format or "json").strip().lower()
+    if fmt not in {"json", "csv"}:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="Unsupported export format",
+        )
+
+    status_label = status_filter.strip() if isinstance(status_filter, str) else None
+    created_from = _parse_iso8601(from_time) if from_time else None
+    created_to = _parse_iso8601(to_time) if to_time else None
+
+    try:
+        query = _build_download_query(
+            session,
+            include_all=True,
+            status_filter=status_label,
+            created_from=created_from,
+            created_to=created_to,
+        )
+        downloads = query.all()
+    except HTTPException:
+        raise
+    except Exception as exc:  # pragma: no cover - defensive database failure handling
+        logger.exception("Failed to export downloads: %s", exc)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to export downloads",
+        ) from exc
+
+    payload = [_serialise_download(item) for item in downloads]
+
+    if fmt == "json":
+        return Response(
+            content=json.dumps(payload, ensure_ascii=False),
+            media_type="application/json",
+        )
+
+    buffer = io.StringIO()
+    writer = csv.DictWriter(buffer, fieldnames=CSV_HEADERS)
+    writer.writeheader()
+    for item in payload:
+        writer.writerow({
+            "id": item.get("id"),
+            "filename": item.get("filename"),
+            "status": item.get("status"),
+            "progress": item.get("progress"),
+            "username": item.get("username"),
+            "created_at": item.get("created_at"),
+            "updated_at": item.get("updated_at"),
+        })
+
+    return Response(content=buffer.getvalue(), media_type="text/csv")
+
+
 @router.post("/download/{download_id}/retry", status_code=status.HTTP_202_ACCEPTED)
 async def retry_download(
     download_id: int,
@@ -296,17 +551,23 @@ async def retry_download(
     if filesize is not None:
         payload_copy.setdefault("filesize", filesize)
 
+    priority = _coerce_int(payload_copy.get("priority"))
+    if priority is None:
+        priority = original.priority
+
     new_download = Download(
         filename=filename,
         state="queued",
         progress=0.0,
         username=original.username,
+        priority=priority,
     )
     session.add(new_download)
     session.flush()
 
     payload_copy["download_id"] = new_download.id
     payload_copy.setdefault("filename", filename)
+    payload_copy["priority"] = priority
     new_download.request_payload = payload_copy
 
     try:

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -98,6 +98,7 @@ class SoulseekDownloadEntry(BaseModel):
     progress: float
     created_at: datetime
     updated_at: datetime
+    priority: int = 0
 
     model_config = ConfigDict(from_attributes=True)
 
@@ -114,6 +115,8 @@ class DownloadEntryResponse(BaseModel):
     progress: float
     created_at: datetime
     updated_at: datetime
+    priority: int = 0
+    username: Optional[str] = None
     state: str = Field(exclude=True)
 
     model_config = ConfigDict(from_attributes=True)
@@ -131,6 +134,10 @@ class DownloadListResponse(BaseModel):
 
 class SoulseekCancelResponse(BaseModel):
     cancelled: bool
+
+
+class DownloadPriorityUpdate(BaseModel):
+    priority: int
 
 
 class MatchingRequest(BaseModel):

--- a/app/workers/sync_worker.py
+++ b/app/workers/sync_worker.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import asyncio
 import os
 from datetime import datetime
-from typing import Any, Dict, Iterable, List, Optional, Set
+from typing import Any, Dict, Iterable, List, Optional, Set, Tuple
 
 from app.core.soulseek_client import SoulseekClient
 from app.db import session_scope
@@ -22,6 +22,9 @@ ALLOWED_STATES = {"queued", "downloading", "completed", "failed", "cancelled"}
 DEFAULT_CONCURRENCY = 2
 DEFAULT_IDLE_POLL = 15.0
 
+MAX_RETRY_ATTEMPTS = 3
+RETRY_BACKOFF = (5, 15, 30)
+
 
 class SyncWorker:
     def __init__(
@@ -34,7 +37,10 @@ class SyncWorker:
     ) -> None:
         self._client = soulseek_client
         self._job_store = PersistentJobQueue("sync")
-        self._queue: asyncio.Queue[QueuedJob | None] = asyncio.Queue()
+        self._queue: asyncio.PriorityQueue[Tuple[int, int, Optional[QueuedJob]]] = (
+            asyncio.PriorityQueue()
+        )
+        self._enqueue_sequence = 0
         self._manager_task: asyncio.Task | None = None
         self._worker_tasks: List[asyncio.Task] = []
         self._poll_task: asyncio.Task | None = None
@@ -46,6 +52,9 @@ class SyncWorker:
         self._concurrency = max(1, concurrency or self._resolve_concurrency())
         self._cancelled_downloads: Set[int] = set()
         self._cancel_lock = asyncio.Lock()
+        self._retry_attempts: Dict[int, int] = {}
+        self._retry_lock = asyncio.Lock()
+        self._retry_tasks: Set[asyncio.Task] = set()
 
     def _resolve_concurrency(self) -> int:
         setting_value = read_setting("sync_worker_concurrency")
@@ -61,12 +70,32 @@ class SyncWorker:
                 return parsed
         return DEFAULT_CONCURRENCY
 
+    @staticmethod
+    def _coerce_priority(value: Any) -> int:
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return 0
+
+    @staticmethod
+    def _extract_file_priority(file_info: Dict[str, Any]) -> int:
+        return SyncWorker._coerce_priority(file_info.get("priority"))
+
     @property
-    def queue(self) -> asyncio.Queue[QueuedJob | None]:
+    def queue(self) -> asyncio.PriorityQueue[Tuple[int, int, Optional[QueuedJob]]]:
         return self._queue
 
     def is_running(self) -> bool:
         return self._running.is_set()
+
+    async def _put_job(self, job: QueuedJob | None) -> None:
+        self._enqueue_sequence += 1
+        priority = 0 if job is None else max(self._coerce_priority(job.priority), 0)
+        await self._queue.put((-priority, self._enqueue_sequence, job))
+
+    def _track_task(self, task: asyncio.Task) -> None:
+        self._retry_tasks.add(task)
+        task.add_done_callback(self._retry_tasks.discard)
 
     async def start(self) -> None:
         if self._manager_task is not None and not self._manager_task.done():
@@ -88,7 +117,7 @@ class SyncWorker:
 
         record = self._job_store.enqueue(job)
         if self.is_running():
-            await self._queue.put(record)
+            await self._put_job(record)
             return
 
         await self._execute_job(record)
@@ -104,9 +133,13 @@ class SyncWorker:
         logger.info("SyncWorker started")
         write_setting("worker.sync.last_start", datetime.utcnow().isoformat())
         record_worker_heartbeat("sync")
-        pending = self._job_store.list_pending()
+        pending = sorted(
+            self._job_store.list_pending(),
+            key=lambda job: self._coerce_priority(job.priority),
+            reverse=True,
+        )
         for job in pending:
-            await self._queue.put(job)
+            await self._put_job(job)
 
         self._worker_tasks = [
             asyncio.create_task(self._worker_loop(index))
@@ -118,7 +151,7 @@ class SyncWorker:
             await self._stop_event.wait()
         finally:
             for _ in self._worker_tasks:
-                await self._queue.put(None)
+                await self._put_job(None)
             await asyncio.gather(*self._worker_tasks, return_exceptions=True)
             if self._poll_task:
                 self._poll_task.cancel()
@@ -126,6 +159,11 @@ class SyncWorker:
                     await self._poll_task
                 except asyncio.CancelledError:  # pragma: no cover - lifecycle cleanup
                     pass
+            for task in list(self._retry_tasks):
+                task.cancel()
+            if self._retry_tasks:
+                await asyncio.gather(*self._retry_tasks, return_exceptions=True)
+                self._retry_tasks.clear()
             self._job_store.requeue_incomplete()
             write_setting("worker.sync.last_stop", datetime.utcnow().isoformat())
             self._running.clear()
@@ -136,8 +174,9 @@ class SyncWorker:
     async def _worker_loop(self, index: int) -> None:
         logger.debug("SyncWorker task %d started", index)
         while self._running.is_set():
-            job = await self._queue.get()
+            _, _, job = await self._queue.get()
             if job is None:
+                self._queue.task_done()
                 break
             try:
                 await self._execute_job(job)
@@ -211,8 +250,188 @@ class SyncWorker:
             await self._client.download({"username": username, "files": filtered_files})
         except Exception as exc:  # pragma: no cover - defensive
             logger.error("Failed to queue Soulseek download: %s", exc)
-            self._mark_failed(filtered_files)
+            await self._handle_download_failure(job, filtered_files, exc)
             raise
+        else:
+            await self._handle_retry_success(filtered_files)
+
+    async def _handle_download_failure(
+        self,
+        job: Dict[str, Any],
+        files: List[Dict[str, Any]],
+        error: Exception | str,
+    ) -> None:
+        if not files:
+            return
+
+        retry_batches: Dict[int, List[Dict[str, Any]]] = {}
+        scheduled: List[Dict[str, Any]] = []
+        failures: List[Dict[str, Any]] = []
+        error_message = str(error)
+
+        for file_info in files:
+            identifier = file_info.get("download_id") or file_info.get("id")
+            try:
+                download_id = int(identifier)
+            except (TypeError, ValueError):
+                continue
+
+            attempts = await self._increment_retry_attempt(download_id)
+            if attempts <= MAX_RETRY_ATTEMPTS:
+                delay_index = min(attempts, len(RETRY_BACKOFF)) - 1
+                delay = RETRY_BACKOFF[delay_index]
+                payload = dict(file_info)
+                payload["download_id"] = download_id
+                if "priority" not in payload:
+                    payload["priority"] = self._extract_file_priority(payload)
+                retry_batches.setdefault(delay, []).append(payload)
+                scheduled.append(
+                    {
+                        "download_id": download_id,
+                        "attempt": attempts,
+                        "delay_seconds": delay,
+                    }
+                )
+            else:
+                recorded_attempts = await self._mark_retry_failed(download_id)
+                failures.append(
+                    {
+                        "download_id": download_id,
+                        "attempts": recorded_attempts,
+                    }
+                )
+
+        if scheduled:
+            record_activity(
+                "download",
+                "download_retry_scheduled",
+                details={
+                    "downloads": scheduled,
+                    "username": job.get("username"),
+                },
+            )
+        if failures:
+            record_activity(
+                "download",
+                "download_retry_failed",
+                details={
+                    "downloads": failures,
+                    "username": job.get("username"),
+                    "error": error_message,
+                },
+            )
+
+        if retry_batches:
+            for delay, batch in retry_batches.items():
+                priority = max(
+                    (self._extract_file_priority(item) for item in batch),
+                    default=0,
+                )
+                retry_job = {
+                    "username": job.get("username"),
+                    "files": batch,
+                    "priority": priority,
+                }
+                download_ids = [
+                    int(item.get("download_id"))
+                    for item in batch
+                    if item.get("download_id") is not None
+                ]
+                task = asyncio.create_task(
+                    self._delayed_enqueue(retry_job, delay, download_ids)
+                )
+                self._track_task(task)
+
+    async def _handle_retry_success(self, files: Iterable[Dict[str, Any]]) -> None:
+        completed: List[Dict[str, Any]] = []
+        for file_info in files:
+            identifier = file_info.get("download_id") or file_info.get("id")
+            try:
+                download_id = int(identifier)
+            except (TypeError, ValueError):
+                continue
+
+            attempts = await self._clear_retry_state(download_id)
+            if attempts > 0:
+                completed.append({"download_id": download_id, "attempts": attempts})
+
+        if completed:
+            record_activity(
+                "download",
+                "download_retry_completed",
+                details={"downloads": completed},
+            )
+
+    async def _delayed_enqueue(
+        self,
+        job: Dict[str, Any],
+        delay: int,
+        download_ids: List[int],
+    ) -> None:
+        try:
+            await asyncio.sleep(delay)
+            await self.enqueue(job)
+        except asyncio.CancelledError:  # pragma: no cover - shutdown handling
+            return
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.error("Failed to enqueue retry job for %s: %s", download_ids, exc)
+            for download_id in download_ids:
+                await self._mark_retry_failed(download_id)
+            record_activity(
+                "download",
+                "download_retry_failed",
+                details={
+                    "downloads": [
+                        {"download_id": identifier} for identifier in download_ids
+                    ],
+                    "error": str(exc),
+                },
+            )
+
+    async def _increment_retry_attempt(self, download_id: int) -> int:
+        async with self._retry_lock:
+            attempts = self._retry_attempts.get(download_id, 0) + 1
+            self._retry_attempts[download_id] = attempts
+        with session_scope() as session:
+            download = session.get(Download, download_id)
+            if download is None:
+                return attempts
+            payload = dict(download.request_payload or {})
+            payload["retry_attempts"] = attempts
+            download.request_payload = payload
+            download.state = "queued"
+            download.progress = 0.0
+            download.updated_at = datetime.utcnow()
+        return attempts
+
+    async def _mark_retry_failed(self, download_id: int) -> int:
+        async with self._retry_lock:
+            attempts = self._retry_attempts.pop(download_id, MAX_RETRY_ATTEMPTS)
+        attempts = max(attempts, MAX_RETRY_ATTEMPTS)
+        with session_scope() as session:
+            download = session.get(Download, download_id)
+            if download is None:
+                return attempts
+            payload = dict(download.request_payload or {})
+            payload["retry_attempts"] = attempts
+            download.request_payload = payload
+            download.state = "failed"
+            download.progress = 0.0
+            download.updated_at = datetime.utcnow()
+        return attempts
+
+    async def _clear_retry_state(self, download_id: int) -> int:
+        async with self._retry_lock:
+            attempts = self._retry_attempts.pop(download_id, 0)
+        with session_scope() as session:
+            download = session.get(Download, download_id)
+            if download is None:
+                return attempts
+            payload = dict(download.request_payload or {})
+            if payload.pop("retry_attempts", None) is not None:
+                download.request_payload = payload
+                download.updated_at = datetime.utcnow()
+        return attempts
 
     async def refresh_downloads(self) -> bool:
         """Poll Soulseek for download progress and persist it."""
@@ -296,24 +515,6 @@ class SyncWorker:
                     self._cancelled_downloads.discard(identifier)
 
         return active
-
-    def _mark_failed(self, files: Iterable[Dict[str, Any]]) -> None:
-        download_ids = []
-        for file_info in files:
-            identifier = file_info.get("download_id") or file_info.get("id")
-            if identifier is not None:
-                download_ids.append(int(identifier))
-
-        if not download_ids:
-            return
-
-        with session_scope() as session:
-            for download_id in download_ids:
-                download = session.get(Download, download_id)
-                if download is None:
-                    continue
-                download.state = "failed"
-                download.updated_at = datetime.utcnow()
 
     def _record_heartbeat(self) -> None:
         record_worker_heartbeat("sync")

--- a/frontend/src/__tests__/DownloadWidget.test.tsx
+++ b/frontend/src/__tests__/DownloadWidget.test.tsx
@@ -28,13 +28,15 @@ describe('DownloadWidget', () => {
         id: 1,
         filename: 'Track One.mp3',
         status: 'running',
-        progress: 45
+        progress: 45,
+        priority: 2
       },
       {
         id: 2,
         filename: 'Track Two.mp3',
         status: 'queued',
-        progress: 10
+        progress: 10,
+        priority: 1
       }
     ]);
 
@@ -43,7 +45,8 @@ describe('DownloadWidget', () => {
     expect(await screen.findByText('Track One.mp3')).toBeInTheDocument();
     expect(screen.getByText('Running')).toBeInTheDocument();
     expect(screen.getByText('45%')).toBeInTheDocument();
-    expect(mockedFetchDownloads).toHaveBeenCalledWith(5);
+    expect(screen.getAllByText(/Priorität/)[0]).toHaveTextContent('Priorität: 2');
+    expect(mockedFetchDownloads).toHaveBeenCalledWith({ limit: 5 });
   });
 
   it('shows empty state when no downloads are active', async () => {
@@ -67,12 +70,12 @@ describe('DownloadWidget', () => {
 
   it('navigates to downloads page when clicking show all', async () => {
     mockedFetchDownloads.mockResolvedValue([
-      { id: 1, filename: 'A.mp3', status: 'running', progress: 60 },
-      { id: 2, filename: 'B.mp3', status: 'running', progress: 40 },
-      { id: 3, filename: 'C.mp3', status: 'running', progress: 20 },
-      { id: 4, filename: 'D.mp3', status: 'running', progress: 10 },
-      { id: 5, filename: 'E.mp3', status: 'running', progress: 5 },
-      { id: 6, filename: 'F.mp3', status: 'running', progress: 2 }
+      { id: 1, filename: 'A.mp3', status: 'running', progress: 60, priority: 5 },
+      { id: 2, filename: 'B.mp3', status: 'running', progress: 40, priority: 4 },
+      { id: 3, filename: 'C.mp3', status: 'running', progress: 20, priority: 3 },
+      { id: 4, filename: 'D.mp3', status: 'running', progress: 10, priority: 2 },
+      { id: 5, filename: 'E.mp3', status: 'running', progress: 5, priority: 1 },
+      { id: 6, filename: 'F.mp3', status: 'running', progress: 2, priority: 1 }
     ]);
 
     renderWithProviders(<DownloadWidget />, { toastFn: toastMock, route: '/dashboard' });
@@ -88,11 +91,11 @@ describe('DownloadWidget', () => {
 
   it('hides the show all button when five or fewer downloads are available', async () => {
     mockedFetchDownloads.mockResolvedValue([
-      { id: 1, filename: 'A.mp3', status: 'running', progress: 60 },
-      { id: 2, filename: 'B.mp3', status: 'running', progress: 40 },
-      { id: 3, filename: 'C.mp3', status: 'running', progress: 20 },
-      { id: 4, filename: 'D.mp3', status: 'running', progress: 10 },
-      { id: 5, filename: 'E.mp3', status: 'running', progress: 5 }
+      { id: 1, filename: 'A.mp3', status: 'running', progress: 60, priority: 5 },
+      { id: 2, filename: 'B.mp3', status: 'running', progress: 40, priority: 4 },
+      { id: 3, filename: 'C.mp3', status: 'running', progress: 20, priority: 3 },
+      { id: 4, filename: 'D.mp3', status: 'running', progress: 10, priority: 2 },
+      { id: 5, filename: 'E.mp3', status: 'running', progress: 5, priority: 1 }
     ]);
 
     renderWithProviders(<DownloadWidget />, { toastFn: toastMock, route: '/dashboard' });
@@ -103,10 +106,22 @@ describe('DownloadWidget', () => {
 
   it('cancels an active download', async () => {
     mockedFetchDownloads.mockResolvedValueOnce([
-      { id: 1, filename: 'Cancelable Widget.mp3', status: 'running', progress: 40 }
+      {
+        id: 1,
+        filename: 'Cancelable Widget.mp3',
+        status: 'running',
+        progress: 40,
+        priority: 3
+      }
     ]);
     mockedFetchDownloads.mockResolvedValue([
-      { id: 1, filename: 'Cancelable Widget.mp3', status: 'cancelled', progress: 40 }
+      {
+        id: 1,
+        filename: 'Cancelable Widget.mp3',
+        status: 'cancelled',
+        progress: 40,
+        priority: 3
+      }
     ]);
     mockedCancelDownload.mockResolvedValue();
 
@@ -125,17 +140,30 @@ describe('DownloadWidget', () => {
 
   it('retries a failed download', async () => {
     mockedFetchDownloads.mockResolvedValueOnce([
-      { id: 2, filename: 'Retry Widget.mp3', status: 'failed', progress: 0 }
+      { id: 2, filename: 'Retry Widget.mp3', status: 'failed', progress: 0, priority: 0 }
     ]);
     mockedFetchDownloads.mockResolvedValue([
-      { id: 2, filename: 'Retry Widget.mp3', status: 'failed', progress: 0 },
-      { id: 3, filename: 'Retry Widget.mp3', status: 'queued', progress: 0 }
+      {
+        id: 2,
+        filename: 'Retry Widget.mp3',
+        status: 'failed',
+        progress: 0,
+        priority: 0
+      },
+      {
+        id: 3,
+        filename: 'Retry Widget.mp3',
+        status: 'queued',
+        progress: 0,
+        priority: 1
+      }
     ]);
     mockedRetryDownload.mockResolvedValue({
       id: 3,
       filename: 'Retry Widget.mp3',
       status: 'queued',
-      progress: 0
+      progress: 0,
+      priority: 1
     });
 
     renderWithProviders(<DownloadWidget />, { toastFn: toastMock, route: '/dashboard' });

--- a/frontend/src/__tests__/DownloadsPage.test.tsx
+++ b/frontend/src/__tests__/DownloadsPage.test.tsx
@@ -1,21 +1,32 @@
-import userEvent from '@testing-library/user-event';
 import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import DownloadsPage from '../pages/DownloadsPage';
 import { renderWithProviders } from '../test-utils';
-import { cancelDownload, fetchActiveDownloads, retryDownload, startDownload } from '../lib/api';
+import {
+  cancelDownload,
+  exportDownloads,
+  fetchDownloads,
+  retryDownload,
+  startDownload,
+  updateDownloadPriority
+} from '../lib/api';
 
 jest.mock('../lib/api', () => ({
   ...jest.requireActual('../lib/api'),
-  fetchActiveDownloads: jest.fn(),
+  fetchDownloads: jest.fn(),
   startDownload: jest.fn(),
   cancelDownload: jest.fn(),
-  retryDownload: jest.fn()
+  retryDownload: jest.fn(),
+  updateDownloadPriority: jest.fn(),
+  exportDownloads: jest.fn()
 }));
 
-const mockedFetchDownloads = fetchActiveDownloads as jest.MockedFunction<typeof fetchActiveDownloads>;
+const mockedFetchDownloads = fetchDownloads as jest.MockedFunction<typeof fetchDownloads>;
 const mockedStartDownload = startDownload as jest.MockedFunction<typeof startDownload>;
 const mockedCancelDownload = cancelDownload as jest.MockedFunction<typeof cancelDownload>;
 const mockedRetryDownload = retryDownload as jest.MockedFunction<typeof retryDownload>;
+const mockedUpdatePriority = updateDownloadPriority as jest.MockedFunction<typeof updateDownloadPriority>;
+const mockedExportDownloads = exportDownloads as jest.MockedFunction<typeof exportDownloads>;
 
 const toastMock = jest.fn();
 
@@ -24,200 +35,112 @@ describe('DownloadsPage', () => {
     jest.clearAllMocks();
   });
 
-  it('renders downloads table', async () => {
+  it('filters downloads by status', async () => {
     mockedFetchDownloads.mockResolvedValue([
       {
         id: 1,
-        filename: 'Test File.mp3',
-        status: 'running',
-        progress: 45,
-        created_at: '2024-01-01T12:00:00Z'
+        filename: 'Queued File.mp3',
+        status: 'queued',
+        progress: 10,
+        priority: 1
       }
     ]);
 
     renderWithProviders(<DownloadsPage />, { toastFn: toastMock, route: '/downloads' });
 
-    expect(await screen.findByText('Test File.mp3')).toBeInTheDocument();
-    expect(mockedFetchDownloads).toHaveBeenCalled();
-    expect(mockedFetchDownloads.mock.calls[0][0]).toBeUndefined();
-    expect(screen.getByText('45%')).toBeInTheDocument();
-    const expectedDateLabel = new Intl.DateTimeFormat(undefined, {
-      dateStyle: 'short',
-      timeStyle: 'short'
-    }).format(new Date('2024-01-01T12:00:00Z'));
+    expect(await screen.findByText('Queued File.mp3')).toBeInTheDocument();
+    expect(mockedFetchDownloads).toHaveBeenCalledWith({ includeAll: false, status: undefined });
 
-    await waitFor(() => expect(screen.getByText(expectedDateLabel)).toBeInTheDocument());
-  });
-
-  it('starts a download via the form', async () => {
-    mockedFetchDownloads.mockResolvedValue([]);
-    mockedStartDownload.mockResolvedValue({
-      id: 2,
-      filename: 'Another File.mp3',
-      status: 'queued',
-      progress: 0,
-      created_at: '2024-01-02T08:15:00Z'
-    });
-
-    renderWithProviders(<DownloadsPage />, { toastFn: toastMock, route: '/downloads' });
-
-    await userEvent.type(screen.getByLabelText('Track-ID'), 'track-123');
-    await userEvent.click(screen.getByRole('button', { name: 'Download starten' }));
-
-    await waitFor(() => expect(mockedStartDownload).toHaveBeenCalledWith({ track_id: 'track-123' }));
-    expect(toastMock).toHaveBeenCalledWith(
-      expect.objectContaining({ title: 'Download gestartet' })
-    );
-  });
-
-  it('shows toast on download error', async () => {
-    mockedFetchDownloads.mockResolvedValue([]);
-    mockedStartDownload.mockRejectedValue(new Error('failed'));
-
-    renderWithProviders(<DownloadsPage />, { toastFn: toastMock, route: '/downloads' });
-
-    await userEvent.type(screen.getByLabelText('Track-ID'), 'track-404');
-    await userEvent.click(screen.getByRole('button', { name: 'Download starten' }));
-
-    await waitFor(() => expect(toastMock).toHaveBeenCalledWith(expect.objectContaining({ title: 'Download fehlgeschlagen' })));
-  });
-
-  it('toggles between active and all downloads', async () => {
     mockedFetchDownloads.mockResolvedValueOnce([
       {
-        id: 3,
-        filename: 'Running File.mp3',
-        status: 'running',
-        progress: 50,
-        created_at: '2024-02-01T10:00:00Z'
-      }
-    ]);
-    mockedFetchDownloads.mockResolvedValueOnce([
-      {
-        id: 3,
-        filename: 'Running File.mp3',
-        status: 'running',
-        progress: 50,
-        created_at: '2024-02-01T10:00:00Z'
-      },
-      {
-        id: 4,
-        filename: 'Completed File.mp3',
-        status: 'completed',
-        progress: 100,
-        created_at: '2024-02-01T09:00:00Z'
-      }
-    ]);
-    mockedFetchDownloads.mockResolvedValue([
-      {
-        id: 3,
-        filename: 'Running File.mp3',
-        status: 'running',
-        progress: 50,
-        created_at: '2024-02-01T10:00:00Z'
-      },
-      {
-        id: 4,
-        filename: 'Completed File.mp3',
-        status: 'completed',
-        progress: 100,
-        created_at: '2024-02-01T09:00:00Z'
+        id: 2,
+        filename: 'Failed File.mp3',
+        status: 'failed',
+        progress: 0,
+        priority: 2
       }
     ]);
 
-    renderWithProviders(<DownloadsPage />, { toastFn: toastMock, route: '/downloads' });
-
-    expect(await screen.findByText('Running File.mp3')).toBeInTheDocument();
-    expect(mockedFetchDownloads.mock.calls[0][0]).toBeUndefined();
-
-    const toggleButton = screen.getByRole('button', { name: 'Alle anzeigen' });
-    await userEvent.click(toggleButton);
+    await userEvent.selectOptions(screen.getByLabelText('Status'), ['failed']);
 
     await waitFor(() =>
-      expect(mockedFetchDownloads).toHaveBeenLastCalledWith({ includeAll: true })
+      expect(mockedFetchDownloads).toHaveBeenLastCalledWith({ includeAll: false, status: 'failed' })
     );
-    expect(await screen.findByText('Completed File.mp3')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Nur aktive' })).toBeInTheDocument();
+    expect(await screen.findByText('Failed File.mp3')).toBeInTheDocument();
   });
 
-  it('cancels a running download', async () => {
-    mockedFetchDownloads.mockResolvedValueOnce([
-      {
-        id: 5,
-        filename: 'Cancelable File.mp3',
-        status: 'running',
-        progress: 30,
-        created_at: '2024-03-01T12:00:00Z'
-      }
-    ]);
+  it('updates priority via the inline editor', async () => {
     mockedFetchDownloads.mockResolvedValue([
       {
-        id: 5,
-        filename: 'Cancelable File.mp3',
-        status: 'cancelled',
-        progress: 30,
-        created_at: '2024-03-01T12:00:00Z'
-      }
-    ]);
-    mockedCancelDownload.mockResolvedValue();
-
-    renderWithProviders(<DownloadsPage />, { toastFn: toastMock, route: '/downloads' });
-
-    const cancelButton = await screen.findByRole('button', { name: 'Abbrechen' });
-    await userEvent.click(cancelButton);
-
-    await waitFor(() => expect(mockedCancelDownload).toHaveBeenCalledWith('5'));
-    await waitFor(() => expect(mockedFetchDownloads).toHaveBeenCalledTimes(2));
-    await waitFor(() => expect(screen.getByText(/cancelled/i)).toBeInTheDocument());
-    expect(toastMock).toHaveBeenCalledWith(
-      expect.objectContaining({ title: 'Download abgebrochen' })
-    );
-  });
-
-  it('retries a failed download', async () => {
-    mockedFetchDownloads.mockResolvedValueOnce([
-      {
-        id: 6,
-        filename: 'Broken File.mp3',
-        status: 'failed',
-        progress: 0,
-        created_at: '2024-03-02T09:00:00Z'
-      }
-    ]);
-    mockedFetchDownloads.mockResolvedValue([
-      {
-        id: 6,
-        filename: 'Broken File.mp3',
-        status: 'failed',
-        progress: 0,
-        created_at: '2024-03-02T09:00:00Z'
-      },
-      {
-        id: 7,
-        filename: 'Broken File.mp3',
+        id: 3,
+        filename: 'Priority File.mp3',
         status: 'queued',
         progress: 0,
-        created_at: '2024-03-02T09:05:00Z'
+        priority: 0
       }
     ]);
-    mockedRetryDownload.mockResolvedValue({
-      id: 7,
-      filename: 'Broken File.mp3',
+    mockedUpdatePriority.mockResolvedValue({
+      id: 3,
+      filename: 'Priority File.mp3',
       status: 'queued',
-      progress: 0
-    });
+      progress: 0,
+      priority: 5
+    } as never);
 
     renderWithProviders(<DownloadsPage />, { toastFn: toastMock, route: '/downloads' });
 
-    const retryButton = await screen.findByRole('button', { name: 'Neu starten' });
-    await userEvent.click(retryButton);
+    const priorityInput = await screen.findByLabelText('Priorität für Priority File.mp3');
+    await userEvent.clear(priorityInput);
+    await userEvent.type(priorityInput, '5');
+    await userEvent.click(screen.getByRole('button', { name: 'Setzen' }));
 
-    await waitFor(() => expect(mockedRetryDownload).toHaveBeenCalledWith('6'));
-    await waitFor(() => expect(mockedFetchDownloads).toHaveBeenCalledTimes(2));
-    await waitFor(() => expect(screen.getAllByText(/queued/i).length).toBeGreaterThan(0));
-    await waitFor(() => expect(screen.getAllByText('Broken File.mp3').length).toBeGreaterThan(1));
-    expect(toastMock).toHaveBeenCalledWith(
-      expect.objectContaining({ title: 'Download neu gestartet' })
-    );
+    await waitFor(() => expect(mockedUpdatePriority).toHaveBeenCalledWith({ id: '3', priority: 5 }));
+    expect(toastMock).toHaveBeenCalledWith(expect.objectContaining({ title: 'Priorität aktualisiert' }));
+  });
+
+  it('displays retry statuses with readable labels', async () => {
+    mockedFetchDownloads.mockResolvedValue([
+      {
+        id: 4,
+        filename: 'Retried File.mp3',
+        status: 'download_retry_scheduled',
+        progress: 0,
+        priority: 1
+      }
+    ]);
+
+    renderWithProviders(<DownloadsPage />, { toastFn: toastMock, route: '/downloads' });
+
+    expect(await screen.findByText('Retried File.mp3')).toBeInTheDocument();
+    expect(screen.getByText('Download Retry Scheduled')).toBeInTheDocument();
+  });
+
+  it('exports downloads as CSV', async () => {
+    mockedFetchDownloads.mockResolvedValue([]);
+    const blob = new Blob(['id,filename'], { type: 'text/csv' });
+    mockedExportDownloads.mockResolvedValue(blob);
+
+    const createObjectURLSpy = jest.spyOn(URL, 'createObjectURL').mockReturnValue('blob:mock');
+    const revokeSpy = jest.spyOn(URL, 'revokeObjectURL').mockImplementation(() => undefined);
+    const clickSpy = jest.fn();
+    const createElementSpy = jest.spyOn(document, 'createElement').mockReturnValue({
+      href: '',
+      download: '',
+      click: clickSpy,
+      remove: jest.fn()
+    } as unknown as HTMLAnchorElement);
+
+    renderWithProviders(<DownloadsPage />, { toastFn: toastMock, route: '/downloads' });
+
+    const csvButton = await screen.findByRole('button', { name: 'Export CSV' });
+    await userEvent.click(csvButton);
+
+    await waitFor(() => expect(mockedExportDownloads).toHaveBeenCalledWith('csv', { status: undefined }));
+    expect(createObjectURLSpy).toHaveBeenCalledWith(blob);
+    expect(clickSpy).toHaveBeenCalled();
+
+    createObjectURLSpy.mockRestore();
+    revokeSpy.mockRestore();
+    createElementSpy.mockRestore();
   });
 });

--- a/tests/test_download_export.py
+++ b/tests/test_download_export.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+from app.db import session_scope
+from app.models import Download
+
+
+def seed_downloads() -> dict[str, int]:
+    with session_scope() as session:
+        older = Download(
+            filename="old.mp3",
+            state="completed",
+            progress=100.0,
+            priority=2,
+        )
+        newer = Download(
+            filename="new.mp3",
+            state="queued",
+            progress=0.0,
+            priority=5,
+        )
+        failed = Download(
+            filename="failed.mp3",
+            state="failed",
+            progress=0.0,
+            priority=1,
+        )
+        session.add_all([older, newer, failed])
+        session.flush()
+
+        older.created_at = datetime.utcnow() - timedelta(days=2)
+        older.updated_at = older.created_at
+        session.add(older)
+        return {"older": older.id, "newer": newer.id, "failed": failed.id}
+
+
+def test_json_export_returns_full_payload(client) -> None:
+    ids = seed_downloads()
+
+    response = client.get("/api/downloads/export", params={"format": "json"})
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("application/json")
+
+    payload = response.json()
+    assert isinstance(payload, list)
+    assert {entry["id"] for entry in payload} == set(ids.values())
+    queued_entry = next(entry for entry in payload if entry["id"] == ids["newer"])
+    assert queued_entry["priority"] == 5
+    assert queued_entry["status"] == "queued"
+
+
+def test_csv_export_contains_expected_header(client) -> None:
+    seed_downloads()
+
+    response = client.get("/api/downloads/export", params={"format": "csv"})
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/csv")
+
+    body = response._body.decode("utf-8")
+    rows = body.strip().splitlines()
+    assert rows[0] == "id,filename,status,progress,username,created_at,updated_at"
+    assert any("new.mp3" in row for row in rows[1:])
+
+
+def test_status_filter_limits_export(client) -> None:
+    ids = seed_downloads()
+
+    response = client.get(
+        "/api/downloads/export",
+        params={"format": "json", "status": "failed"},
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    assert {entry["id"] for entry in payload} == {ids["failed"]}
+
+
+def test_date_filters_apply_to_export(client) -> None:
+    ids = seed_downloads()
+    cutoff = datetime.utcnow() - timedelta(days=1)
+
+    response = client.get(
+        "/api/downloads/export",
+        params={"format": "json", "from": cutoff.isoformat()},
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    assert {entry["id"] for entry in payload} == {ids["newer"], ids["failed"]}
+
+
+def test_invalid_format_returns_422(client) -> None:
+    response = client.get("/api/downloads/export", params={"format": "xml"})
+    assert response.status_code == 422
+
+
+def test_invalid_date_returns_422(client) -> None:
+    response = client.get("/api/downloads/export", params={"from": "invalid"})
+    assert response.status_code == 422

--- a/tests/test_download_filters.py
+++ b/tests/test_download_filters.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from app.db import session_scope
+from app.models import Download
+
+
+def create_download(
+    filename: str,
+    state: str,
+    priority: int = 0,
+    progress: float = 0.0,
+) -> int:
+    with session_scope() as session:
+        download = Download(
+            filename=filename,
+            state=state,
+            progress=progress,
+            priority=priority,
+        )
+        session.add(download)
+        session.flush()
+        return download.id
+
+
+def test_status_filter_returns_expected_entries(client) -> None:
+    queued_id = create_download("queued.mp3", "queued", priority=1)
+    running_id = create_download("running.mp3", "running", priority=5)
+    downloading_id = create_download("downloading.mp3", "downloading", priority=4, progress=30.0)
+    failed_id = create_download("failed.mp3", "failed")
+    create_download("completed.mp3", "completed")
+
+    response = client.get("/api/downloads", params={"status": "failed"})
+    assert response.status_code == 200
+    payload = response.json()["downloads"]
+    assert {entry["id"] for entry in payload} == {failed_id}
+
+    running_response = client.get("/api/downloads", params={"status": "running"})
+    assert running_response.status_code == 200
+    running_payload = running_response.json()["downloads"]
+    running_ids = {entry["id"] for entry in running_payload}
+    assert running_id in running_ids
+    assert downloading_id in running_ids
+
+    queued_response = client.get("/api/downloads", params={"status": "queued"})
+    assert queued_response.status_code == 200
+    queued_payload = queued_response.json()["downloads"]
+    assert {entry["id"] for entry in queued_payload} == {queued_id}
+
+
+def test_invalid_status_filter_returns_422(client) -> None:
+    response = client.get("/api/downloads", params={"status": "unknown"})
+    assert response.status_code == 422

--- a/tests/test_download_priority.py
+++ b/tests/test_download_priority.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Dict, List
+
+import pytest
+
+from app.db import init_db, reset_engine_for_tests, session_scope
+from app.models import Download
+from app.utils.activity import activity_manager
+from app.workers.sync_worker import SyncWorker
+
+
+class RecordingSoulseekClient:
+    def __init__(self) -> None:
+        self.download_calls: List[Dict[str, Any]] = []
+
+    async def download(self, payload: Dict[str, Any]) -> None:
+        self.download_calls.append(payload)
+
+    async def get_download_status(self) -> List[Dict[str, Any]]:
+        return []
+
+    async def cancel_download(self, identifier: str) -> None:  # pragma: no cover - unused
+        return None
+
+
+@pytest.mark.asyncio
+async def test_high_priority_jobs_are_processed_first() -> None:
+    reset_engine_for_tests()
+    init_db()
+    activity_manager.clear()
+
+    client = RecordingSoulseekClient()
+    worker = SyncWorker(client, concurrency=1)
+
+    with session_scope() as session:
+        low = Download(
+            filename="low.mp3",
+            state="queued",
+            progress=0.0,
+            username="tester",
+            priority=1,
+        )
+        high = Download(
+            filename="high.mp3",
+            state="queued",
+            progress=0.0,
+            username="tester",
+            priority=10,
+        )
+        session.add_all([low, high])
+        session.flush()
+        low_id = low.id
+        high_id = high.id
+
+    await worker.start()
+
+    await worker.enqueue(
+        {
+            "username": "tester",
+            "files": [{"download_id": low_id, "priority": 1}],
+            "priority": 1,
+        }
+    )
+    await worker.enqueue(
+        {
+            "username": "tester",
+            "files": [{"download_id": high_id, "priority": 10}],
+            "priority": 10,
+        }
+    )
+
+    await asyncio.sleep(0.05)
+    await worker.stop()
+
+    assert len(client.download_calls) >= 2
+    first_call = client.download_calls[0]
+    first_download_id = first_call["files"][0]["download_id"]
+    assert first_download_id == high_id
+
+
+def test_priority_can_be_updated_via_api(client) -> None:
+    with session_scope() as session:
+        download = Download(
+            filename="adjustable.mp3",
+            state="queued",
+            progress=0.0,
+            username="tester",
+            priority=0,
+        )
+        session.add(download)
+        session.flush()
+        download_id = download.id
+
+    response = client.patch(
+        f"/api/download/{download_id}/priority",
+        json={"priority": 7},
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["priority"] == 7
+
+    detail_response = client.get(f"/api/download/{download_id}")
+    assert detail_response.status_code == 200
+    detail = detail_response.json()
+    assert detail["priority"] == 7
+    assert detail["status"] == "queued"

--- a/tests/test_download_retry.py
+++ b/tests/test_download_retry.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Dict, List
+
+import pytest
+
+from app.db import init_db, reset_engine_for_tests, session_scope
+from app.models import Download
+from app.utils.activity import activity_manager
+from app.workers.sync_worker import MAX_RETRY_ATTEMPTS, RETRY_BACKOFF, SyncWorker
+
+
+class FlakySoulseekClient:
+    def __init__(self, failures: int) -> None:
+        self.failures = failures
+        self.download_calls: List[Dict[str, Any]] = []
+
+    async def download(self, payload: Dict[str, Any]) -> None:
+        self.download_calls.append(payload)
+        if self.failures > 0:
+            self.failures -= 1
+            raise RuntimeError("simulated failure")
+
+    async def get_download_status(self) -> List[Dict[str, Any]]:
+        return []
+
+    async def cancel_download(self, identifier: str) -> None:  # pragma: no cover - unused
+        return None
+
+
+@pytest.mark.asyncio
+async def test_retry_is_scheduled_and_completed(monkeypatch) -> None:
+    reset_engine_for_tests()
+    init_db()
+    activity_manager.clear()
+
+    monkeypatch.setattr(
+        "app.workers.sync_worker.RETRY_BACKOFF",
+        tuple(0.01 for _ in RETRY_BACKOFF),
+    )
+
+    client = FlakySoulseekClient(failures=1)
+    worker = SyncWorker(client, concurrency=1)
+
+    with session_scope() as session:
+        download = Download(
+            filename="priority-track.mp3",
+            state="queued",
+            progress=0.0,
+            priority=5,
+        )
+        session.add(download)
+        session.flush()
+        download_id = download.id
+
+    job = {
+        "username": "tester",
+        "files": [{"download_id": download_id, "priority": 5}],
+        "priority": 5,
+    }
+
+    await worker.enqueue(job)
+    await asyncio.sleep(0.05)
+
+    entries = activity_manager.list()
+    statuses = [entry["status"] for entry in entries]
+    assert "download_retry_scheduled" in statuses
+    assert "download_retry_completed" in statuses
+
+    with session_scope() as session:
+        refreshed = session.get(Download, download_id)
+        assert refreshed is not None
+        assert refreshed.priority == 5
+        assert refreshed.request_payload.get("retry_attempts") is None
+
+    assert len(client.download_calls) >= 2
+
+
+@pytest.mark.asyncio
+async def test_retry_fails_after_max_attempts(monkeypatch) -> None:
+    reset_engine_for_tests()
+    init_db()
+    activity_manager.clear()
+
+    monkeypatch.setattr(
+        "app.workers.sync_worker.RETRY_BACKOFF",
+        tuple(0.01 for _ in RETRY_BACKOFF),
+    )
+    monkeypatch.setattr(
+        "app.workers.sync_worker.MAX_RETRY_ATTEMPTS",
+        MAX_RETRY_ATTEMPTS,
+    )
+
+    client = FlakySoulseekClient(failures=MAX_RETRY_ATTEMPTS + 1)
+    worker = SyncWorker(client, concurrency=1)
+
+    with session_scope() as session:
+        download = Download(
+            filename="stubborn-track.mp3",
+            state="queued",
+            progress=0.0,
+            priority=1,
+        )
+        session.add(download)
+        session.flush()
+        download_id = download.id
+
+    job = {
+        "username": "tester",
+        "files": [{"download_id": download_id, "priority": 1}],
+        "priority": 1,
+    }
+
+    await worker.enqueue(job)
+    await asyncio.sleep(0.1)
+
+    entries = activity_manager.list()
+    statuses = [entry["status"] for entry in entries]
+    assert "download_retry_failed" in statuses
+
+    with session_scope() as session:
+        refreshed = session.get(Download, download_id)
+        assert refreshed is not None
+        assert refreshed.state == "failed"
+        assert refreshed.request_payload.get("retry_attempts") == MAX_RETRY_ATTEMPTS
+
+    assert len(client.download_calls) >= MAX_RETRY_ATTEMPTS + 1


### PR DESCRIPTION
## Summary
- add download priority support, automatic retry events and status filtering endpoints
- expose download export (CSV/JSON) with filters and document the new flow
- refresh frontend downloads view with filtering, priority controls, and export actions plus updated widgets and tests

## Testing
- `npm run build`
- `npm run test -- --watch=false`
- `pytest` *(fails to complete in CI environment after ~63% despite repeated attempts; see execution log)*

------
https://chatgpt.com/codex/tasks/task_e_68d40a18d8208321a87815d55c174cc6