### PR TITLE
feat: add smart search filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v1.x.x
 
+- Smart Search Filter – `/api/search` akzeptiert ein optionales `filters`-Objekt mit Genre-, Jahr- und Qualitätsangabe. Die Trefferliste enthält nun einheitliche `genre`-Felder, Filter werden case-insensitiv auf alle Quellen angewandt und Suchanfragen mit Filtern werden im Log festgehalten.
 - Smart Search – `/api/search` akzeptiert optionale Filter für Genre, Jahr und Audioqualität. Die Ergebnisse werden als einheitliche Trefferliste mit Quelle, Typ, Jahr und Qualitätslabel zurückgegeben. Fehler einzelner Dienste tauchen weiterhin separat im `errors`-Block auf.
 - High-Quality Artwork – Downloads enthalten automatisch eingebettete Cover in Originalauflösung. Artwork-Dateien werden pro `spotify_album_id` zwischengespeichert (konfigurierbar via `ARTWORK_DIR`) und beim Abschluss von Downloads in MP3/FLAC/MP4 eingebettet. Neue API-Endpunkte: `GET /soulseek/download/{id}/artwork` (liefert Bild oder `404`) und `POST /soulseek/download/{id}/artwork/refresh` (erneut einreihen). Download-Datensätze speichern die zugehörigen Spotify-IDs (`spotify_track_id`, `spotify_album_id`).
 - File Organization – abgeschlossene Downloads werden automatisch nach `Artist/Album/Track` in den Musik-Ordner (`MUSIC_DIR`, Default `./music`) verschoben. Auch Alben ohne Metadaten landen in einem eigenen `<Unknown Album>`-Verzeichnis, Dateinamen werden normalisiert und Duplikate mit Suffixen (`_1`, `_2`, …) abgelegt. Der endgültige Pfad steht in der Datenbank (`downloads.organized_path`) sowie in `GET /soulseek/downloads` zur Verfügung.

--- a/README.md
+++ b/README.md
@@ -20,13 +20,13 @@ und stellt einheitliche JSON-APIs für Automatisierungen und Frontend-Clients be
 
 ## Smart Search
 
-Die globale Suche (`POST /api/search`) kombiniert Spotify-, Plex- und Soulseek-Ergebnisse in einer normalisierten Trefferliste. Optional lassen sich drei Filter setzen:
+Die globale Suche (`POST /api/search`) kombiniert Spotify-, Plex- und Soulseek-Ergebnisse in einer normalisierten Trefferliste. Optional lässt sich ein `filters`-Objekt mit bis zu drei Kriterien setzen:
 
 - `genre`: Begrenzt die Ergebnisse auf ein bestimmtes Genre (z. B. `rock`).
-- `year`: Filtert nach Veröffentlichungsjahr (`int`).
+- `year`: Filtert nach Veröffentlichungsjahr (Ganzzahl oder String).
 - `quality`: Erwartete Audioqualität, etwa `FLAC` oder `320kbps`. Streaming-Resultate (Spotify) werden bei aktivem Qualitätsfilter automatisch ausgeschlossen.
 
