### PR TITLE
chore: harden transfers core error handling [CODX-CORE-078]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - docs: `AGENTS.md` – Initiative Policy, Scope-Guard, Clarification & PR-Regeln ergänzt.
 - Refine AGENTS.md: Commit-Hygiene, Branch-Regel ein Ziel, Testing-Erwartungen, Quality-Gates (ruff/black, eslint/prettier, bandit/npm audit), AI-Review-Pflicht, Lizenz-Header, TASK_ID- und Testnachweise-Pflicht.
 - Update PR-Template: TASK_ID und Testnachweise verpflichtend.
+- chore(core): Transfers-Wrapper typisiert, Fehler auf `VALIDATION_ERROR`/`NOT_FOUND`/`DEPENDENCY_ERROR` gemappt und Import-Sanity-Tests ergänzt.【F:app/core/transfers_api.py†L1-L188】【F:app/core/soulseek_client.py†L1-L190】【F:tests/core/test_transfers_api.py†L1-L124】【F:tests/core/test_imports.py†L1-L27】
 
 # Changelog
 - feat(cache): introduce HTTP conditional requests with strong/weak ETag support, Last-Modified propagation, documented 304

--- a/README.md
+++ b/README.md
@@ -388,6 +388,24 @@ try-Zugriffs im CI bewusst ausgelassen.
 | `SLSKD_MAX_RESULTS` | int | `50` | Maximale Treffer pro slskd-Suche. | — |
 | `PROVIDER_MAX_CONCURRENCY` | int | `4` | Parallele Provider-Aufrufe (Spotify/slskd). | — |
 
+##### Spotify OAuth (PRO-Modus)
+
+- `SPOTIFY_CLIENT_ID` und `SPOTIFY_CLIENT_SECRET` **müssen** gesetzt sein, sobald `SPOTIFY_MODE=PRO` aktiv ist. Die Werte stammen
+  aus der Spotify Developer Console (App → _Settings_). Sie dürfen nicht eingecheckt werden.
+- `SPOTIFY_REDIRECT_URI` muss exakt mit der in Spotify registrierten Redirect-URI übereinstimmen (inkl. Protokoll/Port). Für
+  lokale Tests bietet sich z. B. `http://localhost:3000/api/auth/spotify/callback` an.
+- Optional können die Secrets auch über `/settings` in die Datenbank geschrieben werden. ENV-Werte dienen als Fallback bzw.
+  Initialbefüllung.
+
+##### slskd (Soulseek-Daemon)
+
+- `SLSKD_BASE_URL` verweist auf die HTTP-Instanz (Default `http://localhost:5030`). Legacy-Varianten (`SLSKD_URL`, Host/Port)
+  werden weiterhin gelesen, sollten aber migriert werden.
+- Wenn slskd mit API-Key abgesichert ist, muss `SLSKD_API_KEY` konfiguriert werden. Der Key wird per `X-API-Key` Header
+  übertragen.
+- Zeitkritische Pfade verwenden `SLSKD_TIMEOUT_MS` sowie die Retry-Parameter `SLSKD_RETRY_MAX`/`SLSKD_RETRY_BACKOFF_BASE_MS`.
+  Bei hohen Latenzen empfiehlt sich ein Timeout ≥ 8000 ms sowie ein konservatives Retry-Limit.
+
 #### Artwork & Lyrics
 
 | Variable | Typ | Default | Beschreibung | Sicherheit |

--- a/app/core/transfers_api.py
+++ b/app/core/transfers_api.py
@@ -2,13 +2,82 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict, Iterable
+from collections.abc import Iterable, Mapping, Sequence
+from typing import Any
 
 from app.core.soulseek_client import SoulseekClient, SoulseekClientError
