### PR TITLE
TASK CODX-FE-045 fix(frontend): mount only active library tab and gate queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ## v1.x.x
 
+- fix(frontend): lazy load Library tabs, gate queries/toasts to the active view and sync the tab state with the URL to eliminate background polling.
 - feat(frontend): introduce a unified Library page with shadcn/ui tabs for artists, downloads and watchlist while redirecting legacy routes to the new entry point.
 - sec: enforce global API-Key authentication for all routers, return RFC 7807 problem-details for 401/403, document the scheme in OpenAPI, add configurable allowlist and restrictive CORS via env (`HARMONY_API_KEYS`, `AUTH_ALLOWLIST`, `ALLOWED_ORIGINS`).
 - feat: versioniere alle produktiven Endpunkte unter `/api/v1`, dokumentiere die neue Basis in OpenAPI/Docs, führe das Flag `FEATURE_ENABLE_LEGACY_ROUTES` zur temporären Alias-Bereitstellung ein und aktualisiere das Frontend auf den versionierten Pfad (`API_BASE_PATH`, `VITE_API_BASE_PATH`).

--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ CI_OFFLINE=true make all
 ### Features der UI
 
 - Dashboard mit Systeminformationen, Service-Status und aktiven Jobs.
-- Library-Seite bündelt Artists, Downloads und Watchlist mit konsistenter Tab-Navigation.
+- Library-Seite bündelt Artists, Downloads und Watchlist mit konsistenter Tab-Navigation; nur der aktive Tab wird lazy geladen und führt Polling aus.
 - Detailseiten für Spotify und Soulseek inkl. Tabs für Übersicht und Einstellungen (Plex/Beets-Ansichten archiviert).
 - Matching-Ansicht mit Fortschrittsanzeigen.
 - Settings-Bereich mit Formularen für sämtliche Integrationen.

--- a/ToDo.md
+++ b/ToDo.md
@@ -19,6 +19,7 @@
 - Alle produktiven Endpunkte laufen unter dem versionierten Präfix `/api/v1`; das Feature-Flag `FEATURE_ENABLE_LEGACY_ROUTES` hält die alten Pfade temporär parallel erreichbar, OpenAPI/Docs spiegeln den Namespace und das Frontend nutzt den neuen Basis-Pfad.【F:app/main.py†L295-L389】【F:app/config.py†L424-L511】【F:frontend/src/lib/api.ts†L1-L40】【F:docs/api.md†L5-L113】
 - **Frontend**
   - Das React-Frontend liefert geroutete Seiten für Dashboard, Library (Artists/Downloads/Watchlist), Spotify und Settings und nutzt einen Vite/TypeScript-Tooling-Stack inklusive Lint-, Test- und Build-Skripten.【F:frontend/src/routes/index.tsx†L1-L17】【F:frontend/package.json†L1-L35】
+  - Library-Tabs werden lazy geladen; nur der aktive Tab mountet Queries/Polling und synchronisiert den Tab-State mit der URL (TASK CODX-FE-045).【F:frontend/src/pages/Library/index.tsx†L1-L88】【F:frontend/src/pages/Library/LibraryDownloads.tsx†L1-L200】【F:frontend/src/__tests__/library.tabs.test.tsx†L1-L134】
   - Spotify-Seite mit FREE-Import-Karte (Textarea, Upload, Vorschau, Enqueue) sowie Modus-Schalter im Settings-Tab.【F:frontend/src/pages/SpotifyPage.tsx†L1-L79】【F:frontend/src/components/SpotifyFreeImport.tsx†L1-L187】【F:frontend/src/pages/SettingsPage.tsx†L1-L210】
 - **Tests**
   - Die Pytest-Suite deckt u. a. Such-Filterlogik und Watchlist-Automatisierung ab und läuft vollständig grün mit 214 Tests.【F:tests/test_search.py†L39-L107】【F:tests/test_watchlist.py†L14-L141】【8a3823†L1-L34】

