### PR TITLE
[CODX-DB-010] Add Alembic migrations infrastructure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - sec: enforce global API-Key authentication for all routers, return RFC 7807 problem-details for 401/403, document the scheme in OpenAPI, add configurable allowlist and restrictive CORS via env (`HARMONY_API_KEYS`, `AUTH_ALLOWLIST`, `ALLOWED_ORIGINS`).
 - feat: add feature flags for artwork and lyrics (default disabled) with conditional worker wiring, 503 guards, and refreshed documentation/tests.
 - refactor: purge remaining Plex/Beets wiring, ensure routers/workers only load Spotify & Soulseek, add wiring audit guard, and refresh docs/tests.
+- infra: replace ad-hoc schema management with Alembic migrations (`init_db` runs `alembic upgrade head`, Docker entrypoint applies migrations automatically, Makefile gains `db.upgrade`/`db.revision`, README documents the flow, and the initial revision seeds missing columns/indexes).【F:app/db.py†L1-L107】【F:scripts/docker-entrypoint.sh†L1-L11】【F:Makefile†L1-L48】【F:README.md†L189-L202】【F:alembic.ini†L1-L29】【F:app/migrations/versions/7c9bdb5e1a3d_create_base_schema.py†L1-L111】
 - fix: offload Spotify lookups in the watchlist worker to executor threads to
   prevent event-loop starvation and add regression coverage around the
   cancellation-safe path.

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,10 @@ RUN pip install --upgrade pip && pip install -r requirements.txt
 
 COPY . .
 
+RUN chmod +x scripts/docker-entrypoint.sh
+
 EXPOSE 8000
 
 # Standard: Production
+ENTRYPOINT ["./scripts/docker-entrypoint.sh"]
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,15 @@
-.PHONY: help install-dev quality security analyze all
+.PHONY: help install-dev quality security analyze all db.upgrade db.revision
 PY=python -m
 OFF?=$(CI_OFFLINE)
 
 help:
-	@echo "make install-dev    # install dev tools"
-	@echo "make quality        # ruff, black --check, mypy, pytest"
-	@echo "make security       # bandit, pip-audit (skips if CI_OFFLINE=true)"
-	@echo "make analyze        # radon, vulture (skips if CI_OFFLINE=true)"
-	@echo "make all            # run quality + security + analyze"
+        @echo "make install-dev    # install dev tools"
+        @echo "make quality        # ruff, black --check, mypy, pytest"
+        @echo "make security       # bandit, pip-audit (skips if CI_OFFLINE=true)"
+        @echo "make analyze        # radon, vulture (skips if CI_OFFLINE=true)"
+        @echo "make all            # run quality + security + analyze"
+        @echo "make db.upgrade     # apply database migrations"
+        @echo "make db.revision msg=\"...\" # autogenerate new migration"
 
 install-dev:
 	pip install -r requirements-dev.txt
@@ -28,10 +30,19 @@ endif
 
 analyze:
 ifeq ($(OFF),true)
-	@echo "⚠️ CI_OFFLINE=true → skipping analyze tools (radon, vulture)."
+        @echo "⚠️ CI_OFFLINE=true → skipping analyze tools (radon, vulture)."
 else
-	radon cc -s -a app
-	vulture app tests --exclude .venv
+        radon cc -s -a app
+        vulture app tests --exclude .venv
 endif
 
 all: quality security analyze
+
+db.upgrade:
+        alembic upgrade head
+
+db.revision:
+ifndef msg
+	$(error msg is required, usage: make db.revision msg="<description>")
+endif
+	alembic revision --autogenerate -m "$(msg)"

--- a/README.md
+++ b/README.md
@@ -183,6 +183,12 @@ npm run typecheck
 npm run build
 ```
 
+## Datenbank-Migrationen
+
+- `make db.upgrade` führt `alembic upgrade head` aus und wendet alle offenen Migrationen auf die konfigurierte Datenbank an.
+- `make db.revision msg="..."` erzeugt auf Basis der SQLAlchemy-Models eine neue, automatisch generierte Revision.
+- Der Docker-Entrypoint führt Migrationen beim Start automatisch aus; setze `FEATURE_RUN_MIGRATIONS=off`, um dies temporär zu deaktivieren (z. B. für lokale Debug-Sessions).
+
 ### Code-Qualität lokal (optional offline)
 
 ```bash

