### PR TITLE
feat: add activity feed type filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Alle Änderungen an diesem Projekt werden in diesem Dokument festgehalten. Diese
 - Dashboard-Karten für Service-Status, Worker-Zustand und Activity Feed inklusive neuer Eventtypen (`*_blocked`, `worker_*`).
 - Frontend-Testabdeckung für Dashboard, Downloads, Artists und Settings mit Fokus auf Toast-Verhalten und Interaktionen.
 - ArtistsPage um Release-Filter für Alben, Singles und EPs erweitert.
+- Frontend: Added event-type filter to ActivityFeed.
 
 ### Changed
 - Frontend auf 4 Kernseiten reduziert, API-Client vereinheitlicht, Design-Guidelines verpflichtend.

--- a/ToDo.md
+++ b/ToDo.md
@@ -7,6 +7,7 @@
 - [x] Frontend-Tests für Dashboard, Downloads, Artists und Settings aktualisiert.
 - [x] Design-Guidelines dokumentiert und im UI angewendet.
 - [x] Release-Filter (Album/Single/EP) auf der Artists-Seite ergänzt.
+- [x] Event-Typ-Filter im Activity Feed ergänzt.
 
 ## Offen
 - [ ] Integrationstests für globale API-Fehler (401/403/503) inklusive Redirect-Checks ergänzen.

--- a/docs/api.md
+++ b/docs/api.md
@@ -717,6 +717,8 @@ Die neue Downloads-Seite im Harmony-Frontend ermöglicht das Starten von Test-Do
 
 Auf dem Dashboard ergänzt das Activity-Feed-Widget die bestehenden Statuskacheln. Es pollt den `/api/activity`-Endpunkt alle zehn Sekunden, sortiert die Einträge nach dem neuesten Zeitstempel und visualisiert die letzten Aktionen mit lokalisierten Typen sowie farbcodierten Status-Badges. Für leere Feeds oder Fehlerfälle erscheinen Toast-Benachrichtigungen, sodass Operatorinnen laufende Sync-, Such- und Download-Aktivitäten ohne manuelle API-Abfragen im Blick behalten.
 
+Das Frontend bietet zusätzlich ein Dropdown zum Filtern nach Event-Typ (`Alle`, `Sync`, `Download`, `Metadata`, `Worker`). Damit lassen sich beispielsweise nur fehlgeschlagene Downloads oder laufende Worker-Events fokussiert betrachten, ohne dass serverseitige Filterparameter nötig sind.
+
 ### Artists-Verwaltung
 
 Die Artists-Seite im Frontend nutzt die Spotify-Endpunkte `GET /spotify/artists/followed` und `GET /spotify/artist/{artist_id}/releases`, um eine sortierbare Liste der gefolgten Artists inklusive Coverbildern anzuzeigen. In der Detailspalte lassen sich die verfügbaren Releases mit Jahr, Typ und Track-Anzahl inspizieren. Über einen Toggle "Für Sync aktivieren" kann pro Release gesteuert werden, ob der AutoSync-Worker ihn berücksichtigen soll. Änderungen werden gesammelt über `POST /settings/artist-preferences` gespeichert. Lade- und Fehlerzustände werden mit Spinnern, leeren States ("Keine Artists gefunden", "Keine Releases verfügbar") sowie Toasts visualisiert.


### PR DESCRIPTION
## Summary
- add an event-type dropdown filter to the Activity Feed UI and guard empty states
- cover filtering behaviour with new ActivityFeed tests
- document the new filter in the API docs and housekeeping files

## Testing
- npm run build
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d4b2fc5d0483219fcc125f71e2d4ea