### PR TITLE
feat: embed high-quality artwork for downloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v1.x.x
 
-- High-Quality Artwork – eigener Worker lädt Albumcover in maximaler Auflösung, bettet sie in Audiodateien ein und stellt den Endpoint `GET /soulseek/download/{id}/artwork` bereit.
+- High-Quality Artwork – Downloads enthalten automatisch eingebettete Cover in Originalauflösung, gespeichert unter `/artwork/` inklusive neuem Refresh-Endpoint `POST /soulseek/download/{id}/artwork/refresh`.
 - Rich Metadata – alle Downloads enthalten zusätzliche Tags (Genre, Komponist, Produzent, ISRC, Copyright) und können per `GET /soulseek/download/{id}/metadata` abgerufen werden.
 - Complete Discographies – gesamte Künstlerdiskografien können automatisch heruntergeladen und kategorisiert werden.
 - Automatic Lyrics – Downloads enthalten jetzt synchronisierte `.lrc`-Dateien mit Songtexten aus der Spotify-API (Fallback Musixmatch/lyrics.ovh) samt neuen Endpunkten zum Abruf und Refresh.

--- a/README.md
+++ b/README.md
@@ -73,7 +73,9 @@ Beispielantwort:
 
 ## High-Quality Artwork
 
-Der Artwork-Worker lauscht auf abgeschlossene Downloads und lädt das zugehörige Albumcover in maximaler Spotify-Auflösung herunter. Fällt die Spotify-Quelle aus, werden vorhandene Plex- oder Soulseek-Informationen als Fallback genutzt. Das Bild wird im Zielordner als `cover.jpg`/`cover.png` abgelegt und mittels Mutagen direkt in die Audiodatei eingebettet. Über den Endpoint `GET /soulseek/download/{id}/artwork` lässt sich das Cover als Pfad, Base64-kodierter Inhalt oder direkt als Binärdaten abrufen.
+Der Artwork-Worker lauscht auf abgeschlossene Downloads und lädt das zugehörige Albumcover in maximaler Spotify-Auflösung herunter. Die Originaldatei wird zentral im Verzeichnis `./artwork/` (bzw. per `HARMONY_ARTWORK_DIR`) abgelegt und anschließend mit Mutagen in die Audiodatei eingebettet. Schlägt der Spotify-Abruf fehl, versucht Harmony das Artwork über Plex-Metadaten, Soulseek oder externe Dienste wie Last.fm oder MusicBrainz zu ermitteln. Der Download-Datensatz speichert den Speicherort (`artwork_path`) sowie den Status (`has_artwork`).
+
+Über den Endpoint `GET /soulseek/download/{id}/artwork` liefert die API das eingebettete Cover direkt als `image/jpeg` (inkl. korrektem MIME-Type). Mit `POST /soulseek/download/{id}/artwork/refresh` lässt sich jederzeit ein erneuter Abruf auslösen, etwa wenn bessere Quellen verfügbar geworden sind.
 
 ## Harmony Web UI
 

--- a/app/core/spotify_client.py
+++ b/app/core/spotify_client.py
@@ -122,6 +122,11 @@ class SpotifyClient:
     def add_tracks_to_playlist(self, playlist_id: str, track_uris: List[str]) -> Dict[str, Any]:
         return self._execute(self._client.playlist_add_items, playlist_id, track_uris)
 
