### PR TITLE
feat: harden slskd integration [CODX-INT-079]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## v1.0.1 — 2025-09-25
+- feat(integrations): harden slskd adapter with strict config validation, URL normalisation,
+  jittered retries, structured logging and updated contract tests; integration service and
+  configuration wiring follow suit.【F:app/integrations/slskd_adapter.py†L1-L470】【F:app/services/integration_service.py†L1-L120】【F:app/config.py†L570-L640】【F:app/integrations/registry.py†L1-L80】【F:tests/integrations/test_slskd_adapter.py†L1-L220】【F:tests/services/test_integration_service_slskd.py†L1-L160】
 - docs: AGENTS.md um Initiative-, Scope-Guard- und Clarification-Regeln inkl. Checklisten, CI-Gates und Beispielen erweitert.
 - docs: README/ENV aktualisiert, Health/Ready/Metrics-Doku konsolidiert,
   `.env.example` ergänzt und neue Ops-Guides für Runtime-Konfiguration sowie

--- a/README.md
+++ b/README.md
@@ -384,6 +384,7 @@ try-Zugriffs im CI bewusst ausgelassen.
 | `SLSKD_TIMEOUT_MS` | int | `8000` | Timeout für slskd-Anfragen. | — |
 | `SLSKD_RETRY_MAX` | int | `3` | Neuversuche pro slskd-Request. | — |
 | `SLSKD_RETRY_BACKOFF_BASE_MS` | int | `250` | Basis für exponentielles Backoff bei slskd. | — |
+| `SLSKD_JITTER_PCT` | int | `20` | Zufälliger ±Jitter (in %) für das Backoff pro Versuch. | — |
 | `SLSKD_PREFERRED_FORMATS` | csv | `FLAC,ALAC,APE,MP3` | Ranking-Priorisierung für Audioformate. | — |
 | `SLSKD_MAX_RESULTS` | int | `50` | Maximale Treffer pro slskd-Suche. | — |
 | `PROVIDER_MAX_CONCURRENCY` | int | `4` | Parallele Provider-Aufrufe (Spotify/slskd). | — |
@@ -401,8 +402,8 @@ try-Zugriffs im CI bewusst ausgelassen.
 
 - `SLSKD_BASE_URL` verweist auf die HTTP-Instanz (Default `http://localhost:5030`). Legacy-Varianten (`SLSKD_URL`, Host/Port)
   werden weiterhin gelesen, sollten aber migriert werden.
-- Wenn slskd mit API-Key abgesichert ist, muss `SLSKD_API_KEY` konfiguriert werden. Der Key wird per `X-API-Key` Header
-  übertragen.
+- `SLSKD_API_KEY` **muss** konfiguriert werden und wird per `X-API-Key` Header übertragen.
+- `SLSKD_JITTER_PCT` steuert den ±Jitter für das exponentielle Backoff (Default ±20 %).
 - Zeitkritische Pfade verwenden `SLSKD_TIMEOUT_MS` sowie die Retry-Parameter `SLSKD_RETRY_MAX`/`SLSKD_RETRY_BACKOFF_BASE_MS`.
   Bei hohen Latenzen empfiehlt sich ein Timeout ≥ 8000 ms sowie ein konservatives Retry-Limit.
 

--- a/app/config.py
+++ b/app/config.py
@@ -35,6 +35,7 @@ class SoulseekConfig:
     timeout_ms: int
     retry_max: int
     retry_backoff_base_ms: int
+    retry_jitter_pct: float
     preferred_formats: tuple[str, ...]
     max_results: int
 
@@ -192,6 +193,7 @@ DEFAULT_PROVIDER_MAX_CONCURRENCY = 4
 DEFAULT_SLSKD_TIMEOUT_MS = 8_000
 DEFAULT_SLSKD_RETRY_MAX = 3
 DEFAULT_SLSKD_RETRY_BACKOFF_BASE_MS = 250
+DEFAULT_SLSKD_RETRY_JITTER_PCT = 20.0
 DEFAULT_SLSKD_PREFERRED_FORMATS = ("FLAC", "ALAC", "APE", "MP3")
 DEFAULT_SLSKD_MAX_RESULTS = 50
 DEFAULT_HEALTH_DB_TIMEOUT_MS = 500
@@ -606,6 +608,10 @@ def load_config() -> AppConfig:
             default=DEFAULT_SLSKD_RETRY_BACKOFF_BASE_MS,
         ),
     )
+    retry_jitter_pct_raw = _as_float(
+        os.getenv("SLSKD_JITTER_PCT"), default=DEFAULT_SLSKD_RETRY_JITTER_PCT
+    )
+    retry_jitter_pct = min(100.0, max(0.0, retry_jitter_pct_raw))
     preferred_formats_list = _parse_list(os.getenv("SLSKD_PREFERRED_FORMATS"))
     if not preferred_formats_list:
         preferred_formats_list = list(DEFAULT_SLSKD_PREFERRED_FORMATS)
@@ -632,6 +638,7 @@ def load_config() -> AppConfig:
         timeout_ms=timeout_ms,
         retry_max=retry_max,
         retry_backoff_base_ms=retry_backoff_base_ms,
+        retry_jitter_pct=retry_jitter_pct,
         preferred_formats=preferred_formats,
         max_results=max_results,
     )

--- a/app/integrations/base.py
+++ b/app/integrations/base.py
@@ -96,7 +96,7 @@ class MusicProviderAdapter(Protocol):
     async def search_tracks(
         self, query: str, artist: str | None = None, limit: int = 50
     ) -> list[TrackCandidate]:
