### PR TITLE
feat: add harmony layout scaffolding

### DIFF
--- a/frontend/layout/Layout.tsx
+++ b/frontend/layout/Layout.tsx
@@ -1,0 +1,26 @@
+import { ReactNode, useState } from 'react';
+
+import Navbar from './Navbar';
+import Sidebar from './Sidebar';
+
+export interface LayoutProps {
+  children: ReactNode;
+}
+
+const Layout = ({ children }: LayoutProps) => {
+  const [mobileOpen, setMobileOpen] = useState(false);
+
+  return (
+    <div className="flex min-h-screen bg-background text-foreground">
+      <Sidebar open={mobileOpen} onOpenChange={setMobileOpen} />
+      <div className="flex min-h-screen w-full flex-1 flex-col lg:ml-72">
+        <Navbar onMenuClick={() => setMobileOpen(true)} />
+        <main className="flex-1 bg-muted/40 px-4 py-6 sm:px-8 lg:px-10">
+          <div className="mx-auto w-full max-w-6xl space-y-6">{children}</div>
+        </main>
+      </div>
+    </div>
+  );
+};
+
+export default Layout;

--- a/frontend/layout/Navbar.tsx
+++ b/frontend/layout/Navbar.tsx
@@ -1,0 +1,91 @@
+import { FormEvent, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { Bell, Menu, Moon, Search, Sun } from 'lucide-react';
+
+import { useTheme } from '../src/hooks/useTheme';
+import { Input } from '../src/components/ui/input';
+import { cn } from '../src/lib/utils';
+
+export interface NavbarProps {
+  onMenuClick?: () => void;
+}
+
+const Navbar = ({ onMenuClick }: NavbarProps) => {
+  const { theme, setTheme } = useTheme();
+  const [searchTerm, setSearchTerm] = useState('');
+  const isDark = theme === 'dark';
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+  };
+
+  const toggleTheme = () => {
+    setTheme(isDark ? 'light' : 'dark');
+  };
+
+  return (
+    <header className="sticky top-0 z-40 border-b border-slate-200/80 bg-white/90 backdrop-blur-md dark:border-slate-800/70 dark:bg-slate-950/80">
+      <div className="flex h-16 items-center gap-4 px-4 sm:px-6">
+        <button
+          type="button"
+          onClick={onMenuClick}
+          className="inline-flex h-10 w-10 items-center justify-center rounded-lg text-slate-500 transition-colors hover:bg-slate-100 hover:text-slate-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 focus:ring-offset-white dark:text-slate-300 dark:hover:bg-slate-800 dark:hover:text-slate-100 dark:focus:ring-offset-slate-950 lg:hidden"
+          aria-label="Open navigation menu"
+        >
+          <Menu className="h-5 w-5" />
+        </button>
+
+        <Link
+          to="/dashboard"
+          className="flex items-center gap-2 text-xl font-semibold tracking-tight text-slate-900 transition-colors hover:text-slate-700 dark:text-slate-100 dark:hover:text-slate-300"
+        >
+          <span className="inline-flex h-10 w-10 items-center justify-center rounded-xl bg-slate-900 text-lg font-bold text-white dark:bg-indigo-500/80 dark:text-white">
+            H
+          </span>
+          Harmony
+        </Link>
+
+        <form
+          onSubmit={handleSubmit}
+          className="relative hidden flex-1 items-center md:flex"
+          role="search"
+        >
+          <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-400" />
+          <Input
+            value={searchTerm}
+            onChange={(event) => setSearchTerm(event.target.value)}
+            placeholder="Search services, libraries, media..."
+            className="h-10 rounded-lg border border-slate-200 bg-white pl-10 pr-4 text-sm text-slate-700 shadow-sm transition focus:border-indigo-500 focus:ring-2 focus:ring-indigo-400 dark:border-slate-700 dark:bg-slate-900/80 dark:text-slate-200 dark:placeholder:text-slate-500"
+            aria-label="Search"
+          />
+        </form>
+
+        <div className="ml-auto flex items-center gap-2 sm:gap-3">
+          <button
+            type="button"
+            onClick={toggleTheme}
+            className={cn(
+              'inline-flex items-center gap-2 rounded-full border border-slate-200 px-3 py-2 text-sm font-medium text-slate-600 transition-colors hover:border-indigo-400 hover:text-slate-900 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 focus:ring-offset-white dark:border-slate-700 dark:text-slate-200 dark:hover:border-indigo-400/70 dark:hover:text-slate-50 dark:focus:ring-offset-slate-950',
+              'bg-white/80 dark:bg-slate-900/60'
+            )}
+            aria-pressed={isDark}
+            aria-label="Toggle theme"
+          >
+            {isDark ? <Moon className="h-4 w-4" /> : <Sun className="h-4 w-4" />}
+            <span className="hidden sm:inline">{isDark ? 'Dark' : 'Light'} mode</span>
+          </button>
+
+          <button
+            type="button"
+            className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-slate-200 bg-white/80 text-slate-500 transition-colors hover:border-indigo-400 hover:text-slate-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 focus:ring-offset-white dark:border-slate-700 dark:bg-slate-900/60 dark:text-slate-300 dark:hover:border-indigo-400/70 dark:hover:text-slate-100 dark:focus:ring-offset-slate-950"
+            aria-label="Open notifications"
+          >
+            <Bell className="h-5 w-5" />
+          </button>
+        </div>
+      </div>
+    </header>
+  );
+};
+
+export default Navbar;

