### PR TITLE
feat: add original-resolution artwork flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v1.x.x
 
-- High-Quality Artwork – Downloads enthalten automatisch eingebettete Cover in Originalauflösung, gespeichert unter `/artwork/` inklusive neuem Refresh-Endpoint `POST /soulseek/download/{id}/artwork/refresh`.
+- High-Quality Artwork – Downloads enthalten automatisch eingebettete Cover in Originalauflösung. Artwork-Dateien werden pro `spotify_album_id` zwischengespeichert (konfigurierbar via `ARTWORK_DIR`) und beim Abschluss von Downloads in MP3/FLAC/MP4 eingebettet. Neue API-Endpunkte: `GET /soulseek/download/{id}/artwork` (liefert Bild oder `404`) und `POST /soulseek/download/{id}/artwork/refresh` (erneut einreihen). Download-Datensätze speichern die zugehörigen Spotify-IDs (`spotify_track_id`, `spotify_album_id`).
 - Rich Metadata – alle Downloads enthalten zusätzliche Tags (Genre, Komponist, Produzent, ISRC, Copyright) und können per `GET /soulseek/download/{id}/metadata` abgerufen werden.
 - Complete Discographies – gesamte Künstlerdiskografien können automatisch heruntergeladen und kategorisiert werden.
 - Automatic Lyrics – Downloads enthalten jetzt synchronisierte `.lrc`-Dateien mit Songtexten aus der Spotify-API (Fallback Musixmatch/lyrics.ovh) samt neuen Endpunkten zum Abruf und Refresh.

--- a/README.md
+++ b/README.md
@@ -73,9 +73,9 @@ Beispielantwort:
 
 ## High-Quality Artwork
 
-Der Artwork-Worker lauscht auf abgeschlossene Downloads und lädt das zugehörige Albumcover in maximaler Spotify-Auflösung herunter. Die Originaldatei wird zentral im Verzeichnis `./artwork/` (bzw. per `HARMONY_ARTWORK_DIR`) abgelegt und anschließend mit Mutagen in die Audiodatei eingebettet. Schlägt der Spotify-Abruf fehl, versucht Harmony das Artwork über Plex-Metadaten, Soulseek oder externe Dienste wie Last.fm oder MusicBrainz zu ermitteln. Der Download-Datensatz speichert den Speicherort (`artwork_path`) sowie den Status (`has_artwork`).
+Der Artwork-Worker lauscht auf abgeschlossene Downloads und lädt das zugehörige Albumcover in maximaler Spotify-Auflösung herunter. Die Originaldatei wird zentral im Verzeichnis `./artwork/` abgelegt; über die Umgebungsvariable `ARTWORK_DIR` (Fallback `HARMONY_ARTWORK_DIR`) lässt sich der Speicherort anpassen. Für jede Spotify-Album-ID wird das Bild nur einmal heruntergeladen und anschließend wiederverwendet. Beim Einbetten sorgt Mutagen für ID3/FLAC/MP4-Tags in Originalauflösung. Schlägt der Spotify-Abruf fehl, versucht Harmony das Artwork über Plex-Metadaten, Soulseek oder externe Dienste wie Last.fm oder MusicBrainz zu ermitteln. Der Download-Datensatz speichert neben Pfad (`artwork_path`) und Status (`has_artwork`) nun auch die zugehörigen Spotify-IDs (`spotify_track_id`, `spotify_album_id`).
 
-Über den Endpoint `GET /soulseek/download/{id}/artwork` liefert die API das eingebettete Cover direkt als `image/jpeg` (inkl. korrektem MIME-Type). Mit `POST /soulseek/download/{id}/artwork/refresh` lässt sich jederzeit ein erneuter Abruf auslösen, etwa wenn bessere Quellen verfügbar geworden sind.
+Über den Endpoint `GET /soulseek/download/{id}/artwork` liefert die API das eingebettete Cover direkt als `image/jpeg` (inkl. korrektem MIME-Type). Ist noch kein Artwork verfügbar, antwortet der Server mit `404`. Mit `POST /soulseek/download/{id}/artwork/refresh` lässt sich jederzeit ein erneuter Abruf auslösen, etwa wenn bessere Quellen verfügbar geworden sind; das Cover wird dabei neu heruntergeladen, zwischengespeichert und erneut eingebettet.
 
 ## Harmony Web UI
 

--- a/app/models.py
+++ b/app/models.py
@@ -55,6 +55,8 @@ class Download(Base):
     artwork_path = Column(String(2048), nullable=True)
     artwork_status = Column(String(32), nullable=False, default="pending")
     has_artwork = Column(Boolean, nullable=False, default=False)
+    spotify_track_id = Column(String(128), nullable=True, index=True)
+    spotify_album_id = Column(String(128), nullable=True, index=True)
     lyrics_path = Column(String(2048), nullable=True)
     lyrics_status = Column(String(32), nullable=False, default="pending")
     has_lyrics = Column(Boolean, nullable=False, default=False)

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -136,6 +136,8 @@ class SoulseekDownloadEntry(BaseModel):
     artwork_path: Optional[str] = None
     artwork_status: Optional[str] = None
     has_artwork: Optional[bool] = None
