### PR TITLE
feat: add complete discography downloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,4 @@
 ## v1.x.x
 
 - Rich Metadata und High-Quality Artwork implementiert: Tags + Cover werden nach jedem Download ergänzt.
+- Complete Discographies – gesamte Künstlerdiskografien können automatisch heruntergeladen und kategorisiert werden.

--- a/README.md
+++ b/README.md
@@ -17,6 +17,24 @@ und stellt einheitliche JSON-APIs für Automatisierungen und Frontend-Clients be
 - **Hintergrund-Worker** für Soulseek-Synchronisation, Matching-Queue, Plex-Scans und Spotify-Playlist-Sync.
 - **Docker & GitHub Actions** für reproduzierbare Builds, Tests und Continuous Integration.
 
+## Complete Discographies
+
+Harmony kann komplette Künstler-Diskografien automatisiert herunterladen. Für einen Spotify-Artist werden alle Alben samt Tracks
+ermittelt, mit der Plex-Bibliothek abgeglichen und fehlende Titel über Soulseek nachgeladen. Nach dem Download übernimmt Beets die
+Kategorisierung.
+
+Beispiel-API-Aufruf:
+
+```bash
+curl -X POST \
+  http://localhost:8000/soulseek/discography/download \
+  -H 'Content-Type: application/json' \
+  -d '{"artist_id": "123"}'
+```
+
+Der Status der Discography-Jobs wird in der Datenbank protokolliert und kann über die Soulseek- und Matching-Endpunkte
+nachverfolgt werden.
+
 ## Harmony Web UI
 
 Die neue React-basierte Oberfläche befindet sich im Verzeichnis [`frontend/`](frontend/). Sie orientiert sich am Porttracker-Layout mit Sidebar, Header, Karten, Tabellen und Tabs. Das UI nutzt Tailwind CSS, shadcn/ui (Radix UI Komponenten) und React Query für Live-Daten aus den bestehenden APIs.

--- a/app/main.py
+++ b/app/main.py
@@ -36,6 +36,7 @@ from app.utils.activity import activity_manager
 from app.utils.settings_store import ensure_default_settings
 from app.workers import (
     AutoSyncWorker,
+    DiscographyWorker,
     MatchingWorker,
     MetadataUpdateWorker,
     PlaylistSyncWorker,
@@ -120,6 +121,14 @@ async def startup_event() -> None:
         )
         await app.state.auto_sync_worker.start()
 
+        app.state.discography_worker = DiscographyWorker(
+            spotify_client,
+            soulseek_client,
+            plex_client=plex_client,
+            beets_client=beets_client,
+        )
+        await app.state.discography_worker.start()
+
     logger.info("Harmony application started")
 
 
@@ -136,6 +145,8 @@ async def shutdown_event() -> None:
     if worker := getattr(app.state, "playlist_worker", None):
         await worker.stop()
     if worker := getattr(app.state, "metadata_worker", None):
+        await worker.stop()
+    if worker := getattr(app.state, "discography_worker", None):
         await worker.stop()
     try:
         plex_client = get_plex_client()

--- a/app/models.py
+++ b/app/models.py
@@ -78,6 +78,22 @@ class Download(Base):
         self.request_payload = payload
 
 
+class DiscographyJob(Base):
+    __tablename__ = "discography_jobs"
+
+    id = Column(Integer, primary_key=True, index=True)
+    artist_id = Column(String(128), nullable=False, index=True)
+    artist_name = Column(String(512), nullable=True)
+    status = Column(String(32), nullable=False, default="pending", index=True)
+    created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+    updated_at = Column(
+        DateTime,
+        default=datetime.utcnow,
+        onupdate=datetime.utcnow,
+        nullable=False,
+    )
+
+
 class Match(Base):
     __tablename__ = "matches"
 

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -36,6 +36,16 @@ class ArtistReleasesResponse(BaseModel):
     releases: List[Dict[str, Any]]
 
 
+class DiscographyAlbum(BaseModel):
+    album: Dict[str, Any]
+    tracks: List[Dict[str, Any]] = Field(default_factory=list)
+
+
+class DiscographyResponse(BaseModel):
+    artist_id: str
+    albums: List[DiscographyAlbum] = Field(default_factory=list)
+
+
 class PlaylistEntry(BaseModel):
     id: str
     name: str
@@ -83,6 +93,16 @@ class SoulseekSearchRequest(BaseModel):
 class SoulseekDownloadRequest(BaseModel):
     username: str = Field(..., description="Soulseek username hosting the files")
     files: List[Dict[str, Any]] = Field(..., description="List of files to download")
+
+
+class DiscographyDownloadRequest(BaseModel):
+    artist_id: str
+    artist_name: Optional[str] = None
+
+
+class DiscographyJobResponse(BaseModel):
+    job_id: int
+    status: str
 
 
 class SoulseekSearchResponse(BaseModel):