--- a/frontend/layout/Sidebar.tsx
+++ b/frontend/layout/Sidebar.tsx
@@ -1,0 +1,134 @@
+import { Fragment, useEffect } from 'react';
+import { createPortal } from 'react-dom';
+import { NavLink } from 'react-router-dom';
+import {
+  LayoutDashboard,
+  Music,
+  PlaySquare,
+  Radio,
+  Library,
+  Sparkles,
+  Settings,
+  X
+} from 'lucide-react';
+
+const navigationItems = [
+  { to: '/dashboard', label: 'Dashboard', icon: LayoutDashboard },
+  { to: '/spotify', label: 'Spotify', icon: Music },
+  { to: '/plex', label: 'Plex', icon: PlaySquare },
+  { to: '/soulseek', label: 'Soulseek', icon: Radio },
+  { to: '/beets', label: 'Beets', icon: Library },
+  { to: '/matching', label: 'Matching', icon: Sparkles },
+  { to: '/settings', label: 'Settings', icon: Settings }
+] as const;
+
+export interface SidebarProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+const Sidebar = ({ open, onOpenChange }: SidebarProps) => {
+  const renderNavigation = (closeOnNavigate?: () => void) => (
+    <nav className="flex flex-col gap-1">
+      {navigationItems.map((item) => {
+        const Icon = item.icon;
+        return (
+          <NavLink
+            key={item.to}
+            to={item.to}
+            className={({ isActive }) =>
+              [
+                'group flex items-center gap-3 rounded-xl px-3 py-2.5 text-sm font-medium transition-all duration-150',
+                'text-slate-600 hover:bg-slate-100 hover:text-slate-900 dark:text-slate-300 dark:hover:bg-slate-800/70 dark:hover:text-slate-50',
+                isActive
+                  ? 'bg-slate-900 text-white shadow-sm dark:bg-indigo-500/80 dark:text-white'
+                  : 'bg-transparent'
+              ].join(' ')
+            }
+            onClick={closeOnNavigate}
+          >
+            <span className="flex h-9 w-9 items-center justify-center rounded-lg bg-slate-100 text-slate-600 transition group-hover:bg-indigo-100 group-hover:text-indigo-600 dark:bg-slate-800/70 dark:text-slate-300 dark:group-hover:bg-indigo-500/20 dark:group-hover:text-indigo-200">
+              <Icon className="h-4 w-4" />
+            </span>
+            {item.label}
+          </NavLink>
+        );
+      })}
+    </nav>
+  );
+
+  useEffect(() => {
+    if (!open) return undefined;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        onOpenChange(false);
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [open, onOpenChange]);
+
+  const mobileDrawer =
+    open &&
+    createPortal(
+      <div className="fixed inset-0 z-40 flex">
+        <button
+          type="button"
+          className="absolute inset-0 h-full w-full bg-slate-900/50 backdrop-blur-sm"
+          aria-label="Close navigation"
+          onClick={() => onOpenChange(false)}
+        />
+        <div
+          role="dialog"
+          aria-modal="true"
+          className="relative ml-0 flex h-full w-72 max-w-full translate-x-0 flex-col border-r border-slate-200 bg-white/95 p-6 shadow-xl transition-transform duration-300 ease-out dark:border-slate-800 dark:bg-slate-950/95"
+        >
+          <div className="mb-6 flex items-center justify-between">
+            <span className="text-lg font-semibold text-slate-900 dark:text-slate-100">Harmony</span>
+            <button
+              type="button"
+              className="inline-flex h-9 w-9 items-center justify-center rounded-lg text-slate-500 transition-colors hover:bg-slate-100 hover:text-slate-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 focus:ring-offset-white dark:text-slate-300 dark:hover:bg-slate-800 dark:hover:text-slate-100 dark:focus:ring-offset-slate-950"
+              aria-label="Close navigation"
+              onClick={() => onOpenChange(false)}
+            >
+              <X className="h-4 w-4" />
+            </button>
+          </div>
+          <div className="flex-1 overflow-y-auto pr-1">{renderNavigation(() => onOpenChange(false))}</div>
+        </div>
+      </div>,
+      document.body
+    );
+
+  return (
+    <Fragment>
+      <aside className="hidden w-72 flex-col border-r border-slate-200/80 bg-white/80 px-6 py-8 shadow-sm dark:border-slate-800/70 dark:bg-slate-950/70 lg:flex">
+        <div className="mb-8">
+          <NavLink
+            to="/dashboard"
+            className="flex items-center gap-3 text-lg font-semibold text-slate-900 transition-colors hover:text-slate-700 dark:text-slate-100 dark:hover:text-slate-300"
+          >
+            <span className="inline-flex h-10 w-10 items-center justify-center rounded-xl bg-slate-900 text-lg font-bold text-white dark:bg-indigo-500/80 dark:text-white">
+              H
+            </span>
+            Harmony
+          </NavLink>
+        </div>
+        <div className="flex-1 space-y-4">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-400 dark:text-slate-500">Navigation</p>
+          </div>
+          {renderNavigation()}
+        </div>
+      </aside>
+      {mobileDrawer}
+    </Fragment>
+  );
+};
+
+export default Sidebar;

--- a/frontend/src/__tests__/layout-components.test.tsx
+++ b/frontend/src/__tests__/layout-components.test.tsx
@@ -1,0 +1,40 @@
+import { fireEvent, screen } from '@testing-library/react';
+import Navbar from '../../layout/Navbar';
+import Sidebar from '../../layout/Sidebar';
+import Layout from '../../layout/Layout';
+import { renderWithProviders } from '../test-utils';
+
+describe('Harmony layout primitives', () => {
+  it('renders the navbar with search, toggle, and notifications', () => {
+    renderWithProviders(<Navbar onMenuClick={jest.fn()} />);
+
+    expect(screen.getByText('Harmony')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText(/search services/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /toggle theme/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /open notifications/i })).toBeInTheDocument();
+  });
+
+  it('displays all sidebar navigation entries', () => {
+    renderWithProviders(<Sidebar open onOpenChange={jest.fn()} />);
+
+    const expectedLinks = ['Dashboard', 'Spotify', 'Plex', 'Soulseek', 'Beets', 'Matching', 'Settings'];
+
+    expectedLinks.forEach((label) => {
+      expect(screen.getAllByRole('link', { name: label })[0]).toBeInTheDocument();
+    });
+  });
+
+  it('shows the dark/light mode toggle inside the composed layout', () => {
+    renderWithProviders(
+      <Layout>
+        <div>layout content</div>
+      </Layout>
+    );
+
+    const toggleButton = screen.getByRole('button', { name: /toggle theme/i });
+    expect(toggleButton).toBeInTheDocument();
+
+    fireEvent.click(toggleButton);
+    expect(toggleButton).toHaveAttribute('aria-pressed', 'true');
+  });
+});

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -1,4 +1,5 @@
 import { createRequire } from 'module';
