### PR TITLE
CODX-P0-WORKERS-103: document worker defaults and log startup config

### DIFF
--- a/README.md
+++ b/README.md
@@ -499,6 +499,10 @@ try-Zugriffs im CI bewusst ausgelassen.
 
 > **Hinweis:** Spotify- und slskd-Zugangsdaten können über `/settings` in der Datenbank persistiert werden. Beim Laden der Anwendung haben Datenbankwerte Vorrang vor Umgebungsvariablen; ENV-Variablen dienen als Fallback und Basis für neue Deployments. Eine ausführliche Laufzeitreferenz inkl. Überschneidungen mit Datenbank-Settings befindet sich in [`docs/ops/runtime-config.md`](docs/ops/runtime-config.md).
 
+### Background Workers
+
+Eine kuratierte Übersicht der Worker-Defaults, Environment-Variablen und Beispiel-Profile findet sich in [`docs/workers.md`](docs/workers.md). Beim Applikationsstart wird zusätzlich ein strukturiertes Log-Event `worker.config` geschrieben (`component="bootstrap"`), das die aktiven Parameter ohne Secrets ausgibt.
+
 ### Frontend-Umgebungsvariablen (Vite)
 
 | Variable | Typ | Default | Beschreibung | Sicherheit |

--- a/docs/workers.md
+++ b/docs/workers.md
@@ -1,33 +1,122 @@
-# Hintergrund-Worker (MVP-Slim)
+# Background Workers – Defaults & Konfiguration
 
-Harmony startet mehrere asynchrone Worker, sobald die Anwendung initialisiert ist (`app/main.py`). Plex- und Beets-Worker sind archiviert und werden nicht geladen. Dieses Dokument fasst die aktiven Komponenten zusammen.
+Harmony betreibt mehrere asynchrone Worker, die beim Lifespan-Start der FastAPI-Anwendung initialisiert werden. Dieses Dokument liefert einen konsolidierten Überblick über Aufgaben, Standardwerte, relevante Umgebungsvariablen sowie praktische Beispielprofile.
 
-## Übersicht
+## Überblick
 
-| Worker | Datei | Aufgabe |
-| ------ | ----- | ------- |
-| SyncWorker | `app/workers/sync_worker.py` | Verarbeitet Soulseek-Downloads, führt Datei-Organisation aus und aktualisiert Retry-Informationen. |
-| MatchingWorker | `app/workers/matching_worker.py` | Persistiert Matching-Jobs aus der Queue (`WorkerJob`). |
-| PlaylistSyncWorker | `app/workers/playlist_sync_worker.py` | Synchronisiert Spotify-Playlists mit der Datenbank. |
-| ArtworkWorker | `app/workers/artwork_worker.py` | Lädt Cover in höchster Auflösung, cached Dateien und bettet sie in Downloads ein. |
-| LyricsWorker | `app/workers/lyrics_worker.py` | Erstellt `.lrc`-Dateien aus Spotify-Lyrics oder externen Quellen. |
-| MetadataWorker | `app/workers/metadata_worker.py` | Ergänzt Metadaten (Genre, Komponist, Produzent, ISRC, Copyright). |
-| BackfillWorker | `app/workers/backfill_worker.py` | Reichert FREE-Ingest-Daten mit Spotify-Informationen an. |
-| WatchlistWorker | `app/workers/watchlist_worker.py` | Überwacht gespeicherte Artists auf neue Releases und stößt Downloads an. |
-| RetryScheduler | `app/workers/retry_scheduler.py` | Plant fehlgeschlagene Downloads mit Backoff neu ein. |
+| Worker | Modul | Aufgabe |
+| --- | --- | --- |
+| `SyncWorker` | `app/workers/sync_worker.py` | Lädt Dateien über Soulseek herunter, führt Nachbearbeitung durch und aktualisiert Retry-Informationen. |
+| `MatchingWorker` | `app/workers/matching_worker.py` | Persistiert neue Match-Ergebnisse und verarbeitet die `WorkerJob`-Queue. |
+| `PlaylistSyncWorker` | `app/workers/playlist_sync_worker.py` | Synchronisiert gespeicherte Spotify-Playlists mit der Datenbank. |
+| `ArtworkWorker` | `app/workers/artwork_worker.py` | Lädt Cover in hoher Auflösung, cached Dateien und bettet sie in Downloads ein. |
+| `LyricsWorker` | `app/workers/lyrics_worker.py` | Erstellt `.lrc`-Dateien aus Spotify-Lyrics bzw. externen Quellen. |
+| `MetadataWorker` | `app/workers/metadata_worker.py` | Ergänzt Metadaten wie Genres, Komponist:innen oder ISRC-Codes. |
+| `BackfillWorker` | `app/workers/backfill_worker.py` | Reichert FREE-Ingest-Daten mit Spotify-Informationen an. |
+| `WatchlistWorker` | `app/workers/watchlist_worker.py` | Überwacht Artists auf neue Releases und stößt automatische Downloads an. |
+| `RetryScheduler` | `app/workers/retry_scheduler.py` | Plant fehlgeschlagene Downloads mit Backoff neu ein. |
 