+    spotify_track_id: Optional[str] = None
+    spotify_album_id: Optional[str] = None
     lyrics_status: Optional[str] = None
     lyrics_path: Optional[str] = None
     has_lyrics: Optional[bool] = None
@@ -166,6 +168,8 @@ class DownloadEntryResponse(BaseModel):
     artwork_path: Optional[str] = None
     artwork_status: Optional[str] = None
     has_artwork: Optional[bool] = None
+    spotify_track_id: Optional[str] = None
+    spotify_album_id: Optional[str] = None
     lyrics_status: Optional[str] = None
     lyrics_path: Optional[str] = None
     has_lyrics: Optional[bool] = None

--- a/app/utils/artwork_utils.py
+++ b/app/utils/artwork_utils.py
@@ -1,115 +1,110 @@
-"""Utility helpers for downloading and embedding artwork files."""
+"""Helper utilities for fetching, caching and embedding album artwork."""
 from __future__ import annotations
 
 import mimetypes
 import os
+import re
 import tempfile
-import uuid
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Iterable, Mapping, Optional
 
 import httpx
 
 from app.logging import get_logger
+from app.models import Download
 
 logger = get_logger(__name__)
 
 SPOTIFY_CLIENT: Any | None = None
 
-
-def _guess_extension(url: str, content_type: str | None) -> str:
-    """Guess a sensible file extension for an artwork file."""
-
-    if content_type:
-        guessed = mimetypes.guess_extension(content_type.split(";")[0].strip())
-        if guessed:
-            return guessed
-
-    suffix = Path(url).suffix
-    if suffix:
-        return suffix
-
-    return ".jpg"
+DEFAULT_TIMEOUT = 15.0
+MAX_IMAGE_SIZE_BYTES = 10 * 1024 * 1024
 
 
 def fetch_spotify_artwork(album_id: str) -> Optional[str]:
-    """Return the highest resolution Spotify artwork URL for an album."""
+    """Return the best available Spotify artwork URL for ``album_id``."""
 
+    album_id = (album_id or "").strip()
     if not album_id:
         return None
 
     client = SPOTIFY_CLIENT
     if client is None:
-        logger.debug("Spotify artwork requested for %s but no client configured", album_id)
+        logger.debug("Spotify client missing when resolving album %s", album_id)
         return None
 
     try:
         album_payload = client.get_album_details(album_id)
-    except Exception as exc:  # pragma: no cover - defensive logging
+    except Exception as exc:  # pragma: no cover - network errors mocked in tests
         logger.debug("Spotify album lookup failed for %s: %s", album_id, exc)
         return None
 
-    if not isinstance(album_payload, dict):
+    if not isinstance(album_payload, Mapping):
         return None
 
-    images = album_payload.get("images")
-    if not isinstance(images, list):
-        return None
-
-    best_url: Optional[str] = None
-    best_score = -1
-    for entry in images:
-        if not isinstance(entry, dict):
-            continue
-        url = entry.get("url")
-        if not isinstance(url, str) or not url.strip():
-            continue
-        width = int(entry.get("width") or 0)
-        height = int(entry.get("height") or 0)
-        score = width * height
-        if score > best_score:
-            best_score = score
-            best_url = url.strip()
-
-    return best_url
+    return _pick_best_image(album_payload.get("images"))
 
 
-def _resolve_destination(path: Path, suffix: str) -> Path:
-    if path.suffix:
-        return path
-    if path.exists() and path.is_dir():
-        filename = f"{uuid.uuid4().hex}{suffix}"
-        return path / filename
-    return path.with_suffix(suffix)
+def download_artwork(
+    url: str,
+    path: Path,
+    *,
+    timeout: float = DEFAULT_TIMEOUT,
+    max_bytes: int = MAX_IMAGE_SIZE_BYTES,
+) -> Path:
+    """Download ``url`` to ``path`` enforcing sane timeouts and file sizes."""
 
-
-def download_artwork(url: str, path: Path) -> Path:
-    """Download artwork to the desired location and return the stored path."""
-
+    url = (url or "").strip()
     if not url:
         raise ValueError("Artwork URL must be provided")
 
+    headers = {"User-Agent": "Harmony/1.0"}
+
     try:
-        with httpx.Client(timeout=15.0) as client:
+        with httpx.Client(timeout=timeout, follow_redirects=True, headers=headers) as client:
             response = client.get(url)
             response.raise_for_status()
-    except httpx.HTTPError as exc:  # pragma: no cover - network failure
+    except httpx.HTTPError as exc:  # pragma: no cover - dependent on network
         logger.debug("Failed to download artwork from %s: %s", url, exc)
         raise
 