+    def get_album_details(self, album_id: str) -> Dict[str, Any]:
+        """Return metadata for a single Spotify album."""
+
+        return self._execute(self._client.album, album_id)
+
     def remove_tracks_from_playlist(self, playlist_id: str, track_uris: List[str]) -> Dict[str, Any]:
         return self._execute(
             self._client.playlist_remove_all_occurrences_of_items, playlist_id, track_uris

--- a/app/models.py
+++ b/app/models.py
@@ -54,6 +54,7 @@ class Download(Base):
     artwork_url = Column(String(2048), nullable=True)
     artwork_path = Column(String(2048), nullable=True)
     artwork_status = Column(String(32), nullable=False, default="pending")
+    has_artwork = Column(Boolean, nullable=False, default=False)
     lyrics_path = Column(String(2048), nullable=True)
     lyrics_status = Column(String(32), nullable=False, default="pending")
     has_lyrics = Column(Boolean, nullable=False, default=False)

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -133,6 +133,9 @@ class SoulseekDownloadEntry(BaseModel):
     isrc: Optional[str] = None
     copyright: Optional[str] = None
     artwork_url: Optional[str] = None
+    artwork_path: Optional[str] = None
+    artwork_status: Optional[str] = None
+    has_artwork: Optional[bool] = None
     lyrics_status: Optional[str] = None
     lyrics_path: Optional[str] = None
     has_lyrics: Optional[bool] = None
@@ -160,6 +163,9 @@ class DownloadEntryResponse(BaseModel):
     isrc: Optional[str] = None
     copyright: Optional[str] = None
     artwork_url: Optional[str] = None
+    artwork_path: Optional[str] = None
+    artwork_status: Optional[str] = None
+    has_artwork: Optional[bool] = None
     lyrics_status: Optional[str] = None
     lyrics_path: Optional[str] = None
     has_lyrics: Optional[bool] = None

--- a/app/utils/artwork_utils.py
+++ b/app/utils/artwork_utils.py
@@ -4,13 +4,17 @@ from __future__ import annotations
 import mimetypes
 import os
 import tempfile
+import uuid
 from pathlib import Path
+from typing import Any, Optional
 
 import httpx
 
 from app.logging import get_logger
 
 logger = get_logger(__name__)
+
+SPOTIFY_CLIENT: Any | None = None
 
 
 def _guess_extension(url: str, content_type: str | None) -> str:
@@ -28,13 +32,59 @@ def _guess_extension(url: str, content_type: str | None) -> str:
     return ".jpg"
 
 
-def download_artwork(url: str) -> Path:
-    """Download an artwork image and return the temporary file path.
+def fetch_spotify_artwork(album_id: str) -> Optional[str]:
+    """Return the highest resolution Spotify artwork URL for an album."""
 
-    The caller is responsible for moving the returned file to its final
-    destination.  A temporary file is always created to avoid partially
-    written output when the network transfer fails.
-    """
+    if not album_id:
+        return None
+
+    client = SPOTIFY_CLIENT
+    if client is None:
+        logger.debug("Spotify artwork requested for %s but no client configured", album_id)
+        return None
+
+    try:
+        album_payload = client.get_album_details(album_id)
+    except Exception as exc:  # pragma: no cover - defensive logging
+        logger.debug("Spotify album lookup failed for %s: %s", album_id, exc)
+        return None
+
+    if not isinstance(album_payload, dict):
+        return None
+
+    images = album_payload.get("images")
+    if not isinstance(images, list):
+        return None
+
+    best_url: Optional[str] = None
+    best_score = -1
+    for entry in images:
+        if not isinstance(entry, dict):
+            continue
+        url = entry.get("url")
+        if not isinstance(url, str) or not url.strip():
+            continue
+        width = int(entry.get("width") or 0)
+        height = int(entry.get("height") or 0)
+        score = width * height
+        if score > best_score:
+            best_score = score
+            best_url = url.strip()
+
+    return best_url
+
+
+def _resolve_destination(path: Path, suffix: str) -> Path:
+    if path.suffix:
+        return path
+    if path.exists() and path.is_dir():
+        filename = f"{uuid.uuid4().hex}{suffix}"
+        return path / filename
+    return path.with_suffix(suffix)
+
+
+def download_artwork(url: str, path: Path) -> Path:
+    """Download artwork to the desired location and return the stored path."""
 
     if not url:
         raise ValueError("Artwork URL must be provided")
@@ -48,14 +98,21 @@ def download_artwork(url: str) -> Path:
         raise
 
     suffix = _guess_extension(url, response.headers.get("content-type"))
+    destination = _resolve_destination(Path(path), suffix)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+
     fd, temp_path = tempfile.mkstemp(prefix="harmony-artwork-", suffix=suffix)
     try:
         with os.fdopen(fd, "wb") as handle:
             handle.write(response.content)
+        if destination.exists():
+            destination.unlink()
+        os.replace(temp_path, destination)
     except Exception:
         os.unlink(temp_path)
         raise
-    return Path(temp_path)
+
+    return destination
 
 
 def embed_artwork(audio_file: Path, artwork_file: Path) -> None:

--- a/app/workers/discography_worker.py
+++ b/app/workers/discography_worker.py
@@ -304,11 +304,15 @@ class DiscographyWorker:
             download_identifier = None
 
         metadata: Dict[str, Any] = {}
+        spotify_album_id = None
         if isinstance(album, dict):
             metadata["album"] = dict(album)
             images = album.get("images")
             if isinstance(images, list):
                 metadata.setdefault("artwork_urls", []).extend(images)
+            candidate = album.get("id") or album.get("spotify_id") or album.get("spotifyId")
+            if isinstance(candidate, str) and candidate.strip():
+                spotify_album_id = candidate.strip()
 
         artwork_url = None
         if isinstance(track, dict):
@@ -328,6 +332,7 @@ class DiscographyWorker:
                 str(file_path),
                 metadata=metadata,
                 spotify_track_id=spotify_track_id,
+                spotify_album_id=spotify_album_id,
                 artwork_url=artwork_url if isinstance(artwork_url, str) else None,
             )
         except Exception as exc:  # pragma: no cover - defensive logging

