### PR TITLE
feat: CODX-SEC-001 global API key enforcement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ## v1.x.x
 
+- sec: enforce global API-Key authentication for all routers, return RFC 7807 problem-details for 401/403, document the scheme in OpenAPI, add configurable allowlist and restrictive CORS via env (`HARMONY_API_KEYS`, `AUTH_ALLOWLIST`, `ALLOWED_ORIGINS`).
 - feat: add feature flags for artwork and lyrics (default disabled) with conditional worker wiring, 503 guards, and refreshed documentation/tests.
 - refactor: purge remaining Plex/Beets wiring, ensure routers/workers only load Spotify & Soulseek, add wiring audit guard, and refresh docs/tests.
 - fix: offload Spotify lookups in the watchlist worker to executor threads to

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Harmony ist ein FastAPI-Backend, das Spotify, Soulseek (slskd) sowie eine eigene
 - **Spotify PRO Backfill** reichert bestehende FREE-Ingest-Daten nach OAuth-Setup automatisch mit Spotify-IDs, ISRCs und Laufzeiten an und expandiert gemeldete Playlist-Links zu vollständigen Tracklisten.
 - **Soulseek-Anbindung** inklusive Download-/Upload-Verwaltung, Warteschlangen und Benutzerinformationen.
 - **Automatische Metadaten-Anreicherung**: Nach jedem Download ergänzt Harmony Genre, Komponist, Produzent, ISRC und Copyright, bettet Cover in höchster verfügbarer Auflösung ein und stellt die Tags per API bereit.
+- **Globale API-Key-Authentifizierung** schützt sämtliche Produktiv-Endpunkte (`X-API-Key` oder `Authorization: Bearer`). Keys werden über `HARMONY_API_KEYS`/`HARMONY_API_KEYS_FILE` verwaltet, Ausnahmen via `AUTH_ALLOWLIST`, CORS über `ALLOWED_ORIGINS` restriktiv konfiguriert.
 - **Automatic Lyrics** *(Feature-Flag `ENABLE_LYRICS`, Default: deaktiviert)*: Für jeden neuen Download erzeugt Harmony automatisch eine synchronisierte LRC-Datei mit passenden Songtexten. Die Lyrics stammen vorrangig aus der Spotify-API; falls dort keine Texte verfügbar sind, greift Harmony auf externe Provider wie Musixmatch oder lyrics.ovh zurück.
 - **Matching-Engine** zur Ermittlung der besten Kandidaten zwischen Spotify ↔ Soulseek inklusive Persistierung (Plex-Matching archiviert).
 - **SQLite-Datenbank** mit SQLAlchemy-Modellen für Playlists, Downloads, Matches und Settings.

--- a/ToDo.md
+++ b/ToDo.md
@@ -2,6 +2,7 @@
 
 ## ✅ Erledigt
 - **Backend**
+  - Globale API-Key-Authentifizierung sichert alle Router per Dependency, nutzt Problem-Details für 401/403 und respektiert konfigurierbare Allowlists; CORS akzeptiert nur definierte Origins.【F:app/dependencies.py†L1-L114】【F:app/main.py†L220-L315】【F:app/config.py†L79-L136】
   - FastAPI bindet die aktiven Router (`/spotify`, `/soulseek`, `/matching`, `/settings`, `/search`, `/sync`, `/system`, `/download`, `/activity`, `/health`, `/watchlist`) ein, initialisiert die Datenbank und setzt Default-Settings im Lifespan-Hook. Archivierte Plex/Beets-Routen werden nicht registriert.【F:app/main.py†L248-L268】
   - Der Lifespan-Handler startet Artwork-, Lyrics-, Metadata-, Sync-, Matching-, Playlist-, Watchlist- und Retry-Worker und stoppt sie über die zentralisierte Shutdown-Routine wieder sauber. Plex/Beets-abhängige Worker bleiben deaktiviert.【F:app/main.py†L94-L214】
   - Artwork- und Lyrics-Funktionalität sind per Feature-Flags (`ENABLE_ARTWORK`, `ENABLE_LYRICS`) standardmäßig deaktiviert; Lifespan und Router aktivieren Worker sowie Endpunkte nur bei gesetzten Flags und liefern ansonsten `503 FEATURE_DISABLED`.【F:app/config.py†L79-L143】【F:app/main.py†L107-L165】【F:app/routers/soulseek_router.py†L24-L133】【F:README.md†L8-L116】

