### PR TITLE
feat: unify logging helper and request id middleware [CODX-P0-LOG-101]

### DIFF
--- a/app/logging_events.py
+++ b/app/logging_events.py
@@ -1,0 +1,65 @@
+"""Structured logging helpers for Harmony services."""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Mapping
+from typing import Any
+
+_JSON_PRIMITIVES = (str, int, float, bool, type(None))
+
+
+def _validate_flat_value(name: str, value: Any) -> None:
+    if isinstance(value, _JSON_PRIMITIVES):
+        return
+    raise TypeError(f"Field '{name}' must be a flat JSON-compatible value")
+
+
+def _ensure_meta(meta: Mapping[str, Any] | None) -> Mapping[str, Any] | None:
+    if meta is None:
+        return None
+    if not isinstance(meta, Mapping):
+        raise TypeError("meta must be a mapping if provided")
+    meta_dict = dict(meta)
+    _validate_json_payload(meta_dict, path="meta")
+    return meta_dict
+
+
+def _validate_json_payload(value: Any, *, path: str) -> None:
+    if isinstance(value, _JSON_PRIMITIVES):
+        return
+    if isinstance(value, Mapping):
+        for key, nested in value.items():
+            if not isinstance(key, str):
+                raise TypeError(f"Keys in '{path}' must be strings")
+            _validate_json_payload(nested, path=f"{path}.{key}")
+        return
+    if isinstance(value, (list, tuple)):
+        for index, nested in enumerate(value):
+            _validate_json_payload(nested, path=f"{path}[{index}]")
+        return
+    raise TypeError(f"Unsupported value in '{path}': {type(value).__name__}")
+
+
+def log_event(logger: Any, event: str, /, **fields: Any) -> None:
+    """Emit a structured log event with a canonical payload."""
+
+    if not isinstance(event, str) or not event.strip():
+        raise ValueError("event must be a non-empty string")
+
+    meta = _ensure_meta(fields.pop("meta", None))
+
+    extra: dict[str, Any] = {"event": event}
+    for name, value in fields.items():
+        _validate_flat_value(name, value)
+        extra[name] = value
+    if meta is not None:
+        extra["meta"] = meta
+
+    logger.info(event, extra=extra)
+
+
+def now_ms() -> int:
+    """Return the current UNIX timestamp in milliseconds."""
+
+    return int(time.time() * 1000)

--- a/app/main.py
+++ b/app/main.py
@@ -66,6 +66,7 @@ from app.services.backfill_service import BackfillService
 from app.services.health import HealthService
 from app.services.secret_validation import SecretValidationService
 from app.middleware.cache_conditional import CachePolicy, ConditionalCacheMiddleware
+from app.middleware.request_id import RequestIDMiddleware
 from app.services.cache import ResponseCache
 from app.utils.activity import activity_manager
 from app.utils.settings_store import ensure_default_settings