-## Lebenszyklus
+## Lebenszyklus & Steuerung
 
-- `HARMONY_DISABLE_WORKERS=1` deaktiviert alle Worker (nützlich für Tests oder read-only-Demos).
-- Einzelne Feature-Flags: `ENABLE_ARTWORK` und `ENABLE_LYRICS` aktivieren Artwork-/Lyrics-Worker und zugehörige Endpunkte (Default: `false`).
-- Beim Shutdown ruft Harmony `stop()` auf allen Worker-Instanzen auf (`app/main.py::_stop_background_workers`).
+- Die Worker werden beim Aufruf von `app.router.lifespan_context(app)` gestartet und beim Shutdown kontrolliert gestoppt.
+- `HARMONY_DISABLE_WORKERS=1` deaktiviert sämtliche Hintergrund-Worker – praktisch für Read-only-Demos oder Tests.
+- Einzelne Worker können über Feature-Flags deaktiviert werden (`ENABLE_ARTWORK`, `ENABLE_LYRICS`).
+- Beim Start emittiert die Anwendung ein strukturiertes Log-Event `worker.config` mit den wichtigsten Parametern (`component="bootstrap"`, `status="ok"`). Das Event enthält ausschließlich nicht-sensible Metadaten und erleichtert das Monitoring der aktiven Defaults.
 
-## Systemstatus & Observability
+## ENV-Variablen & Defaults
 
-- `GET /status` zeigt Worker-Zustände (`running`, `stale`, `unavailable`) inklusive Queue-Größe für Matching und Sync.
-- Der `wiring_summary`-Logeintrag beim Start listet aktive Worker auf.
-- Activity-Events (`record_activity`) spiegeln wichtige Phasen wider (`sync_started`, `sync_completed`, `soulseek_no_results`, `artwork_embedded`, `lyrics_generated`).
+### Watchlist & Scheduling
 
-## Archiv
+| Variable | Default | Wirkung | Hinweise |
+| --- | ---: | --- | --- |
+| `WATCHLIST_INTERVAL` | `86400` | Wartezeit in Sekunden zwischen zwei vollständigen Watchlist-Runs. | Für lokale Tests auf `300–900` reduzieren. |
+| `WATCHLIST_MAX_CONCURRENCY`<br>`WATCHLIST_CONCURRENCY` | `3` | Parallele Artists pro Tick. | Alias `WATCHLIST_CONCURRENCY` wird weiterhin akzeptiert. |
+| `WATCHLIST_MAX_PER_TICK` | `20` | Anzahl der Artists pro Tick. | Höhere Werte erhöhen API-Last. |
+| `WATCHLIST_BACKOFF_BASE_MS` | `250` | Basiswert für exponentielles Retry-Backoff. | Kombiniert mit `WATCHLIST_JITTER_PCT`. |
+| `WATCHLIST_JITTER_PCT` | `0.2` | Zufälliger Jitter (±20 %) für Backoff-Verzögerungen. | Werte >1.0 werden auf Prozentbasis interpretiert. |
+| `WATCHLIST_RETRY_BUDGET_PER_ARTIST` | `6` | Maximale Retries pro Artist bevor ein Cooldown greift. | Cooldown-Minuten über `WATCHLIST_COOLDOWN_MINUTES`. |
+| `WATCHLIST_RETRY_MAX` | `3` | Retries pro Tick bevor Jobs in die DLQ verschoben werden. | | 
 