+from app.errors import ErrorCode
 
 
 class TransfersApiError(RuntimeError):
     """Raised when the slskd transfers API cannot fulfil a request."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        code: ErrorCode = ErrorCode.DEPENDENCY_ERROR,
+        status_code: int | None = None,
+        details: Mapping[str, Any] | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.code = code
+        self.status_code = status_code
+        self.details = dict(details) if details is not None else None
+
+
+class TransfersDependencyError(TransfersApiError):
+    """Raised when slskd is unavailable or returned a 5xx error."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        status_code: int | None = None,
+        details: Mapping[str, Any] | None = None,
+    ) -> None:
+        super().__init__(
+            message,
+            code=ErrorCode.DEPENDENCY_ERROR,
+            status_code=status_code,
+            details=details,
+        )
+
+
+class TransfersNotFoundError(TransfersApiError):
+    """Raised when a download transfer could not be located."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        status_code: int | None = None,
+        details: Mapping[str, Any] | None = None,
+    ) -> None:
+        super().__init__(
+            message,
+            code=ErrorCode.NOT_FOUND,
+            status_code=status_code,
+            details=details,
+        )
+
+
+class TransfersValidationError(TransfersApiError):
+    """Raised when invalid data is provided to the transfers API."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        status_code: int | None = None,
+        details: Mapping[str, Any] | None = None,
+    ) -> None:
+        super().__init__(
+            message,
+            code=ErrorCode.VALIDATION_ERROR,
+            status_code=status_code,
+            details=details,
+        )
 
 
 class TransfersApi:
@@ -17,19 +86,124 @@ class TransfersApi:
     def __init__(self, client: SoulseekClient) -> None:
         self._client = client
 
-    async def cancel_download(self, download_id: int | str) -> Dict[str, Any]:
+    async def cancel_download(self, transfer_id: str | int) -> bool:
         """Cancel a download via slskd."""
 
+        normalised = self._normalise_transfer_id(transfer_id)
         try:
-            return await self._client.cancel_download(str(download_id))
+            payload = await self._client.cancel_download(normalised)
         except SoulseekClientError as exc:  # pragma: no cover - network failure path
-            raise TransfersApiError(str(exc)) from exc
+            self._raise_from_client_error("Failed to cancel download", exc)
+        return self._acknowledged(payload)
 
-    async def enqueue(self, *, username: str, files: Iterable[Dict[str, Any]]) -> Dict[str, Any]:
+    async def enqueue(
+        self,
+        *,
+        username: str,
+        files: Iterable[Mapping[str, Any]],
+    ) -> str:
         """Enqueue a new download job for the given user and files."""
 
+        normalised_username = username.strip()
+        if not normalised_username:
+            raise TransfersValidationError("username must not be empty")
+        normalised_files = self._normalise_files(files)
+
         try:
-            file_list = list(files)
-            return await self._client.enqueue(username, file_list)
+            payload = await self._client.enqueue(normalised_username, normalised_files)
         except SoulseekClientError as exc:  # pragma: no cover - network failure path
