### PR TITLE
feat: embed high quality artwork into downloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,6 @@
 
 ## v1.x.x
 
-- Rich Metadata und High-Quality Artwork implementiert: Tags + Cover werden nach jedem Download ergänzt.
+- High-Quality Artwork – eigener Worker lädt Albumcover in maximaler Auflösung, bettet sie in Audiodateien ein und stellt den Endpoint `GET /soulseek/download/{id}/artwork` bereit.
 - Complete Discographies – gesamte Künstlerdiskografien können automatisch heruntergeladen und kategorisiert werden.
 - Automatic Lyrics – alle neuen Downloads enthalten synchronisierte Lyrics (.lrc).

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ und stellt einheitliche JSON-APIs für Automatisierungen und Frontend-Clients be
 - **Async Plex-Client** mit Zugriff auf Bibliotheken, Sessions, PlayQueues, Live-TV und Echtzeit-Benachrichtigungen.
 - **Soulseek-Anbindung** inklusive Download-/Upload-Verwaltung, Warteschlangen und Benutzerinformationen.
 - **Beets CLI Bridge** zum Importieren, Aktualisieren, Verschieben und Abfragen der lokalen Musikbibliothek.
-- **Automatische Metadaten-Anreicherung**: Nach jedem Download ergänzt Harmony Genre, Komponist, Produzent, ISRC und bettet das Original-Coverbild ein.
+- **Automatische Metadaten-Anreicherung**: Nach jedem Download ergänzt Harmony Genre, Komponist, Produzent, ISRC und bettet das Cover nun in höchster verfügbarer Auflösung ein.
 - **Automatic Lyrics**: Für jeden neuen Download erzeugt Harmony automatisch eine synchronisierte LRC-Datei mit passenden Songtexten.
 - **Matching-Engine** zur Ermittlung der besten Kandidaten zwischen Spotify ↔ Plex/Soulseek inklusive Persistierung.
 - **SQLite-Datenbank** mit SQLAlchemy-Modellen für Playlists, Downloads, Matches und Settings.
@@ -39,6 +39,10 @@ nachverfolgt werden.
 ## Automatic Lyrics
 
 Nach erfolgreich abgeschlossenen Downloads erstellt Harmony automatisch eine `.lrc`-Datei mit synchronisierten Lyrics und legt sie im gleichen Verzeichnis wie die Audiodatei ab. Der Fortschritt wird im Download-Datensatz gespeichert. Über den neuen Endpunkt `GET /soulseek/download/{id}/lyrics` lässt sich der Inhalt der generierten LRC-Datei abrufen; solange die Generierung noch läuft, liefert der Endpunkt einen entsprechenden Status.
+
+## High-Quality Artwork
+
+Der Artwork-Worker lauscht auf abgeschlossene Downloads und lädt das zugehörige Albumcover in maximaler Spotify-Auflösung herunter. Fällt die Spotify-Quelle aus, werden vorhandene Plex- oder Soulseek-Informationen als Fallback genutzt. Das Bild wird im Zielordner als `cover.jpg`/`cover.png` abgelegt und mittels Mutagen direkt in die Audiodatei eingebettet. Über den Endpoint `GET /soulseek/download/{id}/artwork` lässt sich das Cover als Pfad, Base64-kodierter Inhalt oder direkt als Binärdaten abrufen.
 
 ## Harmony Web UI
 

--- a/app/models.py
+++ b/app/models.py
@@ -51,6 +51,8 @@ class Download(Base):
     producer = Column(String(255), nullable=True)
     isrc = Column(String(64), nullable=True)
     artwork_url = Column(String(2048), nullable=True)
+    artwork_path = Column(String(2048), nullable=True)
+    artwork_status = Column(String(32), nullable=False, default="pending")
     lyrics_path = Column(String(2048), nullable=True)
     lyrics_status = Column(String(32), nullable=False, default="pending")
     request_payload = Column(JSON, nullable=True)