-Frühere Worker (`ScanWorker`, `AutoSyncWorker`, `DiscographyWorker`, Beets-Poststeps) liegen unter [`archive/integrations/plex_beets/`](../archive/integrations/plex_beets/). Die neue Wiring-Audit (`scripts/audit_wiring.py`) stellt sicher, dass sie nicht versehentlich erneut importiert werden.
+### Queue, Retry & DLQ
+
+| Variable | Default | Wirkung | Hinweise |
+| --- | ---: | --- | --- |
+| `WORKER_VISIBILITY_TIMEOUT_S` | `60` | Lease-Dauer für persistente Worker-Jobs. | Minimum sind 5 s; längere Jobs entsprechend erhöhen. |
+| `RETRY_MAX_ATTEMPTS` | `10` | Automatische Neuversuche pro Download. | Gilt für Sync/RetryScheduler. |
+| `RETRY_BASE_SECONDS` | `60` | Basiswartezeit zwischen Retries. | Wird exponentiell mit `RETRY_JITTER_PCT` kombiniert. |
+| `RETRY_JITTER_PCT` | `0.2` | Zufallsanteil (±20 %) für Retry-Verzögerungen. | |
+| `DLQ_PAGE_SIZE_DEFAULT` | `25` | Standardpaginierung für DLQ-Listen. | Anpassbar bis `DLQ_PAGE_SIZE_MAX`. |
+| `DLQ_REQUEUE_LIMIT` | `500` | Obergrenze für Bulk-Requeue. | |
+| `DLQ_PURGE_LIMIT` | `1000` | Obergrenze für Bulk-Purge. | |
+
+### Provider & Externe Abhängigkeiten
+
+| Variable | Default | Wirkung | Hinweise |
+| --- | ---: | --- | --- |
+| `PROVIDER_MAX_CONCURRENCY` | `4` | Maximale Parallelität für Integrationen. | Sollte zu Provider-Limits passen. |
+| `SLSKD_TIMEOUT_MS` | `8000` | Timeout (ms) für Soulseek-Requests. | Bei instabilen Netzen erhöhen. |
+| `SLSKD_RETRY_MAX` | `3` | Retries für Soulseek-Anfragen. | | 
+| `SLSKD_RETRY_BACKOFF_BASE_MS` | `250` | Basis-Delay für Soulseek-Retries. | |
+| `SLSKD_JITTER_PCT` | `20.0` | Zufallsjitter (±20 %) für Soulseek-Retries. | |
+
+### Feature-Flags & globale Schalter
+
+| Variable | Default | Wirkung | Hinweise |
+| --- | ---: | --- | --- |
+| `HARMONY_DISABLE_WORKERS` | `0` | Globaler Kill-Switch für alle Worker. | `1` deaktiviert sämtliche Hintergrundprozesse. |
+| `ENABLE_ARTWORK` | `0` | Aktiviert Artwork-Worker und API-Endpunkte. | | 
+| `ENABLE_LYRICS` | `0` | Aktiviert Lyrics-Worker und API-Endpunkte. | |
+| `FEATURE_REQUIRE_AUTH` | `0` | Erzwingt API-Key-Authentifizierung. | Hat Einfluss auf Worker, die externe APIs ansteuern. |
+| `FEATURE_RATE_LIMITING` | `0` | Aktiviert requestbasierte Rate-Limits. | Relevant für Worker-APIs, die über das Gateway laufen. |
+
+## Beispiel-Profile
+
+### Development (`.env`)
+
+```bash
+HARMONY_DISABLE_WORKERS=0
+WATCHLIST_INTERVAL=600
+WATCHLIST_MAX_CONCURRENCY=2
+WATCHLIST_BACKOFF_BASE_MS=250
+WATCHLIST_JITTER_PCT=0.2
+WORKER_VISIBILITY_TIMEOUT_S=45
+PROVIDER_MAX_CONCURRENCY=3
+SLSKD_TIMEOUT_MS=10000
+SLSKD_RETRY_MAX=2
+SLSKD_RETRY_BACKOFF_BASE_MS=250
+SLSKD_JITTER_PCT=15.0
+FEATURE_REQUIRE_AUTH=false
+FEATURE_RATE_LIMITING=false
+```
+
+### Production (`.env`)
+
+```bash
+HARMONY_DISABLE_WORKERS=0
+WATCHLIST_INTERVAL=86400
+WATCHLIST_MAX_CONCURRENCY=3
+WATCHLIST_BACKOFF_BASE_MS=250
+WATCHLIST_JITTER_PCT=0.2
+WORKER_VISIBILITY_TIMEOUT_S=60
+PROVIDER_MAX_CONCURRENCY=4
+SLSKD_TIMEOUT_MS=8000
+SLSKD_RETRY_MAX=3
+SLSKD_RETRY_BACKOFF_BASE_MS=250
+SLSKD_JITTER_PCT=20.0
+FEATURE_REQUIRE_AUTH=true
+FEATURE_RATE_LIMITING=true
+```
+
+## Troubleshooting
+
+- **Worker starten nicht:** Prüfen, ob `HARMONY_DISABLE_WORKERS=1` gesetzt ist oder Feature-Flags einzelne Worker blockieren.
+- **Watchlist-Läufe dauern zu lange:** `WATCHLIST_INTERVAL`, `WATCHLIST_MAX_CONCURRENCY` und `WATCHLIST_MAX_PER_TICK` an API-Limits und Datenvolumen anpassen.
+- **Jobs bleiben in der Queue hängen:** `WORKER_VISIBILITY_TIMEOUT_S` für langlaufende Aufgaben erhöhen und DLQ via `/dlq`-Endpoints prüfen.
+- **Soulseek-Timeouts:** `SLSKD_TIMEOUT_MS` und `SLSKD_RETRY_MAX` schrittweise erhöhen; Backoff-Werte zur Schonung des Providers nutzen.
+- **Rate-Limit-Fehler über Gateway:** `FEATURE_RATE_LIMITING` deaktivieren oder Limits in der Gateway-Konfiguration anpassen.
+
+## Weiterführende Ressourcen
+
+- [`README.md`](../README.md) – vollständige ENV-Referenz inklusive Frontend-Variablen.
+- [`docs/ops/runtime-config.md`](ops/runtime-config.md) – Laufzeitkonfiguration & Prioritätenmatrix.
+- [`reports/analysis/config_matrix.md`](../reports/analysis/config_matrix.md) – Detailanalyse der Konfigurationsquellen.