--- a/app/dependencies.py
+++ b/app/dependencies.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 from functools import lru_cache
+import hmac
 from typing import Generator
+
+from fastapi import Request, status
 
 from sqlalchemy.orm import Session
 
@@ -13,6 +16,10 @@ from app.core.soulseek_client import SoulseekClient
 from app.core.spotify_client import SpotifyClient
 from app.core.transfers_api import TransfersApi
 from app.db import get_session
+from app.logging import get_logger
+from app.problem_details import ProblemDetailException
+
+logger = get_logger(__name__)
 
 
 @lru_cache()
@@ -46,3 +53,90 @@ def get_db() -> Generator[Session, None, None]:
         yield session
     finally:
         session.close()
+
+
+def _is_allowlisted(path: str, allowlist: tuple[str, ...]) -> bool:
+    for prefix in allowlist:
+        if not prefix:
+            continue
+        if prefix == "/" and path == "/":
+            return True
+        if path == prefix or path.startswith(f"{prefix}/"):
+            return True
+    return False
+
+
+def _extract_presented_key(request: Request) -> str | None:
+    header_key = request.headers.get("X-API-Key")
+    if header_key and header_key.strip():
+        return header_key.strip()
+
+    auth_header = request.headers.get("Authorization", "")
+    if auth_header.lower().startswith("bearer "):
+        candidate = auth_header[7:].strip()
+        if candidate:
+            return candidate
+    return None
+
+
+def require_api_key(request: Request) -> None:
+    config = get_app_config()
+    security = config.security
+
+    if not security.require_auth:
+        return
+
+    if request.method.upper() == "OPTIONS":
+        return
+
+    if _is_allowlisted(request.url.path, security.allowlist):
+        return
+
+    if not security.api_keys:
+        logger.warning(
+            "API key authentication enabled but no keys configured",  # pragma: no cover - logging string
+            extra={
+                "event": "auth.misconfigured",
+                "path": request.url.path,
+                "method": request.method,
+            },
+        )
+        raise ProblemDetailException(
+            status.HTTP_401_UNAUTHORIZED,
+            "Unauthorized",
+            "An API key is required to access this resource.",
+        )
+
+    presented_key = _extract_presented_key(request)
+    if not presented_key:
+        logger.warning(
+            "Missing API key for protected endpoint",  # pragma: no cover - logging string
+            extra={
+                "event": "auth.unauthorized",
+                "path": request.url.path,
+                "method": request.method,
+            },
+        )
+        raise ProblemDetailException(
+            status.HTTP_401_UNAUTHORIZED,
+            "Unauthorized",
+            "An API key is required to access this resource.",
+        )
+
+    for valid_key in security.api_keys:
+        if hmac.compare_digest(presented_key, valid_key):
+            return
+
+    logger.warning(
+        "Invalid API key rejected",  # pragma: no cover - logging string
+        extra={
+            "event": "auth.forbidden",
+            "path": request.url.path,
+            "method": request.method,
+        },
+    )
+    raise ProblemDetailException(
+        status.HTTP_403_FORBIDDEN,
+        "Forbidden",
+        "The provided API key is not valid.",
+    )