--- a/ToDo.md
+++ b/ToDo.md
@@ -29,6 +29,7 @@
   - Black ist auf Version 24.8.0 gepinnt und nutzt die gemeinsame `pyproject.toml`-Konfiguration für reproduzierbare Formatierungsläufe.【F:.github/workflows/ci.yml†L26-L35】【F:pyproject.toml†L1-L14】
   - Bandit, Radon, Vulture und pip-audit sind als Dev-Abhängigkeiten verfügbar, per Makefile lokal aufrufbar und in der CI als verpflichtende Gates integriert; Offline-Umgebungen können die Security- und Analyse-Ziele über `CI_OFFLINE=true` gezielt überspringen.【F:requirements-dev.txt†L1-L4】【F:Makefile†L1-L36】【F:.github/workflows/ci.yml†L20-L69】【F:README.md†L196-L205】
   - `scripts/audit_wiring.py` prüft, dass keine Plex/Beets-Referenzen im aktiven Code landen, und läuft als eigener CI-Schritt.【F:scripts/audit_wiring.py†L1-L87】【F:.github/workflows/ci.yml†L20-L38】
+  - Alembic-basierte Migrationen initialisieren das Datenbankschema deterministisch (`init_db` ruft `alembic upgrade head` auf, Docker-Entrypoint und Makefile bieten Upgrade/Revision-Shortcuts, README beschreibt die Workflows).【F:app/db.py†L1-L107】【F:scripts/docker-entrypoint.sh†L1-L11】【F:Makefile†L1-L48】【F:README.md†L189-L202】
 
 ## ⬜️ Offen
 - **Backend**

--- a/alembic.ini
+++ b/alembic.ini
@@ -1,0 +1,36 @@
+[alembic]
+script_location = app/migrations
+prepend_sys_path = .
+sqlalchemy.url = 
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = INFO
+handlers = console
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stdout,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(asctime)s %(levelname)-5.5s [%(name)s] %(message)s

--- a/app/migrations/__init__.py
+++ b/app/migrations/__init__.py
@@ -1,0 +1,1 @@
+"""Alembic migration package for Harmony."""