--- a/tests/test_artwork.py
+++ b/tests/test_artwork.py
@@ -1,4 +1,3 @@
-import base64
 from pathlib import Path
 from typing import Any, Dict
 
@@ -6,10 +5,9 @@ import pytest
 
 from app.db import session_scope
 from app.models import Download
+from app.utils import artwork_utils
 from app.workers.artwork_worker import ArtworkWorker
 from app.workers.sync_worker import SyncWorker
-from app.utils import artwork_utils
-from app.workers import artwork_worker as artwork_worker_module
 from tests.conftest import StubSoulseekClient
 
 
@@ -29,58 +27,100 @@ async def test_artwork_worker_fetches_spotify_cover(monkeypatch, tmp_path) -> No
         session.refresh(download)
         download_id = download.id
 
-    source_cover = tmp_path / "temp.jpg"
+    stored_files: Dict[str, Path] = {}
 
-    def fake_download(url: str) -> Path:
-        source_cover.write_bytes(b"image-bytes")
-        return source_cover
-
-    embedded: Dict[str, Path] = {}
+    def fake_download(url: str, target: Path) -> Path:
+        destination = Path(target)
+        if not destination.suffix:
+            destination = destination.with_suffix(".jpg")
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        destination.write_bytes(b"image-bytes")
+        stored_files["downloaded"] = destination
+        return destination
 
     def fake_embed(audio_file: Path, artwork_file: Path) -> None:
-        embedded["audio"] = Path(audio_file)
-        embedded["artwork"] = Path(artwork_file)
+        stored_files["audio"] = Path(audio_file)
+        stored_files["artwork"] = Path(artwork_file)
 
     monkeypatch.setattr(artwork_utils, "download_artwork", fake_download)
     monkeypatch.setattr(artwork_utils, "embed_artwork", fake_embed)
-    monkeypatch.setattr(artwork_worker_module, "download_artwork", fake_download)
-    monkeypatch.setattr(artwork_worker_module, "embed_artwork", fake_embed)
 
     class StubSpotify:
-        def get_track_details(self, track_id: str) -> Dict[str, Any]:
-            assert track_id == "spotify-track"
+        def get_album_details(self, album_id: str) -> Dict[str, Any]:
+            assert album_id == "album-123"
             return {
-                "album": {
-                    "images": [
-                        {"url": "http://example.com/cover.jpg", "width": 1000, "height": 1000}
-                    ]
-                }
+                "images": [
+                    {"url": "http://example.com/cover.jpg", "width": 2000, "height": 2000},
+                ]
             }
 
-    worker = ArtworkWorker(spotify_client=StubSpotify())
+        def get_track_details(self, track_id: str) -> Dict[str, Any]:
+            return {}
+
+    artwork_dir = tmp_path / "artwork"
+    worker = ArtworkWorker(spotify_client=StubSpotify(), storage_directory=artwork_dir)
     await worker.start()
     try:
         await worker.enqueue(
             download_id,
             str(audio_path),
             metadata={},
-            spotify_track_id="spotify-track",
+            spotify_album_id="album-123",
         )
         await worker.wait_for_pending()
     finally:
         await worker.stop()
 
-    assert embedded["audio"] == audio_path
-    stored_cover = embedded["artwork"]
+    stored_cover = stored_files["artwork"]
+    assert stored_files["audio"] == audio_path
     assert stored_cover.exists()
-    assert stored_cover.parent == audio_path.parent
+    assert stored_cover.parent == artwork_dir.resolve()
     assert stored_cover.read_bytes() == b"image-bytes"
 
     with session_scope() as session:
         refreshed = session.get(Download, download_id)
         assert refreshed is not None