-            raise TransfersApiError(str(exc)) from exc
+            self._raise_from_client_error("Failed to enqueue download", exc)
+
+        return self._extract_identifier(payload, normalised_files, normalised_username)
+
+    @staticmethod
+    def _normalise_transfer_id(transfer_id: str | int) -> str:
+        if isinstance(transfer_id, str):
+            candidate = transfer_id.strip()
+            if not candidate:
+                raise TransfersValidationError("transfer_id must not be empty")
+            return candidate
+        if isinstance(transfer_id, int):
+            if transfer_id <= 0:
+                raise TransfersValidationError("transfer_id must be positive")
+            return str(transfer_id)
+        raise TransfersValidationError("transfer_id must be a string or integer")
+
+    @staticmethod
+    def _normalise_files(files: Iterable[Mapping[str, Any]]) -> list[dict[str, Any]]:
+        result: list[dict[str, Any]] = []
+        for index, file_entry in enumerate(files, start=1):
+            if not isinstance(file_entry, Mapping):
+                raise TransfersValidationError(
+                    f"files[{index - 1}] must be a mapping, got {type(file_entry)!r}",
+                )
+            normalised = dict(file_entry)
+            filename = normalised.get("filename") or normalised.get("name")
+            if filename:
+                normalised["filename"] = str(filename)
+            result.append(normalised)
+
+        if not result:
+            raise TransfersValidationError("files must contain at least one entry")
+        return result
+
+    @staticmethod
+    def _extract_identifier(
+        payload: Any,
+        files: Sequence[Mapping[str, Any]],
+        username: str,
+    ) -> str:
+        if isinstance(payload, Mapping):
+            for key in ("job_id", "download_id", "id", "identifier"):
+                value = payload.get(key)
+                if value:
+                    return str(value)
+            job = payload.get("job")
+            if isinstance(job, Mapping):
+                for key in ("id", "download_id", "identifier"):
+                    value = job.get(key)
+                    if value:
+                        return str(value)
+            downloads = payload.get("downloads")
+            if isinstance(downloads, Sequence):
+                for entry in downloads:
+                    if isinstance(entry, Mapping):
+                        for key in ("id", "download_id", "identifier"):
+                            value = entry.get(key)
+                            if value:
+                                return str(value)
+
+        for file_entry in files:
+            value = file_entry.get("download_id") or file_entry.get("id")
+            if value:
+                return str(value)
+            filename = file_entry.get("filename") or file_entry.get("name")
+            if filename:
+                return str(filename)
+
+        return username
+
+    @staticmethod
+    def _acknowledged(payload: Any) -> bool:
+        if isinstance(payload, Mapping):
+            status = payload.get("status")
+            if isinstance(status, str):
+                return status.lower() not in {"failed", "error"}
+            if isinstance(status, bool):
+                return status
+            cancelled = payload.get("cancelled")
+            if cancelled:
+                return True
+        return True
+
+    @staticmethod
+    def _raise_from_client_error(message: str, exc: SoulseekClientError) -> None:
+        status_code = getattr(exc, "status_code", None)
+        details = exc.payload if isinstance(exc.payload, Mapping) else None
+        if status_code == 404:
+            raise TransfersNotFoundError(message, status_code=status_code, details=details) from exc
+        if status_code in {400, 422}:
+            raise TransfersValidationError(
+                message, status_code=status_code, details=details
+            ) from exc
+        raise TransfersDependencyError(message, status_code=status_code, details=details) from exc

--- a/tests/core/test_imports.py
+++ b/tests/core/test_imports.py
@@ -1,0 +1,27 @@
+"""Sanity checks ensuring app.core modules import without side-effects."""
+
+from __future__ import annotations
+
+import importlib
+import pkgutil
+from pathlib import Path
+
+import pytest
+
+
+_MODULE_ROOT = Path(__file__).resolve().parents[2] / "app" / "core"
+
+
+def _discover_modules() -> list[str]:
+    modules: list[str] = []
+    for module in pkgutil.iter_modules([str(_MODULE_ROOT)]):
+        name = module.name
+        if name.startswith("__"):
+            continue
+        modules.append(name)
+    return sorted(modules)
+
+
+@pytest.mark.parametrize("module_name", _discover_modules())
+def test_app_core_imports(module_name: str) -> None:
+    importlib.import_module(f"app.core.{module_name}")