@@ -457,6 +458,8 @@ app.state.health_service = HealthService(
 app.state.secret_validation_service = SecretValidationService()
 
 _initial_security = _config_snapshot.security
+
+app.add_middleware(RequestIDMiddleware)
 
 app.add_middleware(
     CORSMiddleware,

--- a/app/middleware/request_id.py
+++ b/app/middleware/request_id.py
@@ -1,0 +1,34 @@
+"""Middleware that ensures every request has a request id."""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+from fastapi import Request
+from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
+from starlette.responses import Response
+from starlette.types import ASGIApp
+
+
+class RequestIDMiddleware(BaseHTTPMiddleware):
+    """Populate ``request.state.request_id`` for downstream handlers."""
+
+    header_name = "X-Request-ID"
+
+    def __init__(self, app: ASGIApp) -> None:
+        super().__init__(app)
+
+    async def dispatch(
+        self, request: Request, call_next: RequestResponseEndpoint
+    ) -> Response:  # type: ignore[override]
+        incoming = request.headers.get(self.header_name, "").strip()
+        request_id = incoming or str(uuid4())
+        request.state.request_id = request_id
+
+        response = await call_next(request)
+        if self.header_name not in response.headers:
+            response.headers[self.header_name] = request_id
+        return response
+
+
+__all__ = ["RequestIDMiddleware"]

--- a/tests/logging/test_log_event.py
+++ b/tests/logging/test_log_event.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from unittest.mock import Mock
+
+import pytest
+
+from app.logging_events import log_event, now_ms
+
+
+def test_log_event_emits_expected_extra_fields() -> None:
+    logger = Mock()
+
+    log_event(
+        logger,
+        "cache.hit",
+        component="cache",
+        status="ok",
+        entity_id="key-1",
+        meta={"nested": {"value": 1}},
+    )
+
+    logger.info.assert_called_once()
+    args, kwargs = logger.info.call_args
+    assert args == ("cache.hit",)
+    assert kwargs["extra"] == {
+        "event": "cache.hit",
+        "component": "cache",
+        "status": "ok",
+        "entity_id": "key-1",
+        "meta": {"nested": {"value": 1}},
+    }
+
+
+def test_log_event_rejects_empty_event() -> None:
+    logger = Mock()
+
+    with pytest.raises(ValueError):
+        log_event(logger, "")
+
+
+def test_log_event_rejects_invalid_meta_type() -> None:
+    logger = Mock()
+
+    with pytest.raises(TypeError):
+        log_event(logger, "sample", component="x", status="ok", meta="oops")
+
+
+def test_now_ms_returns_positive_integer() -> None:
+    value = now_ms()
+    assert isinstance(value, int)
+    assert value > 0

--- a/tests/middleware/test_request_id.py
+++ b/tests/middleware/test_request_id.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import uuid
+
+from fastapi import FastAPI, Request
+from fastapi.testclient import TestClient
+
+from app.middleware.request_id import RequestIDMiddleware
+
+
+def create_app() -> TestClient:
+    app = FastAPI()
+    app.add_middleware(RequestIDMiddleware)
+
+    @app.get("/state")
+    async def read_state(request: Request) -> dict[str, str]:
+        return {"request_id": request.state.request_id}
+
+    return TestClient(app)
+
+
+def test_request_id_header_passthrough_and_generation() -> None:
+    client = create_app()
+
+    custom_id = "abc-123"
+    response = client.get("/state", headers={"X-Request-ID": custom_id})
+    assert response.status_code == 200
+    assert response.json()["request_id"] == custom_id
+    assert response.headers["X-Request-ID"] == custom_id
+
+    generated_response = client.get("/state")
+    assert generated_response.status_code == 200
+    generated_id = generated_response.json()["request_id"]
+    assert generated_id
+    uuid.UUID(generated_id)
+    assert generated_response.headers["X-Request-ID"] == generated_id

--- a/tests/routers/test_search_logging.py
+++ b/tests/routers/test_search_logging.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from typing import Any
+
+import importlib
+
+search_module = importlib.import_module("app.routers.search_router")
+
+
+def test_search_router_emits_api_request_event(monkeypatch, client) -> None:
+    captured: list[dict[str, Any]] = []
+
+    def _capture(logger, event: str, /, **fields: Any) -> None:
+        payload = {"event": event, **fields}
+        captured.append(payload)
+
+    monkeypatch.setattr(search_module, "log_event", _capture)
+
+    payload = {
+        "query": "Track",
+        "type": "track",
+        "sources": ["soulseek"],
+        "limit": 5,
+        "offset": 0,
+    }
+
+    headers = {"X-Request-ID": "req-test-1"}
+    response = client.post("/search", json=payload, headers=headers)
+
+    assert response.status_code == 200
+
+    api_events = [entry for entry in captured if entry["event"] == "api.request"]
+    assert api_events, "Expected api.request event"
+    event_payload = api_events[-1]
+    assert event_payload["component"] == "router.search"
+    assert event_payload["status"] in {"ok", "partial"}
+    assert event_payload["entity_id"] == "req-test-1"
+    assert event_payload["duration_ms"] > 0
+    assert event_payload["path"].endswith("/search")
+    assert event_payload["method"] == "POST"


### PR DESCRIPTION
## Summary
- add a reusable `log_event` helper and lightweight request id middleware to standardise structured logging
- migrate cache, search router, and watchlist worker hotspots to emit canonical events via the helper
- add focused tests to cover the helper, middleware, and API logging behaviour

## Testing
- pytest -q
- mypy app
- ruff check .
- black --check .

## File Changes
### New
- app/logging_events.py
- app/middleware/request_id.py
- tests/logging/test_log_event.py
- tests/middleware/test_request_id.py
- tests/routers/test_search_logging.py

### Updated
- app/main.py
- app/services/cache.py
- app/routers/search_router.py
- app/workers/watchlist_worker.py

## Notes
- Changes follow the repository AGENTS.md guidelines and scope.


------
https://chatgpt.com/codex/tasks/task_e_68dbe232b938832198c79996a398ef54