+        assert refreshed.has_artwork is True
         assert refreshed.artwork_status == "done"
         assert Path(refreshed.artwork_path or "") == stored_cover
+
+
+@pytest.mark.asyncio
+async def test_artwork_worker_marks_failure(monkeypatch, tmp_path) -> None:
+    audio_path = tmp_path / "failure.mp3"
+    audio_path.write_bytes(b"audio")
+
+    with session_scope() as session:
+        download = Download(
+            filename=str(audio_path),
+            state="completed",
+            progress=100.0,
+        )
+        session.add(download)
+        session.commit()
+        session.refresh(download)
+        download_id = download.id
+
+    def fake_download(url: str, target: Path) -> Path:
+        raise RuntimeError("no artwork")
+
+    monkeypatch.setattr(artwork_utils, "download_artwork", fake_download)
+    monkeypatch.setattr(artwork_utils, "embed_artwork", lambda *_: None)
+
+    worker = ArtworkWorker(storage_directory=tmp_path / "artwork")
+    await worker.start()
+    try:
+        await worker.enqueue(download_id, str(audio_path), metadata={})
+        await worker.wait_for_pending()
+    finally:
+        await worker.stop()
+
+    with session_scope() as session:
+        refreshed = session.get(Download, download_id)
+        assert refreshed is not None
+        assert refreshed.has_artwork is False
+        assert refreshed.artwork_status == "failed"
+        assert refreshed.artwork_path is None
 
 
 @pytest.mark.asyncio
@@ -96,6 +136,7 @@ async def test_sync_worker_schedules_artwork(tmp_path) -> None:
             request_payload={
                 "spotify_id": "track-123",
                 "metadata": {"artwork_url": "http://existing.example/cover.jpg"},
+                "album": {"id": "album-999"},
             },
         )
         session.add(download)
@@ -114,6 +155,7 @@ async def test_sync_worker_schedules_artwork(tmp_path) -> None:
             *,
             metadata: Dict[str, Any] | None = None,
             spotify_track_id: str | None = None,
+            spotify_album_id: str | None = None,
             artwork_url: str | None = None,
         ) -> None:
             self.jobs.append(
@@ -122,6 +164,7 @@ async def test_sync_worker_schedules_artwork(tmp_path) -> None:
                     "file_path": file_path,
                     "metadata": dict(metadata or {}),
                     "spotify_track_id": spotify_track_id,
+                    "spotify_album_id": spotify_album_id,
                     "artwork_url": artwork_url,
                 }
             )
@@ -145,10 +188,11 @@ async def test_sync_worker_schedules_artwork(tmp_path) -> None:
     assert job["download_id"] == download_id
     assert job["file_path"] == str(audio_path)
     assert job["spotify_track_id"] == "track-123"
+    assert job["spotify_album_id"] == "album-999"
     assert job["artwork_url"] == "http://existing.example/cover.jpg"
 
 
-def test_artwork_endpoint_returns_base64(client, tmp_path) -> None:
+def test_artwork_endpoint_returns_image(client, tmp_path) -> None:
     cover_path = tmp_path / "cover.png"
     cover_path.write_bytes(b"png-bytes")
 
@@ -159,18 +203,14 @@ def test_artwork_endpoint_returns_base64(client, tmp_path) -> None:
             progress=100.0,
             artwork_status="done",
             artwork_path=str(cover_path),
+            has_artwork=True,
         )
         session.add(download)
         session.commit()
         session.refresh(download)
         download_id = download.id
 
-    response = client.get(
-        f"/soulseek/download/{download_id}/artwork",
-        params={"format": "base64"},
-    )
+    response = client.get(f"/soulseek/download/{download_id}/artwork")
     assert response.status_code == 200
-    payload = response.json()
-    assert payload["status"] == "done"
-    assert payload["mime_type"].startswith("image/")
-    assert base64.b64decode(payload["data"]) == b"png-bytes"
+    assert response.headers["content-type"].startswith("image/")
+    assert response._body == b"png-bytes"


### PR DESCRIPTION
## Summary
- add Spotify album artwork lookup utilities and central artwork storage for downloads
- trigger album artwork embedding from sync and discography workers with refreshable API endpoints
- expose artwork metadata on downloads and update documentation/tests for new workflow

## Testing
- `pytest tests/test_artwork.py tests/test_soulseek.py tests/test_download.py`


------
https://chatgpt.com/codex/tasks/task_e_68d548cccb848321ba185177527a1f7f