-    suffix = _guess_extension(url, response.headers.get("content-type"))
+    content_type = (response.headers.get("content-type") or "").split(";")[0].strip()
+    if content_type and not content_type.startswith("image/"):
+        logger.debug("Discarding non-image artwork payload from %s (%s)", url, content_type)
+        raise ValueError("Downloaded file is not a recognised image")
+
+    length_header = response.headers.get("content-length")
+    if length_header:
+        try:
+            content_length = int(length_header)
+        except (TypeError, ValueError):
+            content_length = None
+        if content_length and content_length > max_bytes:
+            raise ValueError("Artwork exceeds maximum allowed size")
+
+    suffix = _guess_extension(url, content_type or None)
     destination = _resolve_destination(Path(path), suffix)
     destination.parent.mkdir(parents=True, exist_ok=True)
 
     fd, temp_path = tempfile.mkstemp(prefix="harmony-artwork-", suffix=suffix)
+    written = 0
     try:
         with os.fdopen(fd, "wb") as handle:
-            handle.write(response.content)
+            for chunk in response.iter_bytes():
+                if not chunk:
+                    continue
+                written += len(chunk)
+                if written > max_bytes:
+                    raise ValueError("Artwork exceeds maximum allowed size")
+                handle.write(chunk)
         if destination.exists():
             destination.unlink()
         os.replace(temp_path, destination)
     except Exception:
-        os.unlink(temp_path)
+        try:
+            os.unlink(temp_path)
+        except FileNotFoundError:  # pragma: no cover - best effort cleanup
+            pass
         raise
 
     return destination
@@ -126,9 +121,8 @@ def embed_artwork(audio_file: Path, artwork_file: Path) -> None:
     if not image_path.exists():
         raise FileNotFoundError(f"Artwork file not found: {image_path}")
 
-    try:  # pragma: no cover - import guarded for optional dependency
+    try:  # pragma: no cover - dependency import is environment specific
         from mutagen.flac import FLAC, Picture
-        from mutagen.id3 import APIC, ID3, ID3NoHeaderError
         from mutagen.mp4 import MP4, MP4Cover
     except ImportError as exc:  # pragma: no cover - defensive logging
         raise RuntimeError("mutagen is required to embed artwork") from exc
@@ -137,49 +131,144 @@ def embed_artwork(audio_file: Path, artwork_file: Path) -> None:
     mime_type = mimetypes.guess_type(str(image_path))[0] or "image/jpeg"
     image_data = image_path.read_bytes()
 