--- a/tests/docs/test_workers_doc_exists.py
+++ b/tests/docs/test_workers_doc_exists.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def test_workers_doc_exists() -> None:
+    doc_path = Path("docs/workers.md")
+    contents = doc_path.read_text(encoding="utf-8")
+
+    assert contents.startswith("# Background Workers")
+    for section in (
+        "## Überblick",
+        "## Lebenszyklus & Steuerung",
+        "## ENV-Variablen & Defaults",
+        "## Beispiel-Profile",
+        "## Troubleshooting",
+    ):
+        assert section in contents

--- a/tests/workers/test_worker_config_logging.py
+++ b/tests/workers/test_worker_config_logging.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from typing import Any, Iterator
+
+import pytest
+
+from app import dependencies as deps
+from app.main import app
+
+
+def _reset_config_cache() -> None:
+    deps.get_app_config.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def _clear_config_cache() -> Iterator[None]:
+    _reset_config_cache()
+    try:
+        yield
+    finally:
+        _reset_config_cache()
+
+
+@pytest.fixture
+def worker_config_events(monkeypatch: pytest.MonkeyPatch) -> list[dict[str, Any]]:
+    captured: list[dict[str, Any]] = []
+
+    def fake_log_event(logger: Any, event: str, /, **fields: Any) -> None:
+        captured.append({"logger": logger, "event": event, **fields})
+
+    monkeypatch.setattr("app.main.log_event", fake_log_event)
+    return captured
+
+
+@pytest.mark.asyncio
+async def test_config_event_emitted_on_startup(
+    monkeypatch: pytest.MonkeyPatch, worker_config_events: list[dict[str, Any]]
+) -> None:
+    monkeypatch.setenv("HARMONY_DISABLE_WORKERS", "1")
+
+    async with app.router.lifespan_context(app):
+        pass
+
+    assert len(worker_config_events) == 1
+
+    event = worker_config_events[0]
+    assert event["event"] == "worker.config"
+    assert event["component"] == "bootstrap"
+    assert event["status"] == "ok"
+    assert isinstance(event["meta"], dict)
+
+
+@pytest.mark.asyncio
+async def test_config_event_contains_expected_keys(
+    monkeypatch: pytest.MonkeyPatch, worker_config_events: list[dict[str, Any]]
+) -> None:
+    monkeypatch.setenv("HARMONY_DISABLE_WORKERS", "1")
+    monkeypatch.setenv("WATCHLIST_INTERVAL", "123.5")
+    monkeypatch.setenv("WATCHLIST_MAX_CONCURRENCY", "7")
+    monkeypatch.setenv("WATCHLIST_RETRY_BUDGET_PER_ARTIST", "9")
+    monkeypatch.setenv("WATCHLIST_BACKOFF_BASE_MS", "500")
+    monkeypatch.setenv("WATCHLIST_JITTER_PCT", "0.35")
+    monkeypatch.setenv("WORKER_VISIBILITY_TIMEOUT_S", "45")
+    monkeypatch.setenv("PROVIDER_MAX_CONCURRENCY", "6")
+    monkeypatch.setenv("SLSKD_TIMEOUT_MS", "15000")
+    monkeypatch.setenv("SLSKD_RETRY_MAX", "5")
+    monkeypatch.setenv("SLSKD_RETRY_BACKOFF_BASE_MS", "400")
+    monkeypatch.setenv("SLSKD_JITTER_PCT", "18.5")
+    monkeypatch.setenv("FEATURE_REQUIRE_AUTH", "1")
+    monkeypatch.setenv("FEATURE_RATE_LIMITING", "1")
+
+    async with app.router.lifespan_context(app):
+        pass
+
+    assert len(worker_config_events) == 1
+    meta = worker_config_events[0]["meta"]
+
+    watchlist = meta["watchlist"]
+    assert watchlist["interval_s"] == pytest.approx(123.5)
+    assert watchlist["concurrency"] == 7
+    assert watchlist["retry_budget_per_artist"] == 9
+    assert watchlist["backoff_base_ms"] == 500
+    assert watchlist["jitter_pct"] == pytest.approx(0.35)
+
+    queue = meta["queue"]
+    assert queue["visibility_timeout_s"] == 45
+
+    providers = meta["providers"]
+    assert providers["max_concurrency"] == 6
+
+    slskd = providers["slskd"]
+    assert slskd["timeout_ms"] == 15000
+    assert slskd["retry_max"] == 5
+    assert slskd["retry_backoff_base_ms"] == 400
+    assert slskd["jitter_pct"] == pytest.approx(18.5)
+
+    features = meta["features"]
+    assert features["require_auth"] is True
+    assert features["rate_limiting"] is True
+    assert features["workers_disabled"] is True


### PR DESCRIPTION
## Summary
- log the `worker.config` bootstrap event with normalized watchlist, queue, provider and feature values
- document worker defaults, env switches and troubleshooting guidance in `docs/workers.md` and reference it from the README
- cover the new behaviour with startup logging tests and a doc smoke test

## Testing
- ruff check .
- black --check .
- mypy app
- pytest -q


------
https://chatgpt.com/codex/tasks/task_e_68dbf2b937c483218c7b137cfbb58f54