--- a/app/utils/artwork_utils.py
+++ b/app/utils/artwork_utils.py
@@ -1,0 +1,137 @@
+"""Utility helpers for downloading and embedding artwork files."""
+from __future__ import annotations
+
+import mimetypes
+import os
+import tempfile
+from pathlib import Path
+
+import httpx
+
+from app.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+def _guess_extension(url: str, content_type: str | None) -> str:
+    """Guess a sensible file extension for an artwork file."""
+
+    if content_type:
+        guessed = mimetypes.guess_extension(content_type.split(";")[0].strip())
+        if guessed:
+            return guessed
+
+    suffix = Path(url).suffix
+    if suffix:
+        return suffix
+
+    return ".jpg"
+
+
+def download_artwork(url: str) -> Path:
+    """Download an artwork image and return the temporary file path.
+
+    The caller is responsible for moving the returned file to its final
+    destination.  A temporary file is always created to avoid partially
+    written output when the network transfer fails.
+    """
+
+    if not url:
+        raise ValueError("Artwork URL must be provided")
+
+    try:
+        with httpx.Client(timeout=15.0) as client:
+            response = client.get(url)
+            response.raise_for_status()
+    except httpx.HTTPError as exc:  # pragma: no cover - network failure
+        logger.debug("Failed to download artwork from %s: %s", url, exc)
+        raise
+
+    suffix = _guess_extension(url, response.headers.get("content-type"))
+    fd, temp_path = tempfile.mkstemp(prefix="harmony-artwork-", suffix=suffix)
+    try:
+        with os.fdopen(fd, "wb") as handle:
+            handle.write(response.content)
+    except Exception:
+        os.unlink(temp_path)
+        raise
+    return Path(temp_path)
+
+
+def embed_artwork(audio_file: Path, artwork_file: Path) -> None:
+    """Embed the supplied artwork image into the audio file using mutagen."""
+
+    audio_path = Path(audio_file)
+    image_path = Path(artwork_file)
+
+    if not audio_path.exists():
+        raise FileNotFoundError(f"Audio file not found: {audio_path}")
+    if not image_path.exists():
+        raise FileNotFoundError(f"Artwork file not found: {image_path}")
+
+    try:  # pragma: no cover - import guarded for optional dependency
+        from mutagen.flac import FLAC, Picture
+        from mutagen.id3 import APIC, ID3, ID3NoHeaderError
+        from mutagen.mp4 import MP4, MP4Cover
+    except ImportError as exc:  # pragma: no cover - defensive logging
+        raise RuntimeError("mutagen is required to embed artwork") from exc
+
+    suffix = audio_path.suffix.lower()
+    mime_type = mimetypes.guess_type(str(image_path))[0] or "image/jpeg"
+    image_data = image_path.read_bytes()
+
+    if suffix in {".mp3", ".wav", ".aiff", ".aif"}:
+        try:
+            tags = ID3(audio_path)
+        except ID3NoHeaderError:
+            tags = ID3()
+        tags.delall("APIC")
+        tags.add(
+            APIC(
+                encoding=3,
+                mime=mime_type,
+                type=3,
+                desc="Cover",
+                data=image_data,
+            )
+        )
+        tags.save(audio_path)
+        return
+
+    if suffix == ".flac":
+        audio = FLAC(audio_path)
+        picture = Picture()
+        picture.type = 3
+        picture.mime = mime_type
+        picture.desc = "Cover"
+        picture.data = image_data
+        audio.clear_pictures()
+        audio.add_picture(picture)
+        audio.save()
+        return
+
+    if suffix in {".m4a", ".mp4", ".aac", ".m4b"}:
+        cover_format = MP4Cover.FORMAT_PNG if mime_type == "image/png" else MP4Cover.FORMAT_JPEG
+        mp4 = MP4(audio_path)
+        mp4.tags["covr"] = [MP4Cover(image_data, imageformat=cover_format)]
+        mp4.save()
+        return
+
+    # Fall back to ID3 if mutagen supports the format; this covers formats
+    # such as WMA that share the same tagging structure.
+    try:
+        tags = ID3(audio_path)
+    except ID3NoHeaderError:
+        tags = ID3()
+    tags.delall("APIC")
+    tags.add(
+        APIC(
+            encoding=3,
+            mime=mime_type,
+            type=3,
+            desc="Cover",
+            data=image_data,
+        )
+    )
+    tags.save(audio_path)
+

