### PR TITLE
TASK_ID CI-FMT-001: Pin Black version and format code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-          pip install black ruff mypy
+          pip install black==24.8.0 ruff mypy
       - name: Ruff
         run: ruff check .
       - name: Black

--- a/ToDo.md
+++ b/ToDo.md
@@ -23,6 +23,7 @@
   - Smart Search erhielt strukturierte Filter (Genre, Jahr, Qualität) inkl. Normalisierung, Ranking-Boosts und aktualisierte API-Dokumentation.【F:app/routers/search_router.py†L1-L280】【F:docs/api.md†L130-L233】
 - **Infrastruktur / CI**
   - Die CI auf Push/PR führt `ruff`, `black --check`, `mypy app`, `pytest -q`, `npm test`, `npm run typecheck`, `npm run build` sowie den OpenAPI-Snapshot-Vergleich aus.【F:.github/workflows/ci.yml†L1-L74】
+  - Black ist auf Version 24.8.0 gepinnt und nutzt die gemeinsame `pyproject.toml`-Konfiguration für reproduzierbare Formatierungsläufe.【F:.github/workflows/ci.yml†L26-L36】【F:pyproject.toml†L1-L14】
 
 ## ⬜️ Offen
 - **Backend**

--- a/app/routers/free_ingest_router.py
+++ b/app/routers/free_ingest_router.py
@@ -129,12 +129,7 @@ def _build_submission_response(result: IngestSubmission) -> SubmissionResponse:
 
 
 def _submission_status_code(result: IngestSubmission) -> int:
-    if (
-        result.error
-        or result.skipped.reason
-        or result.skipped.playlists
-        or result.skipped.tracks
-    ):
+    if result.error or result.skipped.reason or result.skipped.playlists or result.skipped.tracks:
         return status.HTTP_207_MULTI_STATUS
     return status.HTTP_202_ACCEPTED
 

--- a/app/services/free_ingest_service.py
+++ b/app/services/free_ingest_service.py
@@ -276,9 +276,7 @@ class FreeIngestService:
                 )
             ).scalar_one()
 
-            batches = self._calculate_batches(
-                int(track_total), self._resolve_batch_size(None)
-            )
+            batches = self._calculate_batches(int(track_total), self._resolve_batch_size(None))
             accepted = IngestAccepted(
                 playlists=int(playlist_total),
                 tracks=int(track_total),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,18 @@
 [tool.black]
 line-length = 100
 target-version = ["py311"]
+include = "\\.pyi?$"
+exclude = '''
+/(
+    \\.git
+    | \\.mypy_cache
+    | \\.ruff_cache
+    | build
+    | dist
+    | archive
+    | frontend/node_modules
+)/
+'''
 
 [tool.ruff]
 line-length = 100


### PR DESCRIPTION
## Summary
- reformat the Spotify FREE ingest router and service to satisfy the current Black style
- pin Black 24.8.0 in CI and document the shared formatting settings in pyproject.toml
- update the team ToDo to reflect the deterministic Black configuration

## Scope
- backend formatting utilities and CI workflow configuration

## Breaking changes
- none

## Tests
- `black --check .`
- `pytest -q`

## Security
- no changes

## Rollback
- revert the commit to restore previous formatting and CI dependencies

## TASK_ID
- CI-FMT-001

## ToDo Update
- noted the pinned Black version and central configuration in ToDo.md


------
https://chatgpt.com/codex/tasks/task_e_68d6998b33e88321898dd43ecf005fab