--- a/app/migrations/env.py
+++ b/app/migrations/env.py
@@ -1,0 +1,85 @@
+"""Alembic environment configuration for Harmony."""
+
+from __future__ import annotations
+
+from logging.config import fileConfig
+from typing import Optional
+
+from alembic import context
+from alembic.config import Config
+from sqlalchemy import engine_from_config, pool
+
+from app.config import load_config
+from app.db import Base
+
+# Import models for metadata registration
+from app import models  # noqa: F401
+
+config = context.config
+
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+target_metadata = Base.metadata
+
+
+def _resolve_database_url(alembic_config: Optional[Config]) -> str:
+    if alembic_config is not None:
+        candidate = alembic_config.get_main_option("sqlalchemy.url")
+        if candidate:
+            return candidate
+    return load_config().database.url
+
+
+def run_migrations_offline() -> None:
+    """Run migrations in 'offline' mode."""
+
+    url = _resolve_database_url(config)
+    context.configure(
+        url=url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        compare_type=True,
+        compare_server_default=True,
+        dialect_opts={"paramstyle": "named"},
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    """Run migrations in 'online' mode."""
+
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section, {}),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+        url=_resolve_database_url(config),
+        future=True,
+    )
+
+    with connectable.connect() as connection:
+        context.configure(
+            connection=connection,
+            target_metadata=target_metadata,
+            compare_type=True,
+            compare_server_default=True,
+        )
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+    connectable.dispose()
+
+
+def get_database_url(alembic_config: Optional[Config] = None) -> str:
+    """Expose URL resolution for unit tests."""
+
+    return _resolve_database_url(alembic_config or config)
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/app/migrations/script.py.mako
+++ b/app/migrations/script.py.mako
@@ -1,0 +1,15 @@
+"""${message}"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+${imports if imports}
+
+
+def upgrade() -> None:
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade() -> None:
+    ${downgrades if downgrades else "pass"}

--- a/app/migrations/versions/7c9bdb5e1a3d_create_base_schema.py
+++ b/app/migrations/versions/7c9bdb5e1a3d_create_base_schema.py
@@ -1,0 +1,122 @@
+"""Create base schema"""
+
+from __future__ import annotations
+from typing import Any, Dict, Iterable
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import inspect
+
+from app.db import Base
+
+# Import models to populate metadata
+from app import models  # noqa: F401
+
+revision = "7c9bdb5e1a3d"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def _download_column_definitions() -> Dict[str, sa.Column[Any]]:
+    return {
+        "spotify_track_id": sa.Column(
+            "spotify_track_id", sa.String(length=128), nullable=True
+        ),
+        "spotify_album_id": sa.Column(
+            "spotify_album_id", sa.String(length=128), nullable=True
+        ),
+        "artwork_path": sa.Column("artwork_path", sa.String(length=2048), nullable=True),
+        "artwork_url": sa.Column("artwork_url", sa.String(length=2048), nullable=True),
+        "artwork_status": sa.Column(
+            "artwork_status",
+            sa.String(length=32),
+            nullable=False,
+            server_default=sa.text("'pending'"),
+        ),
+        "has_artwork": sa.Column(
+            "has_artwork",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("0"),
+        ),
+        "genre": sa.Column("genre", sa.String(length=255), nullable=True),
+        "composer": sa.Column("composer", sa.String(length=255), nullable=True),
+        "producer": sa.Column("producer", sa.String(length=255), nullable=True),
+        "isrc": sa.Column("isrc", sa.String(length=64), nullable=True),
+        "copyright": sa.Column("copyright", sa.String(length=512), nullable=True),
+        "organized_path": sa.Column(
+            "organized_path", sa.String(length=2048), nullable=True
+        ),
+        "retry_count": sa.Column(
+            "retry_count", sa.Integer(), nullable=False, server_default=sa.text("0")
+        ),
+        "next_retry_at": sa.Column("next_retry_at", sa.DateTime(), nullable=True),
+        "last_error": sa.Column("last_error", sa.Text(), nullable=True),
+    }
+
+
+def _ingest_item_column_definitions() -> Dict[str, sa.Column[Any]]:
+    return {
+        "spotify_track_id": sa.Column(
+            "spotify_track_id", sa.String(length=128), nullable=True
+        ),
+        "spotify_album_id": sa.Column(
+            "spotify_album_id", sa.String(length=128), nullable=True
+        ),
+        "isrc": sa.Column("isrc", sa.String(length=64), nullable=True),
+    }
+
+
+def _ensure_indexes(table: str, expected: Dict[str, Iterable[str]]) -> None:
+    bind = op.get_bind()
+    inspector = inspect(bind)
+    existing = {index["name"] for index in inspector.get_indexes(table)}
+    for name, columns in expected.items():
+        if name not in existing:
+            op.create_index(name, table, list(columns))
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    Base.metadata.create_all(bind=bind, checkfirst=True)
+
+    inspector = inspect(bind)
+
+    downloads_columns = {
+        column["name"] for column in inspector.get_columns("downloads")
+    }
+    for name, column in _download_column_definitions().items():
+        if name not in downloads_columns:
+            op.add_column("downloads", column)
+
+    ingest_columns = {
+        column["name"] for column in inspector.get_columns("ingest_items")
+    }
+    for name, column in _ingest_item_column_definitions().items():
+        if name not in ingest_columns:
+            op.add_column("ingest_items", column)
+
+    _ensure_indexes(
+        "downloads",
+        {
+            "ix_downloads_state": ["state"],
+            "ix_downloads_created_at": ["created_at"],
+            "ix_downloads_spotify_track_id": ["spotify_track_id"],
+            "ix_downloads_spotify_album_id": ["spotify_album_id"],
+        },
+    )
+    _ensure_indexes(
+        "ingest_items",
+        {
+            "ix_ingest_items_job_state": ["job_id", "state"],
+            "ix_ingest_items_job_hash": ["job_id", "dedupe_hash"],
+            "ix_ingest_items_spotify_track_id": ["spotify_track_id"],
+            "ix_ingest_items_spotify_album_id": ["spotify_album_id"],
+        },
+    )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    Base.metadata.drop_all(bind=bind, checkfirst=True)

--- a/app/migrations/versions/__init__.py
+++ b/app/migrations/versions/__init__.py
@@ -1,0 +1,1 @@
+"""Version history for Harmony database migrations."""

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 fastapi
 uvicorn
 sqlalchemy
+alembic
 aiohttp
 spotipy
 pydantic

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env sh
+set -euo pipefail
+
+if [ "${FEATURE_RUN_MIGRATIONS:-on}" != "off" ]; then
+  echo "Applying database migrations..."
+  alembic upgrade head
+else
+  echo "Skipping database migrations (FEATURE_RUN_MIGRATIONS=${FEATURE_RUN_MIGRATIONS:-off})."
+fi
+
+echo "Starting application: $*"
+exec "$@"

--- a/tests/test_migrations_env.py
+++ b/tests/test_migrations_env.py
@@ -1,0 +1,25 @@
+import pytest
+
+pytest.importorskip("alembic", reason="alembic is required for migration environment tests")
+
+from alembic.config import Config
+
+from app.migrations import env
+
+
+def test_get_database_url_prefers_config_override() -> None:
+    config = Config()
+    config.set_main_option("sqlalchemy.url", "sqlite:///override.db")
+
+    assert env.get_database_url(config) == "sqlite:///override.db"
+
+
+def test_get_database_url_falls_back_to_app_config(monkeypatch) -> None:
+    monkeypatch.setenv("DATABASE_URL", "sqlite:///./test-env.db")
+    config = Config()
+    config.set_main_option("sqlalchemy.url", "")
+
+    resolved = env.get_database_url(config)
+
+    assert resolved.endswith("test-env.db")
+    assert resolved.startswith("sqlite")


### PR DESCRIPTION
## What / Why
- replace the ad-hoc schema extensions with an Alembic-based migration workflow that seeds the full ORM schema and backfills legacy columns / indexes.
- run migrations automatically from `init_db`, the Docker entrypoint and new Make targets so fresh environments and CI converge on the same schema.
- document the developer workflow (upgrade / revision) and ensure tests cover the env URL resolution.

## Scope / Files
- backend infrastructure (`app/db.py`, `alembic.ini`, `app/migrations/**`).
- operations tooling (`Makefile`, `scripts/docker-entrypoint.sh`, `Dockerfile`).
- docs & tracking (`README.md`, `CHANGELOG.md`, `ToDo.md`).
- dependency manifest (`requirements.txt`).
- backend tests (`tests/test_migrations_env.py`).

## Database / Migrations
- new Alembic environment with initial revision `7c9bdb5e1a3d` creating the full schema and idempotently adding historical columns / indexes for `downloads` and `ingest_items`.
- `app.db.init_db()` upgrades to `head` (falling back to `Base.metadata.create_all()` if Alembic is unavailable) ensuring deterministic upgrades for fresh and existing SQLite databases.

## Tests
- `pytest -q` (181 passed, 4 skipped). See execution log in chunk `8f59ed`.

## Security
- no secrets introduced; Docker entrypoint only shells out to `alembic upgrade head`.

## Risks / Limitations
- offline environments without Alembic installed rely on the fallback metadata creation (logged) until dependencies are available.
- CLI commands (`alembic upgrade head`) require the new dependency to be present in the runtime image.

## AGENTS.md / Template Compliance
- follows repository guidelines (Conventional Commit, task ID in title/body, docs & ToDo updated, tests executed).

## ToDo Update
- recorded completion of CODX-DB-010 in `ToDo.md` under **Infrastruktur / CI**.

## Task
- CODX-DB-010

------
https://chatgpt.com/codex/tasks/task_e_68d827a08f688321bb13a00194ed9a68