--- a/app/workers/__init__.py
+++ b/app/workers/__init__.py
@@ -1,4 +1,5 @@
 """Background worker exports."""
+from .artwork_worker import ArtworkWorker
 from .auto_sync_worker import AutoSyncWorker
 from .discography_worker import DiscographyWorker
 from .matching_worker import MatchingWorker
@@ -9,6 +10,7 @@ from .sync_worker import SyncWorker
 from .lyrics_worker import LyricsWorker
 
 __all__ = [
+    "ArtworkWorker",
     "AutoSyncWorker",
     "DiscographyWorker",
     "MatchingWorker",

--- a/app/workers/artwork_worker.py
+++ b/app/workers/artwork_worker.py
@@ -1,0 +1,274 @@
+"""Background worker responsible for fetching and embedding artwork."""
+from __future__ import annotations
+
+import asyncio
+import shutil
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, Mapping, Optional
+
+from app.core.plex_client import PlexClient
+from app.core.soulseek_client import SoulseekClient
+from app.core.spotify_client import SpotifyClient
+from app.db import session_scope
+from app.logging import get_logger
+from app.models import Download
+from app.utils.artwork_utils import download_artwork, embed_artwork
+
+logger = get_logger(__name__)
+
+
+@dataclass(slots=True)
+class ArtworkJob:
+    download_id: Optional[int]
+    file_path: str
+    metadata: Dict[str, Any]
+    spotify_track_id: Optional[str]
+    artwork_url: Optional[str]
+
+
+class ArtworkWorker:
+    """Download high-resolution artwork and embed it into media files."""
+
+    def __init__(
+        self,
+        spotify_client: SpotifyClient | None = None,
+        plex_client: PlexClient | None = None,
+        soulseek_client: SoulseekClient | None = None,
+    ) -> None:
+        self._spotify = spotify_client
+        self._plex = plex_client
+        self._soulseek = soulseek_client
+        self._queue: asyncio.Queue[Optional[ArtworkJob]] = asyncio.Queue()
+        self._task: asyncio.Task[None] | None = None
+        self._running = False
+
+    async def start(self) -> None:
+        if self._task is not None and not self._task.done():
+            return
+        self._running = True
+        self._task = asyncio.create_task(self._run())
+
+    async def stop(self) -> None:
+        if not self._running:
+            return
+        self._running = False
+        await self._queue.put(None)
+        if self._task is not None:
+            try:
+                await self._task
+            finally:
+                self._task = None
+
+    async def wait_for_pending(self) -> None:
+        await self._queue.join()
+
+    async def enqueue(
+        self,
+        download_id: int | None,
+        file_path: str,
+        *,
+        metadata: Mapping[str, Any] | None = None,
+        spotify_track_id: str | None = None,
+        artwork_url: str | None = None,
+    ) -> None:
+        job = ArtworkJob(
+            download_id=int(download_id) if download_id is not None else None,
+            file_path=str(file_path),
+            metadata=dict(metadata or {}),
+            spotify_track_id=spotify_track_id,
+            artwork_url=artwork_url,
+        )
+        if not self._running:
+            await self._process_job(job)
+            return
+        await self._queue.put(job)
+
+    async def _run(self) -> None:
+        while True:
+            job = await self._queue.get()
+            if job is None:
+                self._queue.task_done()
+                break
+            try:
+                await self._process_job(job)
+            except Exception as exc:  # pragma: no cover - defensive logging
+                logger.exception("Artwork job failed: %s", exc)
+            finally:
+                self._queue.task_done()
+
+    async def _process_job(self, job: ArtworkJob) -> None:
+        download_id = job.download_id
+        if download_id is not None:
+            self._update_download(download_id, status="pending", path=None)
+
+        try:
+            artwork_path = await self._handle_job(job)
+        except Exception as exc:
+            if download_id is not None:
+                self._update_download(download_id, status="failed", path=None)
+            logger.debug("Artwork processing failed for %s: %s", download_id, exc)
+            return
+
+        if download_id is not None:
+            self._update_download(download_id, status="done", path=str(artwork_path))
+
+    async def _handle_job(self, job: ArtworkJob) -> Path:
+        audio_path = Path(job.file_path)
+        if not audio_path.exists():
+            raise FileNotFoundError(f"Audio file not found: {audio_path}")
+
+        candidates = await self._collect_candidate_urls(job)
+        artwork_file: Path | None = None
+        for url in candidates:
+            try:
+                artwork_file = await asyncio.to_thread(download_artwork, url)
+            except Exception:
+                continue
+            if artwork_file.exists():
+                break
+
+        if artwork_file is None or not artwork_file.exists():
+            raise ValueError("Unable to retrieve artwork image")
+
+        target = self._store_artwork(audio_path, artwork_file)
+        await asyncio.to_thread(embed_artwork, audio_path, target)
+        return target
+
+    async def _collect_candidate_urls(self, job: ArtworkJob) -> list[str]:
+        urls: list[str] = []
+
+        spotify_url = await asyncio.to_thread(self._get_spotify_artwork_url, job.spotify_track_id)
+        if spotify_url:
+            urls.append(spotify_url)
+
+        metadata_url = self._extract_metadata_artwork(job.metadata)
+        if metadata_url and metadata_url not in urls:
+            urls.append(metadata_url)
+
+        if job.artwork_url and job.artwork_url not in urls:
+            urls.append(job.artwork_url)
+
+        urls.extend(self._extract_additional_urls(job.metadata))
+
+        # Deduplicate whilst preserving order.
+        seen: set[str] = set()
+        unique_urls: list[str] = []
+        for url in urls:
+            if not url or url in seen:
+                continue
+            seen.add(url)
+            unique_urls.append(url)
+        return unique_urls
+
+    def _get_spotify_artwork_url(self, track_id: str | None) -> Optional[str]:
+        if not track_id or self._spotify is None:
+            return None
+        try:
+            track = self._spotify.get_track_details(track_id)
+        except Exception as exc:  # pragma: no cover - defensive logging
+            logger.debug("Spotify lookup failed for %s: %s", track_id, exc)
+            return None
+        if not isinstance(track, Mapping):
+            return None
+
+        album = track.get("album")
+        if isinstance(album, Mapping):
+            url = self._pick_best_image(album.get("images"))
+            if url:
+                return url
+
+        # Some Spotify payloads return images at the top level.
+        url = self._pick_best_image(track.get("images"))
+        if url:
+            return url
+
+        return None
+
+    def _extract_metadata_artwork(self, metadata: Mapping[str, Any]) -> Optional[str]:
+        keys = (
+            "artwork_url",
+            "cover_url",
+            "image_url",
+            "thumbnail",
+            "thumb",
+        )
+        for key in keys:
+            value = metadata.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+        album = metadata.get("album")
+        if isinstance(album, Mapping):
+            url = self._pick_best_image(album.get("images"))
+            if url:
+                return url
+        return None
+
+    def _extract_additional_urls(self, metadata: Mapping[str, Any]) -> list[str]:
+        urls: list[str] = []
+        candidates = metadata.get("artwork_urls")
+        if isinstance(candidates, list):
+            for entry in candidates:
+                if isinstance(entry, str) and entry.strip():
+                    urls.append(entry.strip())
+                elif isinstance(entry, Mapping):
+                    url = entry.get("url")
+                    if isinstance(url, str) and url.strip():
+                        urls.append(url.strip())
+
+        # Plex metadata can expose an absolute URL via the thumb key.
+        plex_thumb = metadata.get("plex_thumb") or metadata.get("plex_artwork")
+        if isinstance(plex_thumb, str) and plex_thumb.strip():
+            urls.append(plex_thumb.strip())
+
+        soulseek_url = metadata.get("soulseek_artwork")
+        if isinstance(soulseek_url, str) and soulseek_url.strip():
+            urls.append(soulseek_url.strip())
+
+        return urls
+
+    @staticmethod
+    def _pick_best_image(images: Any) -> Optional[str]:
+        if not isinstance(images, list):
+            return None
+        best_url: Optional[str] = None
+        best_score = -1
+        for item in images:
+            if not isinstance(item, Mapping):
+                continue
+            url = item.get("url")
+            if not url:
+                continue
+            width = int(item.get("width") or 0)
+            height = int(item.get("height") or 0)
+            score = width * height
+            if score > best_score:
+                best_score = score
+                best_url = str(url)
+        return best_url
+
+    @staticmethod
+    def _store_artwork(audio_path: Path, artwork_path: Path) -> Path:
+        target_dir = audio_path.parent
+        suffix = artwork_path.suffix or ".jpg"
+        target = target_dir / f"cover{suffix}"
+        target_dir.mkdir(parents=True, exist_ok=True)
+        try:
+            if target.exists():
+                target.unlink()
+        except OSError:  # pragma: no cover - defensive cleanup
+            logger.debug("Unable to remove existing artwork at %s", target)
+        shutil.move(str(artwork_path), target)
+        return target
+
+    def _update_download(self, download_id: int, *, status: str, path: str | None) -> None:
+        with session_scope() as session:
+            download = session.get(Download, int(download_id))
+            if download is None:
+                return
+            download.artwork_status = status
+            download.artwork_path = path
+            download.updated_at = datetime.utcnow()
+            session.add(download)
+

--- a/tests/test_artwork.py
+++ b/tests/test_artwork.py
@@ -1,0 +1,176 @@
+import base64
+from pathlib import Path
+from typing import Any, Dict
+
+import pytest
+
+from app.db import session_scope
+from app.models import Download
+from app.workers.artwork_worker import ArtworkWorker
+from app.workers.sync_worker import SyncWorker
+from app.utils import artwork_utils
+from app.workers import artwork_worker as artwork_worker_module
+from tests.conftest import StubSoulseekClient
+
+
+@pytest.mark.asyncio
+async def test_artwork_worker_fetches_spotify_cover(monkeypatch, tmp_path) -> None:
+    audio_path = tmp_path / "track.mp3"
+    audio_path.write_bytes(b"audio")
+
+    with session_scope() as session:
+        download = Download(
+            filename=str(audio_path),
+            state="completed",
+            progress=100.0,
+        )
+        session.add(download)
+        session.commit()
+        session.refresh(download)
+        download_id = download.id
+
+    source_cover = tmp_path / "temp.jpg"
+
+    def fake_download(url: str) -> Path:
+        source_cover.write_bytes(b"image-bytes")
+        return source_cover
+
+    embedded: Dict[str, Path] = {}
+
+    def fake_embed(audio_file: Path, artwork_file: Path) -> None:
+        embedded["audio"] = Path(audio_file)
+        embedded["artwork"] = Path(artwork_file)
+
+    monkeypatch.setattr(artwork_utils, "download_artwork", fake_download)
+    monkeypatch.setattr(artwork_utils, "embed_artwork", fake_embed)
+    monkeypatch.setattr(artwork_worker_module, "download_artwork", fake_download)
+    monkeypatch.setattr(artwork_worker_module, "embed_artwork", fake_embed)
+
+    class StubSpotify:
+        def get_track_details(self, track_id: str) -> Dict[str, Any]:
+            assert track_id == "spotify-track"
+            return {
+                "album": {
+                    "images": [
+                        {"url": "http://example.com/cover.jpg", "width": 1000, "height": 1000}
+                    ]
+                }
+            }
+
+    worker = ArtworkWorker(spotify_client=StubSpotify())
+    await worker.start()
+    try:
+        await worker.enqueue(
+            download_id,
+            str(audio_path),
+            metadata={},
+            spotify_track_id="spotify-track",
+        )
+        await worker.wait_for_pending()
+    finally:
+        await worker.stop()
+
+    assert embedded["audio"] == audio_path
+    stored_cover = embedded["artwork"]
+    assert stored_cover.exists()
+    assert stored_cover.parent == audio_path.parent
+    assert stored_cover.read_bytes() == b"image-bytes"
+
+    with session_scope() as session:
+        refreshed = session.get(Download, download_id)
+        assert refreshed is not None
+        assert refreshed.artwork_status == "done"
+        assert Path(refreshed.artwork_path or "") == stored_cover
+
+
+@pytest.mark.asyncio
+async def test_sync_worker_schedules_artwork(tmp_path) -> None:
+    audio_path = tmp_path / "sync.mp3"
+    audio_path.write_bytes(b"audio")
+
+    with session_scope() as session:
+        download = Download(
+            filename=str(audio_path),
+            state="completed",
+            progress=100.0,
+            request_payload={
+                "spotify_id": "track-123",
+                "metadata": {"artwork_url": "http://existing.example/cover.jpg"},
+            },
+        )
+        session.add(download)
+        session.commit()
+        session.refresh(download)
+        download_id = download.id
+
+    class StubArtworkWorker:
+        def __init__(self) -> None:
+            self.jobs: list[Dict[str, Any]] = []
+
+        async def enqueue(
+            self,
+            download_id: int | None,
+            file_path: str,
+            *,
+            metadata: Dict[str, Any] | None = None,
+            spotify_track_id: str | None = None,
+            artwork_url: str | None = None,
+        ) -> None:
+            self.jobs.append(
+                {
+                    "download_id": download_id,
+                    "file_path": file_path,
+                    "metadata": dict(metadata or {}),
+                    "spotify_track_id": spotify_track_id,
+                    "artwork_url": artwork_url,
+                }
+            )
+
+    artwork_worker = StubArtworkWorker()
+    sync_worker = SyncWorker(
+        StubSoulseekClient(),
+        artwork_worker=artwork_worker,
+    )
+
+    payload = {
+        "download_id": download_id,
+        "state": "completed",
+        "local_path": str(audio_path),
+    }
+
+    await sync_worker._handle_download_completion(download_id, payload)
+
+    assert len(artwork_worker.jobs) == 1
+    job = artwork_worker.jobs[0]
+    assert job["download_id"] == download_id
+    assert job["file_path"] == str(audio_path)
+    assert job["spotify_track_id"] == "track-123"
+    assert job["artwork_url"] == "http://existing.example/cover.jpg"
+
+
+def test_artwork_endpoint_returns_base64(client, tmp_path) -> None:
+    cover_path = tmp_path / "cover.png"
+    cover_path.write_bytes(b"png-bytes")
+
+    with session_scope() as session:
+        download = Download(
+            filename="song.mp3",
+            state="completed",
+            progress=100.0,
+            artwork_status="done",
+            artwork_path=str(cover_path),
+        )
+        session.add(download)
+        session.commit()
+        session.refresh(download)
+        download_id = download.id
+
+    response = client.get(
+        f"/soulseek/download/{download_id}/artwork",
+        params={"format": "base64"},
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["status"] == "done"
+    assert payload["mime_type"].startswith("image/")
+    assert base64.b64decode(payload["data"]) == b"png-bytes"


### PR DESCRIPTION
## Summary
- add an ArtworkWorker plus utilities to download and embed cover images
- update models, workers and Soulseek router to persist artwork metadata and expose a new endpoint
- document the high-quality artwork flow and cover it with focused tests

## Testing
- pytest tests/test_artwork.py tests/test_lyrics.py tests/test_sync.py

------
https://chatgpt.com/codex/tasks/task_e_68d4d7f8185483218809e3dc5f65b5ea