-    if suffix in {".mp3", ".wav", ".aiff", ".aif"}:
-        try:
-            tags = ID3(audio_path)
-        except ID3NoHeaderError:
-            tags = ID3()
-        tags.delall("APIC")
-        tags.add(
-            APIC(
-                encoding=3,
-                mime=mime_type,
-                type=3,
-                desc="Cover",
-                data=image_data,
+    try:
+        if suffix in {".mp3", ".wav", ".aiff", ".aif"}:
+            _embed_id3_artwork(audio_path, image_data, mime_type)
+            return
+
+        if suffix == ".flac":
+            audio = FLAC(audio_path)
+            picture = Picture()
+            picture.type = 3
+            picture.mime = mime_type
+            picture.desc = "Cover"
+            picture.data = image_data
+            audio.clear_pictures()
+            audio.add_picture(picture)
+            audio.save()
+            return
+
+        if suffix in {".m4a", ".mp4", ".aac", ".m4b"}:
+            cover_format = (
+                MP4Cover.FORMAT_PNG if mime_type == "image/png" else MP4Cover.FORMAT_JPEG
             )
-        )
-        tags.save(audio_path)
-        return
+            mp4 = MP4(audio_path)
+            mp4.tags["covr"] = [MP4Cover(image_data, imageformat=cover_format)]
+            mp4.save()
+            return
 
-    if suffix == ".flac":
-        audio = FLAC(audio_path)
-        picture = Picture()
-        picture.type = 3
-        picture.mime = mime_type
-        picture.desc = "Cover"
-        picture.data = image_data
-        audio.clear_pictures()
-        audio.add_picture(picture)
-        audio.save()
-        return
+        _embed_id3_artwork(audio_path, image_data, mime_type)
+    except Exception as exc:
+        logger.error("Failed to embed artwork into %s: %s", audio_path, exc)
+        raise
 
-    if suffix in {".m4a", ".mp4", ".aac", ".m4b"}:
-        cover_format = MP4Cover.FORMAT_PNG if mime_type == "image/png" else MP4Cover.FORMAT_JPEG
-        mp4 = MP4(audio_path)
-        mp4.tags["covr"] = [MP4Cover(image_data, imageformat=cover_format)]
-        mp4.save()
-        return
 
-    # Fall back to ID3 if mutagen supports the format; this covers formats
-    # such as WMA that share the same tagging structure.
+def infer_spotify_album_id(download: Download) -> Optional[str]:
+    """Best-effort inference of a Spotify album identifier for a download."""
+
+    if download.spotify_album_id:
+        candidate = download.spotify_album_id.strip()
+        if candidate:
+            return candidate
+
+    payloads: list[Mapping[str, Any]] = []
+    if isinstance(download.request_payload, Mapping):
+        payloads.append(download.request_payload)
+        metadata = download.request_payload.get("metadata")
+        if isinstance(metadata, Mapping):
+            payloads.append(metadata)
+
+    for payload in payloads:
+        album_id = _extract_album_identifier(payload)
+        if album_id:
+            return album_id
+
+    track_id = (download.spotify_track_id or "").strip()
+    if not track_id:
+        for payload in payloads:
+            track_id = _extract_spotify_track_id(payload) or ""
+            if track_id:
+                break
+
+    client = SPOTIFY_CLIENT
+    if track_id and client is not None:
+        try:
+            track_payload = client.get_track_details(track_id)
+        except Exception as exc:  # pragma: no cover - defensive logging
+            logger.debug("Failed to resolve album via track %s: %s", track_id, exc)
+        else:
+            if isinstance(track_payload, Mapping):
+                album = track_payload.get("album")
+                if isinstance(album, Mapping):
+                    album_id = _extract_album_identifier(album)
+                    if album_id:
+                        return album_id
+
+    # Heuristic fallback: derive album name from filename and query Spotify.
+    client = SPOTIFY_CLIENT
+    if client is None:
+        return None
+
+    stem = Path(download.filename or "").stem
+    if not stem:
+        return None
+
+    tokens = [part.strip() for part in re.split(r"[-–]+", stem) if part.strip()]
+    queries: Iterable[str]
+    if len(tokens) >= 2:
+        queries = (f"{tokens[0]} {tokens[1]}", stem)
+    else:
+        queries = (stem,)
+
+    for query in queries:
+        try:
+            result = client.search_albums(query, limit=1)
+        except Exception as exc:  # pragma: no cover - best effort logging
+            logger.debug("Album search failed for %s: %s", query, exc)
+            continue
+        album_payload = None
+        if isinstance(result, Mapping):
+            albums = result.get("albums")
+            if isinstance(albums, Mapping):
+                items = albums.get("items")
+                if isinstance(items, list) and items:
+                    album_payload = items[0]
+        if isinstance(album_payload, Mapping):
+            album_id = _extract_album_identifier(album_payload)
+            if album_id:
+                return album_id
+
+    return None
+
+
+def _guess_extension(url: str, content_type: str | None) -> str:
+    if content_type:
+        guessed = mimetypes.guess_extension(content_type)
+        if guessed:
+            return guessed
+
+    suffix = Path(url).suffix
+    if suffix:
+        return suffix
+    return ".jpg"
+
+
+def _resolve_destination(path: Path, suffix: str) -> Path:
+    if path.suffix:
+        return path
+    if path.exists() and path.is_dir():
+        return path / f"{next(_uuid_sequence())}{suffix}"
+    return path.with_suffix(suffix)
+
+
+def _embed_id3_artwork(audio_path: Path, image_data: bytes, mime_type: str) -> None:
+    from mutagen.id3 import APIC, ID3, ID3NoHeaderError  # type: ignore
+
     try:
         tags = ID3(audio_path)
     except ID3NoHeaderError:
         tags = ID3()
+
     tags.delall("APIC")
     tags.add(
         APIC(
@@ -192,3 +281,63 @@ def embed_artwork(audio_file: Path, artwork_file: Path) -> None:
     )
     tags.save(audio_path)
 
+
+def _pick_best_image(images: Any) -> Optional[str]:
+    if not isinstance(images, list):
+        return None
+    best_url: Optional[str] = None
+    best_score = -1
+    for entry in images:
+        if not isinstance(entry, Mapping):
+            continue
+        url = (entry.get("url") or "").strip()
+        if not url:
+            continue
+        width = int(entry.get("width") or 0)
+        height = int(entry.get("height") or 0)
+        score = width * height
+        if score > best_score:
+            best_score = score
+            best_url = url
+    return best_url
+
+
+def _extract_album_identifier(payload: Mapping[str, Any]) -> Optional[str]:
+    for key in ("spotify_album_id", "album_id", "id", "spotifyId", "spotify_id"):
+        value = payload.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    images = payload.get("images")
+    if isinstance(images, list):
+        for image in images:
+            if isinstance(image, Mapping):
+                candidate = image.get("id")
+                if isinstance(candidate, str) and candidate.strip():
+                    return candidate.strip()
+    return None
+
+
+def _extract_spotify_track_id(payload: Mapping[str, Any]) -> Optional[str]:
+    for key in (
+        "spotify_track_id",
+        "spotify_id",
+        "spotifyTrackId",
+        "spotifyId",
+        "id",
+    ):
+        value = payload.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+        if isinstance(value, Mapping):
+            nested = value.get("id")
+            if isinstance(nested, str) and nested.strip():
+                return nested.strip()
+    track_payload = payload.get("track")
+    if isinstance(track_payload, Mapping):
+        return _extract_spotify_track_id(track_payload)
+    return None
+
+
+def _uuid_sequence() -> Iterable[str]:
+    while True:
+        yield os.urandom(16).hex()

--- a/app/workers/sync_worker.py
+++ b/app/workers/sync_worker.py
@@ -696,6 +696,19 @@ class SyncWorker:
             request_payload,
         )
 
+        if download_id is not None:
+            with session_scope() as session:
+                record = session.get(Download, download_id)
+                if record is not None:
+                    if spotify_track_id:
+                        record.spotify_track_id = spotify_track_id
+                    if spotify_album_id:
+                        record.spotify_album_id = spotify_album_id
+                    if artwork_url:
+                        record.artwork_url = artwork_url
+                    record.updated_at = datetime.utcnow()
+                    session.add(record)
+
         if self._artwork is not None and file_path:
             try:
                 await self._artwork.enqueue(

--- a/docs/api.md
+++ b/docs/api.md
@@ -819,6 +819,8 @@ X-Plex-Token: <token>
 | `GET` | `/soulseek/downloads/all` | Delegiert an `SoulseekClient.get_all_downloads()`. |
 | `DELETE` | `/soulseek/downloads/completed` | Entfernt erledigte Downloads. |
 | `GET` | `/soulseek/download/{id}/queue` | Fragt Queue-Positionen ab. |
+| `GET` | `/soulseek/download/{id}/artwork` | Liefert das gespeicherte Cover (`image/jpeg`/`image/png`) oder `404`, falls kein Artwork vorliegt. |
+| `POST` | `/soulseek/download/{id}/artwork/refresh` | Stößt die Artwork-Aufbereitung erneut an (`202 Accepted`). |
 | `POST` | `/soulseek/enqueue` | Fügt mehrere Dateien der Warteschlange hinzu. |
 | `GET` | `/soulseek/uploads` | Lädt Uploads. |
 | `GET` | `/soulseek/uploads/all` | Alle Uploads. |
@@ -829,6 +831,8 @@ X-Plex-Token: <token>
 | `GET` | `/soulseek/user/{username}/directory?path=...` | Abfrage eines Unterordners. |
 | `GET` | `/soulseek/user/{username}/info` | Benutzerinformationen. |
 | `GET` | `/soulseek/user/{username}/status` | Online-Status. |
+
+> **Download-Felder:** Antworten aus `/soulseek/downloads` enthalten neben Fortschritt und Pfad auch Artwork-Informationen (`artwork_status`, `artwork_path`, `has_artwork`) sowie die ermittelten Spotify-IDs (`spotify_track_id`, `spotify_album_id`). Über diese IDs werden Cover-Dateien zwischengespeichert und später wiederverwendet.
 
 **Beispiel:**
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ pytest
 pytest-asyncio
 httpx
 psutil
+mutagen

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-import os
+# ruff: noqa: E402
+
 from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import Any, Dict, List

--- a/tests/test_artwork.py
+++ b/tests/test_artwork.py
@@ -1,3 +1,7 @@
+from __future__ import annotations
+
+import sys
+import types
 from pathlib import Path
 from typing import Any, Dict
 
@@ -12,9 +16,9 @@ from tests.conftest import StubSoulseekClient
 
 
 @pytest.mark.asyncio
-async def test_artwork_worker_fetches_spotify_cover(monkeypatch, tmp_path) -> None:
+async def test_spotify_artwork_success(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     audio_path = tmp_path / "track.mp3"
-    audio_path.write_bytes(b"audio")
+    audio_path.write_bytes(b"audio-bytes")
 
     with session_scope() as session:
         download = Download(
@@ -27,67 +31,207 @@ async def test_artwork_worker_fetches_spotify_cover(monkeypatch, tmp_path) -> No
         session.refresh(download)
         download_id = download.id
 
-    stored_files: Dict[str, Path] = {}
+    stored: Dict[str, Any] = {}
 
     def fake_download(url: str, target: Path) -> Path:
+        stored["download_url"] = url
         destination = Path(target)
         if not destination.suffix:
             destination = destination.with_suffix(".jpg")
         destination.parent.mkdir(parents=True, exist_ok=True)
         destination.write_bytes(b"image-bytes")
-        stored_files["downloaded"] = destination
+        stored["downloaded_path"] = destination
         return destination
 
     def fake_embed(audio_file: Path, artwork_file: Path) -> None:
-        stored_files["audio"] = Path(audio_file)
-        stored_files["artwork"] = Path(artwork_file)
+        stored["embedded"] = (Path(audio_file), Path(artwork_file))
 
     monkeypatch.setattr(artwork_utils, "download_artwork", fake_download)
     monkeypatch.setattr(artwork_utils, "embed_artwork", fake_embed)
 
     class StubSpotify:
+        def __init__(self) -> None:
+            self.album_calls: list[str] = []
+            self.track_calls: list[str] = []
+
         def get_album_details(self, album_id: str) -> Dict[str, Any]:
-            assert album_id == "album-123"
+            self.album_calls.append(album_id)
             return {
                 "images": [
-                    {"url": "http://example.com/cover.jpg", "width": 2000, "height": 2000},
+                    {"url": "http://example.com/medium.jpg", "width": 640, "height": 640},
+                    {"url": "http://example.com/large.jpg", "width": 2000, "height": 2000},
                 ]
             }
 
         def get_track_details(self, track_id: str) -> Dict[str, Any]:
-            return {}
+            self.track_calls.append(track_id)
+            return {"album": {"id": "album-123"}}
 
-    artwork_dir = tmp_path / "artwork"
-    worker = ArtworkWorker(spotify_client=StubSpotify(), storage_directory=artwork_dir)
+    worker = ArtworkWorker(spotify_client=StubSpotify(), storage_directory=tmp_path / "artwork")
     await worker.start()
     try:
         await worker.enqueue(
             download_id,
             str(audio_path),
             metadata={},
-            spotify_album_id="album-123",
+            spotify_track_id="track-xyz",
         )
         await worker.wait_for_pending()
     finally:
         await worker.stop()
 
-    stored_cover = stored_files["artwork"]
-    assert stored_files["audio"] == audio_path
-    assert stored_cover.exists()
-    assert stored_cover.parent == artwork_dir.resolve()
-    assert stored_cover.read_bytes() == b"image-bytes"
+    stored_path = stored["downloaded_path"]
+    assert stored["download_url"] == "http://example.com/large.jpg"
+    assert stored["embedded"] == (audio_path, stored_path)
+    assert stored_path.exists()
 
     with session_scope() as session:
         refreshed = session.get(Download, download_id)
         assert refreshed is not None
         assert refreshed.has_artwork is True
         assert refreshed.artwork_status == "done"
-        assert Path(refreshed.artwork_path or "") == stored_cover
+        assert refreshed.spotify_album_id == "album-123"
+        assert Path(refreshed.artwork_path or "") == stored_path
 
 
-@pytest.mark.asyncio
-async def test_artwork_worker_marks_failure(monkeypatch, tmp_path) -> None:
-    audio_path = tmp_path / "failure.mp3"
+def _install_mutagen_stubs(monkeypatch: pytest.MonkeyPatch, tracker: Dict[str, Any]) -> None:
+    module_mutagen = types.ModuleType("mutagen")
+
+    class DummyID3NoHeaderError(Exception):
+        pass
+
+    class DummyID3Factory:
+        def __init__(self) -> None:
+            self._first = True
+
+        def __call__(self, path: Path | None = None) -> "DummyID3":
+            tracker.setdefault("id3_calls", []).append(path)
+            if path is not None and self._first:
+                self._first = False
+                raise DummyID3NoHeaderError()
+            return DummyID3()
+
+    class DummyID3:
+        def __init__(self) -> None:
+            self.tags: Dict[str, Any] = {}
+
+        def delall(self, key: str) -> None:
+            tracker["id3_del"] = key
+
+        def add(self, apic: "DummyAPIC") -> None:
+            tracker["id3_apic"] = apic.params
+
+        def save(self, path: Path) -> None:
+            tracker["id3_saved"] = path
+
+    class DummyAPIC:
+        def __init__(self, **params: Any) -> None:
+            self.params = params
+
+    module_id3 = types.ModuleType("mutagen.id3")
+    module_id3.APIC = DummyAPIC
+    module_id3.ID3 = DummyID3Factory()
+    module_id3.ID3NoHeaderError = DummyID3NoHeaderError
+
+    class DummyPicture:
+        def __init__(self) -> None:
+            self.type = None
+            self.mime = None
+            self.desc = None
+            self.data = None
+
+    class DummyFLAC:
+        def __init__(self, path: Path) -> None:
+            tracker["flac_path"] = path
+            self.pictures: list[DummyPicture] = []
+
+        def clear_pictures(self) -> None:
+            tracker["flac_cleared"] = True
+
+        def add_picture(self, picture: DummyPicture) -> None:
+            tracker["flac_picture"] = {
+                "mime": picture.mime,
+                "desc": picture.desc,
+                "data": picture.data,
+            }
+
+        def save(self) -> None:
+            tracker["flac_saved"] = True
+
+    module_flac = types.ModuleType("mutagen.flac")
+    module_flac.FLAC = DummyFLAC
+    module_flac.Picture = DummyPicture
+
+    class DummyMP4Cover:
+        FORMAT_PNG = 1
+        FORMAT_JPEG = 2
+
+        def __init__(self, data: bytes, imageformat: int) -> None:
+            tracker["mp4_cover"] = {"data": data, "format": imageformat}
+
+    class DummyMP4:
+        def __init__(self, path: Path) -> None:
+            tracker["mp4_path"] = path
+            self.tags: Dict[str, Any] = {}
+
+        def save(self) -> None:
+            tracker["mp4_saved"] = True
+
+    module_mp4 = types.ModuleType("mutagen.mp4")
+    module_mp4.MP4 = DummyMP4
+    module_mp4.MP4Cover = DummyMP4Cover
+
+    module_mutagen.id3 = module_id3
+    module_mutagen.flac = module_flac
+    module_mutagen.mp4 = module_mp4
+
+    monkeypatch.setitem(sys.modules, "mutagen", module_mutagen)
+    monkeypatch.setitem(sys.modules, "mutagen.id3", module_id3)
+    monkeypatch.setitem(sys.modules, "mutagen.flac", module_flac)
+    monkeypatch.setitem(sys.modules, "mutagen.mp4", module_mp4)
+
+
+def test_embed_mp3_flac_m4a(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    tracker: Dict[str, Any] = {}
+    _install_mutagen_stubs(monkeypatch, tracker)
+
+    art_path = tmp_path / "cover.jpg"
+    art_path.write_bytes(b"image-bytes")
+
+    mp3_file = tmp_path / "song.mp3"
+    mp3_file.write_bytes(b"mp3")
+    flac_file = tmp_path / "song.flac"
+    flac_file.write_bytes(b"flac")
+    m4a_file = tmp_path / "song.m4a"
+    m4a_file.write_bytes(b"m4a")
+
+    artwork_utils.embed_artwork(mp3_file, art_path)
+    assert tracker["id3_del"] == "APIC"
+    assert tracker["id3_saved"] == mp3_file
+    assert tracker["id3_apic"]["mime"].startswith("image/")
+
+    tracker.clear()
+    _install_mutagen_stubs(monkeypatch, tracker)
+    artwork_utils.embed_artwork(flac_file, art_path)
+    assert tracker["flac_path"] == flac_file
+    assert tracker.get("flac_cleared") is True
+    assert tracker["flac_saved"] is True
+    assert tracker["flac_picture"]["mime"].startswith("image/")
+
+    tracker.clear()
+    _install_mutagen_stubs(monkeypatch, tracker)
+    artwork_utils.embed_artwork(m4a_file, art_path)
+    assert tracker["mp4_path"] == m4a_file
+    assert tracker["mp4_saved"] is True
+    assert tracker["mp4_cover"]["format"] == 2
+
+
+def test_no_artwork_found(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    client,
+) -> None:
+    audio_path = tmp_path / "missing.mp3"
     audio_path.write_bytes(b"audio")
 
     with session_scope() as session:
@@ -101,30 +245,106 @@ async def test_artwork_worker_marks_failure(monkeypatch, tmp_path) -> None:
         session.refresh(download)
         download_id = download.id
 
-    def fake_download(url: str, target: Path) -> Path:
-        raise RuntimeError("no artwork")
+    def raise_no_art(*args: Any, **kwargs: Any) -> Path:
+        raise RuntimeError("no art")
 
-    monkeypatch.setattr(artwork_utils, "download_artwork", fake_download)
+    monkeypatch.setattr(artwork_utils, "download_artwork", raise_no_art)
     monkeypatch.setattr(artwork_utils, "embed_artwork", lambda *_: None)
 
-    worker = ArtworkWorker(storage_directory=tmp_path / "artwork")
-    await worker.start()
-    try:
-        await worker.enqueue(download_id, str(audio_path), metadata={})
-        await worker.wait_for_pending()
-    finally:
-        await worker.stop()
+    async def process() -> None:
+        worker = ArtworkWorker(storage_directory=tmp_path / "artwork")
+        await worker.start()
+        try:
+            await worker.enqueue(download_id, str(audio_path), metadata={})
+            await worker.wait_for_pending()
+        finally:
+            await worker.stop()
+
+    client._loop.run_until_complete(process())
 
     with session_scope() as session:
         refreshed = session.get(Download, download_id)
         assert refreshed is not None
         assert refreshed.has_artwork is False
         assert refreshed.artwork_status == "failed"
-        assert refreshed.artwork_path is None
+
+    response = client.get(f"/soulseek/download/{download_id}/artwork")
+    assert response.status_code == 404
+
+
+def test_refresh_endpoint(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, client) -> None:
+    audio_path = tmp_path / "refresh.mp3"
+    audio_path.write_bytes(b"audio")
+
+    with session_scope() as session:
+        download = Download(
+            filename=str(audio_path),
+            state="completed",
+            progress=100.0,
+            artwork_status="done",
+            artwork_path=str(tmp_path / "old.jpg"),
+            has_artwork=True,
+            request_payload={
+                "metadata": {"artwork_url": "http://example.com/original.jpg"},
+                "album": {"id": "album-999"},
+            },
+        )
+        session.add(download)
+        session.commit()
+        session.refresh(download)
+        download_id = download.id
+
+    jobs: list[Dict[str, Any]] = []
+
+    class StubArtworkWorker:
+        async def enqueue(
+            self,
+            download_id: int | None,
+            file_path: str,
+            *,
+            metadata: Dict[str, Any] | None = None,
+            spotify_track_id: str | None = None,
+            spotify_album_id: str | None = None,
+            artwork_url: str | None = None,
+        ) -> None:
+            jobs.append(
+                {
+                    "download_id": download_id,
+                    "file_path": file_path,
+                    "metadata": dict(metadata or {}),
+                    "spotify_track_id": spotify_track_id,
+                    "spotify_album_id": spotify_album_id,
+                    "artwork_url": artwork_url,
+                }
+            )
+
+        async def start(self) -> None:
+            return None
+
+        async def stop(self) -> None:
+            return None
+
+    client.app.state.artwork_worker = StubArtworkWorker()
+
+    response = client.post(f"/soulseek/download/{download_id}/artwork/refresh")
+    assert response.status_code == 202
+    assert len(jobs) == 1
+    job = jobs[0]
+    assert job["download_id"] == download_id
+    assert job["file_path"] == str(audio_path)
+    assert job["metadata"].get("artwork_url") == "http://example.com/original.jpg"
+    assert job["spotify_album_id"] == "album-999"
+
+    with session_scope() as session:
+        refreshed = session.get(Download, download_id)
+        assert refreshed is not None
+        assert refreshed.artwork_status == "pending"
+        assert refreshed.has_artwork is False
+        assert refreshed.spotify_album_id == "album-999"
 
 
 @pytest.mark.asyncio
-async def test_sync_worker_schedules_artwork(tmp_path) -> None:
+async def test_sync_worker_schedules_artwork(tmp_path: Path) -> None:
     audio_path = tmp_path / "sync.mp3"
     audio_path.write_bytes(b"audio")
 
@@ -191,8 +411,14 @@ async def test_sync_worker_schedules_artwork(tmp_path) -> None:
     assert job["spotify_album_id"] == "album-999"
     assert job["artwork_url"] == "http://existing.example/cover.jpg"
 
+    with session_scope() as session:
+        refreshed = session.get(Download, download_id)
+        assert refreshed is not None
+        assert refreshed.spotify_track_id == "track-123"
+        assert refreshed.spotify_album_id == "album-999"
 
-def test_artwork_endpoint_returns_image(client, tmp_path) -> None:
+
+def test_artwork_endpoint_returns_image(client, tmp_path: Path) -> None:
     cover_path = tmp_path / "cover.png"
     cover_path.write_bytes(b"png-bytes")
 

--- a/tests/test_download_flow_with_artwork.py
+++ b/tests/test_download_flow_with_artwork.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict
+
+import pytest
+
+from app.db import session_scope
+from app.models import Download
+from app.utils import artwork_utils
+from app.workers.artwork_worker import ArtworkWorker
+
+
+def test_download_flow_with_artwork(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    client,
+) -> None:
+    audio_path = tmp_path / "flow.mp3"
+    audio_path.write_bytes(b"audio")
+
+    with session_scope() as session:
+        download = Download(
+            filename=str(audio_path),
+            state="completed",
+            progress=100.0,
+            artwork_status="pending",
+        )
+        session.add(download)
+        session.commit()
+        session.refresh(download)
+        download_id = download.id
+
+    downloads: list[str] = []
+    embeds: Dict[str, Any] = {}
+
+    def fake_download(url: str, target: Path) -> Path:
+        downloads.append(url)
+        destination = target.with_suffix(".jpg")
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        destination.write_bytes(b"cover-bytes")
+        return destination
+
+    def fake_embed(audio_file: Path, artwork_file: Path) -> None:
+        embeds["audio"] = Path(audio_file)
+        embeds["artwork"] = Path(artwork_file)
+
+    monkeypatch.setattr(artwork_utils, "download_artwork", fake_download)
+    monkeypatch.setattr(artwork_utils, "embed_artwork", fake_embed)
+
+    async def process() -> None:
+        worker = ArtworkWorker(storage_directory=tmp_path / "artwork")
+        await worker.start()
+        try:
+            await worker.enqueue(
+                download_id,
+                str(audio_path),
+                metadata={"artwork_url": "http://example.com/cover.jpg"},
+            )
+            await worker.wait_for_pending()
+        finally:
+            await worker.stop()
+
+    client._loop.run_until_complete(process())
+
+    assert downloads == ["http://example.com/cover.jpg"]
+    assert embeds["audio"] == audio_path
+    artwork_path = embeds["artwork"]
+    assert artwork_path.read_bytes() == b"cover-bytes"
+
+    response = client.get(f"/soulseek/download/{download_id}/artwork")
+    assert response.status_code == 200
+    assert response._body == b"cover-bytes"


### PR DESCRIPTION
## Summary
- add persistent Spotify track and album identifiers to downloads and extend the SQLite bootstrap to add the new columns on existing databases
- upgrade the artwork worker to cache per-album covers, validate downloads, and embed images into audio files with improved mutagen handling
- expose artwork fetch/refresh endpoints in the Soulseek router, document the behaviour, and add focused tests for the artwork pipeline

## Testing
- `ruff check .`
- `pytest tests/test_artwork.py tests/test_download_flow_with_artwork.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68d55dd8b8188321916d850ff3340703