### PR TITLE
docs: strengthen AGENTS.md with initiative, scope-guard and clarification rules [CODX-DOC-076]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## v1.0.1 — 2025-09-25
+- docs: AGENTS.md um Initiative-, Scope-Guard- und Clarification-Regeln inkl. Checklisten, CI-Gates und Beispielen erweitert.
 - docs: README/ENV aktualisiert, Health/Ready/Metrics-Doku konsolidiert,
   `.env.example` ergänzt und neue Ops-Guides für Runtime-Konfiguration sowie
   Prometheus-Integration hinzugefügt.【F:README.md†L328-L612】【F:.env.example†L1-L108】【F:docs/ops/runtime-config.md†L1-L83】【F:docs/ops/metrics.md†L1-L61】


### PR DESCRIPTION
## Summary
- erweitere AGENTS.md um verbindliche Kapitel zu zulässiger Initiative, Scope-Guards und Clarification-Triggern inklusive Checklisten
- ergänze Commit-/PR-Standards, CI-/OpenAPI-Gates sowie Do/Don’t-Beispiele für schnelle Entscheidungen
- aktualisiere CHANGELOG.md mit Hinweis auf die erweiterten Richtlinien

## Changes
- Geändert: AGENTS.md — neue Kapitel, Checklisten und Beispiele zu Initiative, Scope-Guard, Clarification, Commit-/PR-Standards und CI-Gates
- Geändert: CHANGELOG.md — Eintrag für die aktualisierten Agenten-Richtlinien ergänzt

## Risks & Limitations
- Dokumentationsänderung ohne Auswirkungen auf Laufzeit oder Public APIs

## Testing
- Not run (documentation-only change)

## AGENTS.md-Konformität
- Scope-Guard geprüft, nur Dokumentation angepasst
- Keine Secrets/`BACKUP`/Lizenz-Dateien geändert
- ToDo.md unverändert (keine betroffenen Einträge)


------
https://chatgpt.com/codex/tasks/task_e_68da9fb630bc8321a91949bce472eb49