--- a/frontend/src/__tests__/library.tabs.smoke.test.tsx
+++ b/frontend/src/__tests__/library.tabs.smoke.test.tsx
@@ -1,0 +1,1 @@
+import './library.tabs.test';

--- a/frontend/src/__tests__/library.tabs.test.tsx
+++ b/frontend/src/__tests__/library.tabs.test.tsx
@@ -1,0 +1,85 @@
+import LibraryDownloads from '../pages/Library/LibraryDownloads';
+import { renderWithProviders } from '../test-utils';
+import { LIBRARY_POLL_INTERVAL_MS } from '../lib/api';
+import { useQuery } from '../lib/query';
+
+type MockedUseQuery = jest.MockedFunction<typeof useQuery>;
+
+jest.mock('../lib/query', () => {
+  const actual = jest.requireActual('../lib/query');
+  return {
+    ...actual,
+    useQuery: jest.fn()
+  };
+});
+
+const mockedUseQuery = useQuery as MockedUseQuery;
+
+describe('Library tab gating', () => {
+  beforeEach(() => {
+    mockedUseQuery.mockReset();
+  });
+
+  it('verhindert Datenabfragen in inaktiven Tabs', () => {
+    const capturedOptions: unknown[] = [];
+    mockedUseQuery.mockImplementation((options: any) => {
+      capturedOptions.push(options);
+      return {
+        data: [],
+        error: undefined,
+        isLoading: false,
+        isError: false,
+        refetch: jest.fn()
+      };
+    });
+
+    renderWithProviders(<LibraryDownloads isActive={false} />);
+
+    expect(capturedOptions).toHaveLength(1);
+    const options = capturedOptions[0] as { enabled?: boolean; refetchInterval?: number | false };
+    expect(options.enabled).toBe(false);
+    expect(options.refetchInterval).toBe(false);
+  });
+
+  it('aktiviert Polling nur im aktiven Tab', () => {
+    const capturedOptions: unknown[] = [];
+    mockedUseQuery.mockImplementation((options: any) => {
+      capturedOptions.push(options);
+      return {
+        data: [],
+        error: undefined,
+        isLoading: false,
+        isError: false,
+        refetch: jest.fn()
+      };
+    });
+
+    renderWithProviders(<LibraryDownloads isActive />);
+
+    expect(capturedOptions).toHaveLength(1);
+    const options = capturedOptions[0] as { enabled?: boolean; refetchInterval?: number | false };
+    expect(options.enabled).toBe(true);
+    expect(options.refetchInterval).toBe(LIBRARY_POLL_INTERVAL_MS);
+  });
+
+  it('unterdrückt Fehler-Toasts wenn der Tab inaktiv ist', () => {
+    const toastSpy = jest.fn();
+    let onError: ((error: unknown) => void) | undefined;
+    mockedUseQuery.mockImplementation((options: any) => {
+      onError = options.onError;
+      return {
+        data: [],
+        error: undefined,
+        isLoading: false,
+        isError: false,
+        refetch: jest.fn()
+      };
+    });
+
+    renderWithProviders(<LibraryDownloads isActive={false} />, { toastFn: toastSpy });
+
+    expect(typeof onError).toBe('function');
+    onError?.(new Error('Testfehler'));
+    expect(toastSpy).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -15,6 +15,27 @@ const apiUrl = (path: string): string => {
   return `${API_BASE_PATH}${normalizedPath}`;
 };
 
+declare global {
+  interface Window {
+    __HARMONY_LIBRARY_POLL_INTERVAL_MS__?: string;
+  }
+}
+
+const DEFAULT_LIBRARY_POLL_INTERVAL_MS = 15000;
+
+export const LIBRARY_POLL_INTERVAL_MS = (() => {
+  const nodeEnv = (globalThis as { process?: { env?: Record<string, string | undefined> } }).process?.env;
+  const browserValue = typeof window !== 'undefined' ? window.__HARMONY_LIBRARY_POLL_INTERVAL_MS__ : undefined;
+  const raw = nodeEnv?.VITE_LIBRARY_POLL_INTERVAL_MS ?? browserValue;
+  if (typeof raw === 'string') {
+    const parsed = Number.parseInt(raw, 10);
+    if (Number.isFinite(parsed) && parsed > 0) {
+      return parsed;
+    }
+  }
+  return DEFAULT_LIBRARY_POLL_INTERVAL_MS;
+})();
+
 export const api = axios.create({
   baseURL: API_BASE_URL,
   timeout: 15000

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -9,12 +9,14 @@ declare global {
   interface Window {
     __HARMONY_API_URL__?: string;
     __HARMONY_API_BASE_PATH__?: string;
+    __HARMONY_LIBRARY_POLL_INTERVAL_MS__?: string;
   }
 }
 
 if (typeof window !== 'undefined') {
   window.__HARMONY_API_URL__ = import.meta.env?.VITE_API_URL;
   window.__HARMONY_API_BASE_PATH__ = import.meta.env?.VITE_API_BASE_PATH;
+  window.__HARMONY_LIBRARY_POLL_INTERVAL_MS__ = import.meta.env?.VITE_LIBRARY_POLL_INTERVAL_MS;
 }
 
 const queryClient = new QueryClient();

--- a/frontend/src/pages/Library/LibraryArtists.tsx
+++ b/frontend/src/pages/Library/LibraryArtists.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { Loader2, Users } from 'lucide-react';
 import {
   Button,
@@ -66,12 +66,22 @@ const areSelectionsEqual = (a: Record<string, boolean>, b: Record<string, boolea
   return true;
 };
 
-const LibraryArtists = () => {
+interface LibraryArtistsProps {
+  isActive?: boolean;
+}
+
+const LibraryArtists = ({ isActive = true }: LibraryArtistsProps = {}) => {
   const { toast } = useToast();
   const [selectedArtistId, setSelectedArtistId] = useState<string | null>(null);
   const [selection, setSelection] = useState<Record<string, boolean>>({});
   const [releaseCounts, setReleaseCounts] = useState<Record<string, number>>({});
   const [releaseFilter, setReleaseFilter] = useState<ReleaseFilterValue>('all');
+
+  const isActiveRef = useRef(isActive);
+
+  useEffect(() => {
+    isActiveRef.current = isActive;
+  }, [isActive]);
 
   const {
     data: artists,
@@ -89,12 +99,16 @@ const LibraryArtists = () => {
         }
         error.markHandled();
       }
+      if (!isActiveRef.current) {
+        return;
+      }
       toast({
         title: 'Artists konnten nicht geladen werden',
         description: 'Bitte Backend-Verbindung prüfen.',
         variant: 'destructive'
       });
-    }
+    },
+    enabled: isActive
   });
 
   const {
@@ -113,12 +127,16 @@ const LibraryArtists = () => {
         }
         error.markHandled();
       }
+      if (!isActiveRef.current) {
+        return;
+      }
       toast({
         title: 'Artist-Präferenzen fehlgeschlagen',
         description: 'Die Auswahl konnte nicht geladen werden.',
         variant: 'destructive'
       });
-    }
+    },
+    enabled: isActive
   });
 
   const {
@@ -143,12 +161,16 @@ const LibraryArtists = () => {
         }
         error.markHandled();
       }
+      if (!isActiveRef.current) {
+        return;
+      }
       toast({
         title: 'Releases konnten nicht geladen werden',
         description: 'Bitte versuchen Sie es erneut.',
         variant: 'destructive'
       });
-    }
+    },
+    enabled: isActive && Boolean(selectedArtistId)
   });
 
   const baseSelection = useMemo(() => {
@@ -215,6 +237,9 @@ const LibraryArtists = () => {
           return;
         }
         error.markHandled();
+      }
+      if (!isActiveRef.current) {
+        return;
       }
       toast({
         title: 'Speichern fehlgeschlagen',

--- a/frontend/src/pages/Library/index.tsx
+++ b/frontend/src/pages/Library/index.tsx
@@ -1,11 +1,13 @@
-import { useEffect, useMemo } from 'react';
+import { Suspense, lazy, useEffect, useMemo } from 'react';
 import { useSearchParams } from 'react-router-dom';
+import { Loader2 } from 'lucide-react';
 
 import { Tabs, TabsContent } from '../../components/ui/shadcn';
-import LibraryArtists from './LibraryArtists';
-import LibraryDownloads from './LibraryDownloads';
 import LibraryTabs, { LibraryTabKey, libraryTabItems } from './LibraryTabs';
-import LibraryWatchlist from './LibraryWatchlist';
+
+const LibraryArtists = lazy(() => import('./LibraryArtists'));
+const LibraryDownloads = lazy(() => import('./LibraryDownloads'));
+const LibraryWatchlist = lazy(() => import('./LibraryWatchlist'));
 
 const DEFAULT_TAB: LibraryTabKey = 'artists';
 
@@ -37,8 +39,16 @@ const LibraryPage = () => {
     const normalized = isLibraryTab(nextTab) ? nextTab : DEFAULT_TAB;
     const params = new URLSearchParams(searchParams);
     params.set('tab', normalized);
-    setSearchParams(params, { replace: true });
+    setSearchParams(params);
   };
+
+  const renderTabFallback = () => (
+    <div className="flex justify-center py-12 text-muted-foreground">
+      <span className="inline-flex items-center gap-2 text-sm">
+        <Loader2 className="h-4 w-4 animate-spin" aria-hidden /> Lädt Inhalte…
+      </span>
+    </div>
+  );
 
   return (
     <div className="space-y-6">
@@ -51,13 +61,25 @@ const LibraryPage = () => {
       <Tabs value={activeTab} onValueChange={handleTabChange} className="space-y-6">
         <LibraryTabs />
         <TabsContent value="artists" className="space-y-6">
-          <LibraryArtists />
+          {activeTab === 'artists' ? (
+            <Suspense fallback={renderTabFallback()}>
+              <LibraryArtists isActive />
+            </Suspense>
+          ) : null}
         </TabsContent>
         <TabsContent value="downloads" className="space-y-6">
-          <LibraryDownloads />
+          {activeTab === 'downloads' ? (
+            <Suspense fallback={renderTabFallback()}>
+              <LibraryDownloads isActive />
+            </Suspense>
+          ) : null}
         </TabsContent>
         <TabsContent value="watchlist" className="space-y-6">
-          <LibraryWatchlist />
+          {activeTab === 'watchlist' ? (
+            <Suspense fallback={renderTabFallback()}>
+              <LibraryWatchlist isActive />
+            </Suspense>
+          ) : null}
         </TabsContent>
       </Tabs>
     </div>


### PR DESCRIPTION
## Summary
- lazy-load the individual Library tab views and sync the active tab state with the URL so only the selected tab mounts
- gate all Library queries, polling intervals, and destructive toasts behind an `isActive` flag driven by the selected tab
- expose the library poll interval at runtime, wire it into the downloads polling, and document the new behaviour

## Changes
### Added
- `frontend/src/__tests__/library.tabs.test.tsx`
- `frontend/src/__tests__/library.tabs.smoke.test.tsx`

### Modified
- `frontend/src/pages/Library/index.tsx`
- `frontend/src/pages/Library/LibraryArtists.tsx`
- `frontend/src/pages/Library/LibraryDownloads.tsx`
- `frontend/src/pages/Library/LibraryWatchlist.tsx`
- `frontend/src/lib/query.tsx`
- `frontend/src/lib/api.ts`
- `frontend/src/main.tsx`
- `README.md`
- `CHANGELOG.md`
- `ToDo.md`

## Testing
- `npm --prefix frontend test -- --runInBand`
- `npm --prefix frontend run typecheck`

## Risks
- Tab content now mounts lazily behind Suspense; ensure fallback spinner and query gating handle slow responses without regressions.

## ToDo Update
- `ToDo.md` documents the completed lazy-loading and query gating work for the Library tabs.

## References
- Conforms to repository standards described in `AGENTS.md`.


------
https://chatgpt.com/codex/tasks/task_e_68d90ee118148321a33105d00c3584b7