-Die Antwort enthält für jeden Treffer konsistente Felder (`id`, `source`, `type`, `artist`, `album`, `title`, `year`, `quality`) und führt alle Quellen in einer Liste zusammen. Fehler einzelner Dienste werden im Feld `errors` gesammelt und blockieren den Gesamtaufruf nicht.
+Die Filter greifen nach dem Abruf aller Quellen und sind case-insensitiv. Die Antwort enthält für jeden Treffer konsistente Felder (`id`, `source`, `type`, `artist`, `album`, `title`, `year`, `genre`, `quality`) und führt alle Quellen in einer Liste zusammen. Fehler einzelner Dienste werden im Feld `errors` gesammelt und blockieren den Gesamtaufruf nicht.
 
 ## Complete Discographies
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -152,15 +152,17 @@ POST /api/metadata/update HTTP/1.1
 {
   "query": "The Beatles",
   "sources": ["spotify", "plex", "soulseek"],
-  "genre": "rock",
-  "year": 1969,
-  "quality": "FLAC"
+  "filters": {
+    "genre": "rock",
+    "year": 1969,
+    "quality": "FLAC"
+  }
 }
 ```
 
 - `query` (Pflicht): Freitext, wird automatisch beschnitten.
 - `sources` (optional): Teilmenge von `spotify`, `plex`, `soulseek`. Fehlt das Feld, durchsucht Harmony alle Quellen.
-- `genre`, `year`, `quality` (optional): Filtert Ergebnisse auf Genre, Erscheinungsjahr sowie Audioqualität (z. B. `FLAC`, `320kbps`).
+- `filters` (optional): Objekt mit `genre`, `year`, `quality`. Die Werte werden fallunabhängig verglichen; `year` akzeptiert Integer oder Strings.
 
 **Antwortstruktur**
 
@@ -177,6 +179,7 @@ POST /api/metadata/update HTTP/1.1
       "album": "Abbey Road",
       "title": "Come Together",
       "year": 1969,
+      "genre": "rock",
       "quality": "FLAC 1000kbps"
     },
     {
@@ -187,6 +190,7 @@ POST /api/metadata/update HTTP/1.1
       "album": "Abbey Road",
       "title": "Something",
       "year": 1969,
+      "genre": "rock",
       "quality": "FLAC 900kbps"
     }
   ],
@@ -196,7 +200,7 @@ POST /api/metadata/update HTTP/1.1
 }
 ```
 
-Die Liste `results` vereinheitlicht die Daten aller Quellen. Qualitätsfilter schließen automatisch alle Treffer ohne Angabe von Format/Bitrate aus (Spotify liefert bei aktivem Qualitätsfilter keine Ergebnisse). Das Feld `errors` ist optional und enthält pro Quelle eine Fehlermeldung, falls einzelne Dienste nicht erreichbar waren.
+Die Liste `results` vereinheitlicht die Daten aller Quellen. Qualitätsfilter schließen automatisch alle Treffer ohne Angabe von Format/Bitrate aus (Spotify liefert bei aktivem Qualitätsfilter keine Ergebnisse). Genre- und Jahresfilter greifen nachgelagert auf Basis der gelieferten Metadaten. Das Feld `errors` ist optional und enthält pro Quelle eine Fehlermeldung, falls einzelne Dienste nicht erreichbar waren.
 
 > **Hinweis:** Die in diesem Dokument verwendeten Statusnamen für Activity-Events sind zentral in `app/utils/events.py` hinterlegt und werden von Routern, Workern und Tests gemeinsam genutzt.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,6 +41,7 @@ class StubSpotifyClient:
                     "release_date": "1969-01-01",
                     "artists": [{"name": "Tester"}],
                 },
+                "genre": "rock",
                 "duration_ms": 200000,
             },
         }
@@ -56,6 +57,7 @@ class StubSpotifyClient:
                 "name": "Album",
                 "artists": [{"name": "Tester"}],
                 "release_date": "1969-02-02",
+                "genres": ["rock"],
             }
         }
         self.playlist_items: Dict[str, Dict[str, Any]] = {
@@ -96,7 +98,13 @@ class StubSpotifyClient:
         year: int | None = None,
     ) -> Dict[str, Any]:
         self.last_requests["artists"] = {"query": query, "genre": genre, "year": year}
-        return {"artists": {"items": [{"id": "artist-1", "name": "Tester"}]}}
+        return {
+            "artists": {
+                "items": [
+                    {"id": "artist-1", "name": "Tester", "genres": ["rock"]}
+                ]
+            }
+        }
 
     def search_albums(
         self,


### PR DESCRIPTION
## Summary
- add a `filters` payload model for `/api/search`, extract genre metadata, and apply case-insensitive post-filtering with logging
- expose genre information in normalized Spotify, Plex, and Soulseek results and document the new response fields
- extend the test suite and stubs to cover genre, year, quality, and combined filter scenarios

## Testing
- pytest
- pytest tests/test_search.py

------
https://chatgpt.com/codex/tasks/task_e_68d5a2c536048321906e4a75f938d739