--- a/tests/core/test_transfers_api.py
+++ b/tests/core/test_transfers_api.py
@@ -1,0 +1,128 @@
+"""Unit tests for the high level transfers API wrapper."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.core.transfers_api import (
+    TransfersApi,
+    TransfersDependencyError,
+    TransfersNotFoundError,
+    TransfersValidationError,
+)
+from app.core.soulseek_client import SoulseekClientError
+
+
+class _StubSoulseekClient:
+    def __init__(self) -> None:
+        self.cancelled: list[str] = []
+        self.enqueued: list[tuple[str, list[dict[str, object]]]] = []
+
+    async def cancel_download(self, transfer_id: str) -> dict[str, object]:
+        self.cancelled.append(transfer_id)
+        return {"status": "cancelled", "cancelled": transfer_id}
+
+    async def enqueue(self, username: str, files: list[dict[str, object]]) -> dict[str, object]:
+        self.enqueued.append((username, files))
+        return {"job": {"id": files[0].get("download_id", "job-1")}}
+
+
+@pytest.mark.asyncio
+async def test_cancel_download_success() -> None:
+    client = _StubSoulseekClient()
+    api = TransfersApi(client)
+
+    assert await api.cancel_download("42") is True
+    assert client.cancelled == ["42"]
+
+
+@pytest.mark.asyncio
+async def test_cancel_download_validates_identifier() -> None:
+    api = TransfersApi(_StubSoulseekClient())
+
+    with pytest.raises(TransfersValidationError):
+        await api.cancel_download("  ")
+
+    with pytest.raises(TransfersValidationError):
+        await api.cancel_download(0)
+
+
+@pytest.mark.asyncio
+async def test_cancel_download_maps_not_found() -> None:
+    class _ErrorClient(_StubSoulseekClient):
+        async def cancel_download(self, transfer_id: str) -> dict[str, object]:  # type: ignore[override]
+            raise SoulseekClientError("not found", status_code=404)
+
+    api = TransfersApi(_ErrorClient())
+
+    with pytest.raises(TransfersNotFoundError) as exc:
+        await api.cancel_download("55")
+
+    assert exc.value.code.value == "NOT_FOUND"
+
+
+@pytest.mark.asyncio
+async def test_cancel_download_maps_dependency_error() -> None:
+    class _ErrorClient(_StubSoulseekClient):
+        async def cancel_download(self, transfer_id: str) -> dict[str, object]:  # type: ignore[override]
+            raise SoulseekClientError("boom", status_code=503)
+
+    api = TransfersApi(_ErrorClient())
+
+    with pytest.raises(TransfersDependencyError) as exc:
+        await api.cancel_download("12")
+
+    assert exc.value.code.value == "DEPENDENCY_ERROR"
+
+
+@pytest.mark.asyncio
+async def test_enqueue_success() -> None:
+    client = _StubSoulseekClient()
+    api = TransfersApi(client)
+
+    identifier = await api.enqueue(
+        username="alice", files=[{"download_id": 1001, "filename": "song.flac"}]
+    )
+
+    assert identifier == "1001"
+    assert client.enqueued[0][0] == "alice"
+
+
+@pytest.mark.asyncio
+async def test_enqueue_validates_inputs() -> None:
+    api = TransfersApi(_StubSoulseekClient())
+
+    with pytest.raises(TransfersValidationError):
+        await api.enqueue(username="  ", files=[{"download_id": 1}])
+
+    with pytest.raises(TransfersValidationError):
+        await api.enqueue(username="alice", files=[])
+
+    with pytest.raises(TransfersValidationError):
+        await api.enqueue(username="alice", files=["not-a-mapping"])  # type: ignore[arg-type]
+
+
+@pytest.mark.asyncio
+async def test_enqueue_maps_validation_errors() -> None:
+    class _ErrorClient(_StubSoulseekClient):
+        async def enqueue(self, username: str, files: list[dict[str, object]]) -> dict[str, object]:  # type: ignore[override]
+            raise SoulseekClientError("bad request", status_code=400)
+
+    api = TransfersApi(_ErrorClient())
+
+    with pytest.raises(TransfersValidationError) as exc:
+        await api.enqueue(username="alice", files=[{"download_id": 100}])
+
+    assert exc.value.code.value == "VALIDATION_ERROR"
+
+
+@pytest.mark.asyncio
+async def test_enqueue_maps_dependency_errors() -> None:
+    class _ErrorClient(_StubSoulseekClient):
+        async def enqueue(self, username: str, files: list[dict[str, object]]) -> dict[str, object]:  # type: ignore[override]
+            raise SoulseekClientError("timeout", status_code=503)
+
+    api = TransfersApi(_ErrorClient())
+
+    with pytest.raises(TransfersDependencyError):
+        await api.enqueue(username="alice", files=[{"download_id": 101}])


### PR DESCRIPTION
## Summary
- propagate slskd status metadata from `SoulseekClientError` and expose typed `TransfersApi` errors for validation/not-found/dependency failures
- cover the new behaviour with focused unit tests plus an import sanity check for `app.core`
- document required Spotify/slskd environment variables for runtime configuration

## Testing
- ruff check .
- black --check .
- mypy app
- pytest -q

## TASK_ID
- CODX-CORE-078

------
https://chatgpt.com/codex/tasks/task_e_68daa86351488321b27d2cbc22fdef88