--- a/app/problem_details.py
+++ b/app/problem_details.py
@@ -1,0 +1,25 @@
+"""Problem Details helpers for RFC 7807 responses."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(slots=True)
+class ProblemDetailException(Exception):
+    """Exception used to signal RFC 7807 problem detail responses."""
+
+    status_code: int
+    title: str
+    detail: str
+    type: str = "about:blank"
+
+    def to_dict(self) -> dict[str, int | str]:
+        """Return the serialisable representation of the problem detail."""
+
+        return {
+            "type": self.type,
+            "title": self.title,
+            "status": self.status_code,
+            "detail": self.detail,
+        }

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -6,3 +6,5 @@ services:
     environment:
       - DATABASE_URL=sqlite:///./harmony.db
       - HARMONY_LOG_LEVEL=DEBUG
+      - HARMONY_API_KEYS=dev-key
+      - ALLOWED_ORIGINS=http://localhost:5173

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,8 @@ services:
     environment:
       - DATABASE_URL=sqlite:///./harmony.db
       - HARMONY_LOG_LEVEL=INFO
+      - HARMONY_API_KEYS=dev-key
+      - ALLOWED_ORIGINS=http://localhost:5173
     ports:
       - "8000:8000"
     volumes:

--- a/docs/api.md
+++ b/docs/api.md
@@ -6,9 +6,12 @@ Alle Endpunkte folgen dem Schema `https://<host>/<route>` und liefern JSON, sofe
 
 ## Authentifizierung
 
-- Spotify-Routen mit OAuth benötigen gültige Credentials (`SPOTIFY_CLIENT_ID`, `SPOTIFY_CLIENT_SECRET`, `SPOTIFY_REDIRECT_URI`).
+- Alle produktiven Endpunkte erfordern einen gültigen API-Key im Header `X-API-Key`. Alternativ wird `Authorization: Bearer <key>` akzeptiert.
+- Die Liste gültiger Schlüssel wird über `HARMONY_API_KEYS` (kommagetrennt) oder `HARMONY_API_KEYS_FILE` gepflegt. Mehrere Schlüssel können parallel aktiv bleiben.
+- Öffentliche Routen (z. B. `/api/health`) lassen sich via `AUTH_ALLOWLIST` freischalten. Die Angabe erfolgt als kommagetrennte Pfadpräfix-Liste.
+- CORS ist standardmäßig restriktiv (`ALLOWED_ORIGINS`). Für Tests und lokale Entwicklung kann `HARMONY_DISABLE_WORKERS=1` gesetzt werden, um Hintergrundprozesse auszuschalten.
+- Spotify-Routen mit OAuth benötigen weiterhin gültige Credentials (`SPOTIFY_CLIENT_ID`, `SPOTIFY_CLIENT_SECRET`, `SPOTIFY_REDIRECT_URI`).
 - Soulseek-Routen verwenden slskd (`SLSKD_URL`, optional `SLSKD_API_KEY`).
-- Für Tests und lokale Entwicklung kann `HARMONY_DISABLE_WORKERS=1` gesetzt werden, um Hintergrundprozesse auszuschalten.
 
 ## Spotify
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,11 +5,16 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Dict, List, Sequence
 
+import os
+
 import sys
 
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
+
+os.environ.setdefault("HARMONY_API_KEYS", "test-key")
+os.environ.setdefault("ALLOWED_ORIGINS", "https://app.local")
 
 import pytest
 from app.core.transfers_api import TransfersApiError

--- a/tests/snapshots/openapi.json
+++ b/tests/snapshots/openapi.json
@@ -2496,6 +2496,14 @@
         "title": "SearchRequest",
         "type": "object"
       }
+    },
+    "securitySchemes": {
+      "ApiKeyAuth": {
+        "description": "Provide the configured API key via the X-API-Key header. Authorization: Bearer is also supported.",
+        "in": "header",
+        "name": "X-API-Key",
+        "type": "apiKey"
+      }
     }
   },
   "info": {
@@ -6104,5 +6112,10 @@
         ]
       }
     }
-  }
+  },
+  "security": [
+    {
+      "ApiKeyAuth": []
+    }
+  ]
 }

--- a/tests/test_api_auth.py
+++ b/tests/test_api_auth.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import pytest
+
+from app import dependencies as deps
+from app.main import app
+from tests.simple_client import SimpleTestClient
+
+
+@pytest.fixture(autouse=True)
+def configure_security(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HARMONY_API_KEYS", "valid-key,rotating-key")
+    monkeypatch.setenv("FEATURE_REQUIRE_AUTH", "1")
+    monkeypatch.setenv("HARMONY_DISABLE_WORKERS", "1")
+    monkeypatch.setenv("ALLOWED_ORIGINS", "https://app.local")
+    monkeypatch.delenv("AUTH_ALLOWLIST", raising=False)
+    deps.get_app_config.cache_clear()
+    app.openapi_schema = None
+    yield
+    deps.get_app_config.cache_clear()
+    app.openapi_schema = None
+
+
+def test_request_without_key_returns_401() -> None:
+    with SimpleTestClient(app, include_env_api_key=False) as client:
+        response = client.get("/")
+
+    assert response.status_code == 401
+    assert response.headers.get("content-type") == "application/problem+json"
+    assert response.json() == {
+        "type": "about:blank",
+        "title": "Unauthorized",
+        "status": 401,
+        "detail": "An API key is required to access this resource.",
+    }
+
+
+def test_invalid_key_returns_403() -> None:
+    with SimpleTestClient(
+        app,
+        default_headers={"X-API-Key": "invalid"},
+        include_env_api_key=False,
+    ) as client:
+        response = client.get("/")
+
+    assert response.status_code == 403
+    assert response.headers.get("content-type") == "application/problem+json"
+    assert response.json() == {
+        "type": "about:blank",
+        "title": "Forbidden",
+        "status": 403,
+        "detail": "The provided API key is not valid.",
+    }
+
+
+def test_allowlist_path_bypasses_auth(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AUTH_ALLOWLIST", "/api/health")
+    deps.get_app_config.cache_clear()
+    app.openapi_schema = None
+
+    with SimpleTestClient(app, include_env_api_key=False) as client:
+        response = client.get("/api/health/spotify")
+
+    assert response.status_code == 200
+
+
+def test_bearer_header_supported() -> None:
+    with SimpleTestClient(app, include_env_api_key=False) as client:
+        response = client.get("/", headers={"Authorization": "Bearer valid-key"})
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "ok"
+
+
+def test_cors_preflight_skips_auth() -> None:
+    with SimpleTestClient(app, include_env_api_key=False) as client:
+        response = client.options(
+            "/spotify/playlists",
+            headers={
+                "Origin": "https://app.local",
+                "Access-Control-Request-Method": "GET",
+                "Access-Control-Request-Headers": "X-API-Key",
+            },
+        )
+
+    assert response.status_code in {200, 204}
+
+
+def test_openapi_declares_api_key_security() -> None:
+    schema = app.openapi()
+
+    assert "ApiKeyAuth" in schema["components"]["securitySchemes"]
+    assert schema["security"] == [{"ApiKeyAuth": []}]
+    health_get = schema["paths"]["/api/health/spotify"]["get"]
+    assert "security" not in health_get


### PR DESCRIPTION
## Summary
- enforce API-key authentication via a shared dependency, RFC 7807 problem responses, and strict CORS defaults across the FastAPI app.
- extend configuration to load keys, allowlist prefixes, and allowed origins from environment variables or files and expose them in OpenAPI.
- adapt test utilities, add an auth regression suite, refresh the OpenAPI snapshot, and document the new security requirements.

## Testing
- `ruff check .`
- `black --check .`
- `mypy app`
- `pytest -q`

## ToDo Update
- Updated `ToDo.md` to record completion of CODX-SEC-001.


------
https://chatgpt.com/codex/tasks/task_e_68d822b5ada48321ac6cce0605c942b6