### PR TITLE
feat(search): route through provider gateway

### DIFF
--- a/app/dependencies.py
+++ b/app/dependencies.py
@@ -16,6 +16,7 @@ from app.core.soulseek_client import SoulseekClient
 from app.core.spotify_client import SpotifyClient
 from app.core.transfers_api import TransfersApi
 from app.db import get_session
+from app.integrations.provider_gateway import ProviderGateway
 from app.integrations.registry import ProviderRegistry
 from app.errors import AppError, ErrorCode
 from app.logging import get_logger
@@ -47,6 +48,15 @@ def get_transfers_api() -> TransfersApi:
 @lru_cache()
 def get_provider_registry() -> ProviderRegistry:
     return ProviderRegistry(config=get_app_config())
+
+
+@lru_cache()
+def get_provider_gateway() -> ProviderGateway:
+    registry = get_provider_registry()
+    registry.initialise()
+    providers = registry.track_providers()
+    config = registry.gateway_config
+    return ProviderGateway(providers=providers, config=config)
 
 
 @lru_cache()

--- a/app/integrations/slskd_adapter.py
+++ b/app/integrations/slskd_adapter.py
@@ -280,12 +280,42 @@ def _extract_metadata(entry: Mapping[str, Any]) -> Mapping[str, Any]:
     filename = _coerce_str(entry.get("filename"))
     if filename:
         metadata["filename"] = filename
+    identifier = entry.get("id") or entry.get("track_id")
+    if identifier:
+        metadata["id"] = identifier
     score = _coerce_float(entry.get("score"))
     if score is not None:
         metadata["score"] = score
     bitrate_mode = _coerce_str(entry.get("bitrate_mode") or entry.get("encoding"))
     if bitrate_mode:
         metadata["bitrate_mode"] = bitrate_mode
+    year = _coerce_int(entry.get("year"))
+    if year is not None:
+        metadata["year"] = year
+    genres_field = entry.get("genres")
+    if isinstance(genres_field, (list, tuple)):
+        metadata["genres"] = [str(item) for item in genres_field if item]
+    genre = _coerce_str(entry.get("genre"))
+    if genre:
+        metadata["genre"] = genre
+    album = _coerce_str(entry.get("album"))
+    if album:
+        metadata["album"] = album
+    artists = entry.get("artists")
+    if isinstance(artists, list):
+        names: list[str] = []
+        for item in artists:
+            if isinstance(item, Mapping):
+                name = _coerce_str(item.get("name"))
+            else:
+                name = _coerce_str(item)
+            if name:
+                names.append(name)
+        if names:
+            metadata["artists"] = names
+    artist = _coerce_str(entry.get("artist"))
+    if artist:
+        metadata.setdefault("artists", []).append(artist)
     if not metadata:
         return _EMPTY_METADATA
     return MappingProxyType(metadata)


### PR DESCRIPTION
## Summary
- integrate the ProviderGateway multi-provider search pipeline into the smart search router and adapt scoring to the normalised DTOs
- extend the integration registry/adapters with Spotify track support and richer Soulseek metadata so gateway responses carry required context
- add gateway stubs plus router tests covering invocation, dependency logging, and dependency failure mapping

## Testing
- pytest tests/test_search.py -q

------
https://chatgpt.com/codex/tasks/task_e_68dc15e228c883218b8030e536b3aca1