+import colors from 'tailwindcss/colors';
 import type { Config } from 'tailwindcss';
 
 const require = createRequire(import.meta.url);
@@ -17,6 +18,7 @@ const config: Config = {
   darkMode: ['class'],
   content: [
     './index.html',
+    './layout/**/*.{ts,tsx}',
     './src/**/*.{ts,tsx}',
     './src/components/**/*.{ts,tsx}',
     './src/pages/**/*.{ts,tsx}'
@@ -63,12 +65,63 @@ const config: Config = {
         card: {
           DEFAULT: 'hsl(var(--card))',
           foreground: 'hsl(var(--card-foreground))'
-        }
+        },
+        slate: colors.slate
+      },
+      fontFamily: {
+        sans: [
+          'Inter',
+          'ui-sans-serif',
+          'system-ui',
+          'Segoe UI',
+          'Helvetica Neue',
+          'Arial',
+          'sans-serif'
+        ],
+        mono: [
+          'JetBrains Mono',
+          'SFMono-Regular',
+          'Menlo',
+          'Monaco',
+          'Consolas',
+          'Liberation Mono',
+          'Courier New',
+          'monospace'
+        ]
       },
       borderRadius: {
         lg: 'var(--radius)',
         md: 'calc(var(--radius) - 2px)',
         sm: 'calc(var(--radius) - 4px)'
+      },
+      keyframes: {
+        'fade-in': {
+          '0%': { opacity: '0', transform: 'translateY(-8px)' },
+          '100%': { opacity: '1', transform: 'translateY(0)' }
+        },
+        'slide-in-from-right': {
+          '0%': { transform: 'translateX(100%)' },
+          '100%': { transform: 'translateX(0)' }
+        },
+        'slide-out-to-right': {
+          '0%': { transform: 'translateX(0)' },
+          '100%': { transform: 'translateX(100%)' }
+        },
+        'fade-in-overlay': {
+          '0%': { opacity: '0' },
+          '100%': { opacity: '1' }
+        },
+        'fade-out': {
+          '0%': { opacity: '1' },
+          '100%': { opacity: '0' }
+        }
+      },
+      animation: {
+        'fade-in': 'fade-in 200ms cubic-bezier(0.16, 1, 0.3, 1)',
+        'slide-in-from-right': 'slide-in-from-right 300ms cubic-bezier(0.16, 1, 0.3, 1)',
+        'slide-out-to-right': 'slide-out-to-right 300ms cubic-bezier(0.16, 1, 0.3, 1)',
+        'fade-in-overlay': 'fade-in-overlay 200ms ease-out',
+        'fade-out': 'fade-out 200ms ease-out'
       }
     }
   },


### PR DESCRIPTION
## Summary
- add reusable Harmony navbar, sidebar, and shell layout using the archived visual language
- synchronize Tailwind theme tokens with the archive palette and register layout directory for scanning
- cover the new UI primitives with Jest + RTL smoke tests for navigation links and theme toggle

## Testing
- `npx jest --runTestsByPath src/__tests__/layout-components.test.tsx` *(fails: Jest requires ts-node which is unavailable in this offline environment)*
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68d4977503348321af0b0826d8201abe