-        """Return potential download candidates for the supplied search query."""
+        """Return a concrete list of download candidates for the supplied search query."""
 
 
 class ProviderError(RuntimeError):

--- a/app/integrations/registry.py
+++ b/app/integrations/registry.py
@@ -57,6 +57,7 @@ class ProviderRegistry:
                 timeout_ms=soulseek.timeout_ms,
                 max_retries=soulseek.retry_max,
                 backoff_base_ms=soulseek.retry_backoff_base_ms,
+                jitter_pct=soulseek.retry_jitter_pct,
                 preferred_formats=soulseek.preferred_formats,
                 max_results=soulseek.max_results,
             )

--- a/app/services/integration_service.py
+++ b/app/services/integration_service.py
@@ -6,12 +6,19 @@ import asyncio
 from dataclasses import dataclass
 from typing import Iterable
 
-from app.errors import DependencyError, InternalServerError, RateLimitedError, ValidationAppError
+from app.errors import (
+    DependencyError,
+    InternalServerError,
+    NotFoundError,
+    RateLimitedError,
+    ValidationAppError,
+)
 from app.integrations.base import TrackCandidate
 from app.integrations.slskd_adapter import (
     SlskdAdapter,
     SlskdAdapterDependencyError,
     SlskdAdapterInternalError,
+    SlskdAdapterNotFoundError,
     SlskdAdapterRateLimitedError,
     SlskdAdapterValidationError,
 )
@@ -96,6 +103,8 @@ class IntegrationService:
                 retry_after_ms=exc.retry_after_ms,
                 retry_after_header=exc.retry_after_header,
             ) from exc
+        except SlskdAdapterNotFoundError as exc:
+            raise NotFoundError("slskd returned no matching results.") from exc
         except SlskdAdapterDependencyError as exc:
             meta = {"provider_status": exc.status_code} if exc.status_code is not None else None
             raise DependencyError("slskd search is currently unavailable.", meta=meta) from exc

--- a/docs/integrations/slskd.md
+++ b/docs/integrations/slskd.md
@@ -12,10 +12,11 @@ upstream service.
 | Variable | Default | Description |
 | --- | --- | --- |
 | `SLSKD_BASE_URL` | `http://localhost:5030` | Base URL of the slskd service. Legacy `SLSKD_URL` is still honoured. |
-| `SLSKD_API_KEY` | `None` | Optional API key presented via the `X-API-Key` header. |
+| `SLSKD_API_KEY` | _(required)_ | Mandatory API key presented via the `X-API-Key` header. |
 | `SLSKD_TIMEOUT_MS` | `8000` | Hard timeout for upstream requests in milliseconds. |
 | `SLSKD_RETRY_MAX` | `3` | Number of retry attempts on timeouts/5xx/429 responses. |
-| `SLSKD_RETRY_BACKOFF_BASE_MS` | `250` | Base value for exponential backoff with ±20 % jitter. |
+| `SLSKD_RETRY_BACKOFF_BASE_MS` | `250` | Base value for exponential backoff (capped at 2 000 ms). |
+| `SLSKD_JITTER_PCT` | `20` | Percentage of symmetric jitter applied to the computed backoff. |
 | `SLSKD_PREFERRED_FORMATS` | `FLAC,ALAC,APE,MP3` | Format preference order used to rank candidates. |
 | `SLSKD_MAX_RESULTS` | `50` | Maximum number of candidates returned per request. |
 
@@ -61,6 +62,7 @@ sorted by the configured format preferences and seeder count.
 | --- | --- | --- |
 | `429 Too Many Requests` | `SlskdAdapterRateLimitedError` | `RATE_LIMITED` with `meta.retry_after_ms` and the original `Retry-After` header when present. |
 | `5xx`, network failures, timeouts | `SlskdAdapterDependencyError` | `DEPENDENCY_ERROR` with optional `meta.provider_status`. |
+| `404 Not Found` | `SlskdAdapterNotFoundError` | `NOT_FOUND`. |
 | Invalid/garbled JSON | `SlskdAdapterInternalError` | `INTERNAL_ERROR`. |
 | Upstream 4xx validation errors | `SlskdAdapterValidationError` | `VALIDATION_ERROR` with `meta.provider_status`. |
 | Local validation (empty query, limit ≤ 0) | – | `VALIDATION_ERROR`. |
@@ -70,9 +72,12 @@ backoff interval before surfacing the rate limit error.
 
 ## Logging
 
-Every slskd lookup emits a structured log with `event="slskd.search"`, including status,
-`duration_ms`, `limit`, `results_count` and the upstream status code. Failures log at `WARNING`
-level for dependency issues and `ERROR` for malformed payloads.
+Each attempt emits `event="slskd.request"` with `provider="slskd"`, HTTP method/path,
+`status`/`status_code`, `attempt`, `max_attempts`, `duration_ms` and a hashed query identifier.
+Completion is logged separately via `event="slskd.complete"` including `status="ok|error"`,
+`retries_used`, `duration_ms`, `results_count` (when successful) and optional `error`/`upstream_status`
+fields. Dependency failures log at `WARNING` level; payload issues log at `WARNING` with
+`error="normalisation-failed"`.
 
 ## Example Response
 


### PR DESCRIPTION
## Summary
- add strict configuration validation, base URL normalisation, jittered retries and structured logging for the slskd adapter
- extend integration service and registry wiring to surface NOT_FOUND and jitter configuration while documenting the contract
- update docs/README/CHANGELOG and add comprehensive adapter contract and retry coverage tests

## Testing
- `ruff check .`
- `black --check .`
- `mypy app`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68daad9981888321b8bd43f39fab54e6