@@ -166,6 +186,27 @@ class MatchingRequest(BaseModel):
 class MatchingResponse(BaseModel):
     best_match: Optional[Dict[str, Any]]
     confidence: float
+
+
+class DiscographyMatchingRequest(BaseModel):
+    artist_id: str
+    albums: List[Dict[str, Any]] = Field(default_factory=list)
+    plex_items: List[Dict[str, Any]] = Field(default_factory=list)
+
+
+class DiscographyMissingAlbum(BaseModel):
+    album: Dict[str, Any]
+    missing_tracks: List[Dict[str, Any]] = Field(default_factory=list)
+
+
+class DiscographyMissingTrack(BaseModel):
+    album: Dict[str, Any]
+    track: Dict[str, Any]
+
+
+class DiscographyMatchingResponse(BaseModel):
+    missing_albums: List[DiscographyMissingAlbum] = Field(default_factory=list)
+    missing_tracks: List[DiscographyMissingTrack] = Field(default_factory=list)
 
 
 class AlbumMatchingRequest(BaseModel):

--- a/app/workers/__init__.py
+++ b/app/workers/__init__.py
@@ -1,5 +1,6 @@
 """Background worker exports."""
 from .auto_sync_worker import AutoSyncWorker
+from .discography_worker import DiscographyWorker
 from .matching_worker import MatchingWorker
 from .playlist_sync_worker import PlaylistSyncWorker
 from .metadata_worker import MetadataUpdateWorker
@@ -8,6 +9,7 @@ from .sync_worker import SyncWorker
 
 __all__ = [
     "AutoSyncWorker",
+    "DiscographyWorker",
     "MatchingWorker",
     "MetadataUpdateWorker",
     "PlaylistSyncWorker",

--- a/app/workers/discography_worker.py
+++ b/app/workers/discography_worker.py
@@ -1,0 +1,206 @@
+"""Discography download worker."""
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+from app.core.beets_client import BeetsClient
+from app.core.plex_client import PlexClient
+from app.core.soulseek_client import SoulseekClient
+from app.core.spotify_client import SpotifyClient
+from app.db import session_scope
+from app.logging import get_logger
+from app.models import DiscographyJob
+from app.routers.matching_router import calculate_discography_missing
+
+logger = get_logger(__name__)
+
+
+class DiscographyWorker:
+    """Process discography download jobs.
+
+    The worker relies on Spotify to provide the complete discography for an
+    artist.  Plex is queried to determine which tracks are already present.
+    Missing tracks are fetched from Soulseek and then handed over to Beets for
+    post-processing.
+    """
+
+    def __init__(
+        self,
+        spotify_client: SpotifyClient,
+        soulseek_client: SoulseekClient,
+        *,
+        plex_client: PlexClient | None = None,
+        beets_client: BeetsClient | None = None,
+    ) -> None:
+        self._spotify = spotify_client
+        self._soulseek = soulseek_client
+        self._plex = plex_client
+        self._beets = beets_client
+        self._queue: asyncio.Queue[Optional[int]] = asyncio.Queue()
+        self._task: asyncio.Task | None = None
+        self._running = False
+
+    async def start(self) -> None:
+        if self._task is not None and not self._task.done():
+            return
+        self._running = True
+        self._task = asyncio.create_task(self._run())
+
+    async def stop(self) -> None:
+        if not self._running:
+            return
+        self._running = False
+        await self._queue.put(None)
+        if self._task is not None:
+            await self._task
+            self._task = None
+
+    async def enqueue(self, job_id: int) -> None:
+        await self._queue.put(int(job_id))
+
+    async def run_job(self, job_id: int) -> None:
+        await self._process_job(int(job_id))
+
+    async def _run(self) -> None:
+        while self._running:
+            job_id = await self._queue.get()
+            if job_id is None:
+                break
+            try:
+                await self._process_job(job_id)
+            except Exception as exc:  # pragma: no cover - defensive logging
+                logger.exception("Discography job %s failed: %s", job_id, exc)
+
+    async def _process_job(self, job_id: int) -> None:
+        job = self._set_status(job_id, "in_progress")
+        if job is None:
+            return
+
+        artist_id = job.artist_id
+        artist_name = job.artist_name or ""
+
+        logger.info("Processing discography job %s for artist %s", job_id, artist_id)
+
+        try:
+            discography = self._spotify.get_artist_discography(artist_id)
+            albums = discography.get("albums") if isinstance(discography, dict) else []
+            plex_items = await self._fetch_existing_tracks(artist_name)
+            missing_albums, missing_tracks = calculate_discography_missing(
+                artist_id,
+                albums if isinstance(albums, list) else [],
+                plex_items,
+            )
+            await self._download_missing_tracks(missing_tracks, artist_name)
+            self._set_status(job_id, "done")
+        except Exception as exc:  # pragma: no cover - defensive logging
+            logger.exception("Failed to process discography job %s: %s", job_id, exc)
+            self._set_status(job_id, "failed")
+
+    def _set_status(self, job_id: int, status: str) -> Optional[DiscographyJob]:
+        with session_scope() as session:
+            job = session.get(DiscographyJob, int(job_id))
+            if job is None:
+                return None
+            job.status = status
+            return job
+
+    async def _fetch_existing_tracks(self, artist_name: str) -> List[Dict[str, Any]]:
+        if not artist_name or self._plex is None:
+            return []
+        getter = getattr(self._plex, "get_artist_tracks", None)
+        if getter is None:
+            return []
+        result = getter(artist_name)
+        if asyncio.iscoroutine(result):
+            return await result
+        return list(result or [])
+
+    async def _download_missing_tracks(
+        self,
+        missing_tracks: Iterable[Dict[str, Any]],
+        artist_name: str,
+    ) -> None:
+        for entry in missing_tracks:
+            if not isinstance(entry, dict):
+                continue
+            album = entry.get("album") if isinstance(entry.get("album"), dict) else {}
+            track = entry.get("track") if isinstance(entry.get("track"), dict) else {}
+            query = self._build_search_query(artist_name, album, track)
+            if not query:
+                continue
+            result = await self._soulseek.search(query)
+            username, file_info = self._select_download_candidate(result)
+            if not username or not file_info:
+                logger.warning("No Soulseek matches found for query %s", query)
+                continue
+            await self._soulseek.download({"username": username, "files": [file_info]})
+            self._import_with_beets(file_info)
+
+    @staticmethod
+    def _build_search_query(
+        artist_name: str,
+        album: Dict[str, Any],
+        track: Dict[str, Any],
+    ) -> str:
+        title = track.get("name") or track.get("title")
+        if not title:
+            return ""
+        artist = artist_name or ""
+        if not artist:
+            artists = track.get("artists")
+            if isinstance(artists, list) and artists:
+                first = artists[0]
+                if isinstance(first, dict):
+                    artist = first.get("name", "")
+        parts = [artist.strip(), title.strip()]
+        if album.get("name"):
+            parts.append(str(album.get("name")).strip())
+        return " ".join(part for part in parts if part)
+
+    @staticmethod
+    def _select_download_candidate(
+        result: Any,
+    ) -> Tuple[Optional[str], Optional[Dict[str, Any]]]:
+        if isinstance(result, dict):
+            candidates = result.get("results")
+            if isinstance(candidates, list):
+                for candidate in candidates:
+                    username, file_info = DiscographyWorker._extract_candidate(candidate)
+                    if username and file_info:
+                        return username, file_info
+        elif isinstance(result, list):
+            for candidate in result:
+                username, file_info = DiscographyWorker._extract_candidate(candidate)
+                if username and file_info:
+                    return username, file_info
+        return None, None
+
+    @staticmethod
+    def _extract_candidate(candidate: Any) -> Tuple[Optional[str], Optional[Dict[str, Any]]]:
+        if not isinstance(candidate, dict):
+            return None, None
+        username = candidate.get("username")
+        files = candidate.get("files")
+        if isinstance(files, list):
+            for file_info in files:
+                if isinstance(file_info, dict):
+                    enriched = dict(file_info)
+                    if "filename" not in enriched and "name" in enriched:
+                        enriched["filename"] = enriched["name"]
+                    return username, enriched
+        return None, None
+
+    def _import_with_beets(self, file_info: Dict[str, Any]) -> None:
+        if self._beets is None:
+            return
+        importer = getattr(self._beets, "import_file", None)
+        if importer is None:
+            return
+        filename = file_info.get("local_path") or file_info.get("path") or file_info.get("filename")
+        if not filename:
+            return
+        try:
+            importer(str(filename), quiet=True)
+        except Exception as exc:  # pragma: no cover - defensive logging
+            logger.warning("Beets import failed for %s: %s", filename, exc)

--- a/tests/test_discography.py
+++ b/tests/test_discography.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+import pytest
+
+from app.db import session_scope
+from app.models import DiscographyJob
+from app.workers.discography_worker import DiscographyWorker
+
+
+class SpotifyDiscographyStub:
+    def __init__(self, albums: list[dict]) -> None:
+        self.albums = albums
+        self.requests: list[str] = []
+
+    def get_artist_discography(self, artist_id: str) -> dict:
+        self.requests.append(artist_id)
+        return {"artist_id": artist_id, "albums": list(self.albums)}
+
+
+class PlexDiscographyStub:
+    def __init__(self, track_ids: list[str]) -> None:
+        self.track_ids = track_ids
+        self.lookups: list[str] = []
+
+    async def get_artist_tracks(self, artist_name: str) -> list[dict]:
+        self.lookups.append(artist_name)
+        return [{"guid": f"spotify://track:{track_id}"} for track_id in self.track_ids]
+
+
+class SoulseekDiscographyStub:
+    def __init__(self) -> None:
+        self.search_queries: list[str] = []
+        self.download_payloads: list[dict] = []
+
+    async def search(self, query: str) -> dict:
+        self.search_queries.append(query)
+        return {
+            "results": [
+                {
+                    "username": "collector",
+                    "files": [
+                        {
+                            "filename": f"{query}.flac",
+                            "size": 1024,
+                        }
+                    ],
+                }
+            ]
+        }
+
+    async def download(self, payload: dict) -> None:
+        self.download_payloads.append(payload)
+
+
+class BeetsImportStub:
+    def __init__(self) -> None:
+        self.imports: list[str] = []
+
+    def import_file(self, path: str, quiet: bool = True) -> str:  # pragma: no cover - simple stub
+        self.imports.append(path)
+        return path
+
+
+def _create_job(artist_id: str, artist_name: str) -> int:
+    with session_scope() as session:
+        job = DiscographyJob(artist_id=artist_id, artist_name=artist_name, status="pending")
+        session.add(job)
+        session.flush()
+        return job.id
+
+
+@pytest.mark.asyncio
+async def test_discography_worker_processes_complete_discography() -> None:
+    albums = [
+        {
+            "album": {"id": "album-1", "name": "First"},
+            "tracks": [
+                {"id": "track-1", "name": "Track One"},
+                {"id": "track-2", "name": "Track Two"},
+            ],
+        },
+        {
+            "album": {"id": "album-2", "name": "Second"},
+            "tracks": [
+                {"id": "track-3", "name": "Track Three"},
+            ],
+        },
+    ]
+    spotify = SpotifyDiscographyStub(albums)
+    plex = PlexDiscographyStub(track_ids=[])
+    soulseek = SoulseekDiscographyStub()
+    beets = BeetsImportStub()
+
+    worker = DiscographyWorker(
+        spotify,
+        soulseek,
+        plex_client=plex,
+        beets_client=beets,
+    )
+
+    job_id = _create_job("artist-1", "Test Artist")
+
+    await worker.run_job(job_id)
+
+    with session_scope() as session:
+        job = session.get(DiscographyJob, job_id)
+        assert job is not None
+        assert job.status == "done"
+
+    assert spotify.requests == ["artist-1"]
+    assert len(soulseek.download_payloads) == 3
+    assert len(beets.imports) == 3
+
+
+@pytest.mark.asyncio
+async def test_discography_worker_downloads_only_missing_tracks() -> None:
+    albums = [
+        {
+            "album": {"id": "album-1", "name": "First"},
+            "tracks": [
+                {"id": "track-1", "name": "Track One"},
+                {"id": "track-2", "name": "Track Two"},
+            ],
+        }
+    ]
+    spotify = SpotifyDiscographyStub(albums)
+    plex = PlexDiscographyStub(track_ids=["track-1"])
+    soulseek = SoulseekDiscographyStub()
+    beets = BeetsImportStub()
+
+    worker = DiscographyWorker(
+        spotify,
+        soulseek,
+        plex_client=plex,
+        beets_client=beets,
+    )
+
+    job_id = _create_job("artist-2", "Another Artist")
+
+    await worker.run_job(job_id)
+
+    with session_scope() as session:
+        job = session.get(DiscographyJob, job_id)
+        assert job is not None
+        assert job.status == "done"
+
+    assert len(soulseek.download_payloads) == 1
+    assert soulseek.download_payloads[0]["files"][0]["filename"].startswith("Another Artist Track Two")
+
+
+def test_discography_download_endpoint_persists_job(client) -> None:
+    response = client.post(
+        "/soulseek/discography/download",
+        json={"artist_id": "artist-3", "artist_name": "Integration"},
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["status"] == "pending"
+
+    job_id = payload["job_id"]
+    with session_scope() as session:
+        job = session.get(DiscographyJob, job_id)
+        assert job is not None
+        assert job.artist_id == "artist-3"
+        assert job.artist_name == "Integration"


### PR DESCRIPTION
## Summary
- add DiscographyJob persistence and expose new Spotify and Soulseek endpoints for complete artist discographies
- introduce a DiscographyWorker that orchestrates Spotify, Plex, Soulseek, and Beets to fill missing releases and import them
- extend matching schemas/router and documentation, plus cover the new workflow with unit and integration tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d4ce11bc8883219df1f0d83e09e334