### PR TITLE
feat: consolidate spotify domain routing

### DIFF
--- a/app/api/router_registry.py
+++ b/app/api/router_registry.py
@@ -8,10 +8,8 @@ from fastapi import APIRouter
 
 from app.routers import (
     activity_router,
-    backfill_router,
     download_router,
     dlq_router,
-    free_ingest_router,
     health_router,
     imports_router,
     integrations_router,
@@ -20,8 +18,7 @@ from app.routers import (
     search_router,
     settings_router,
     soulseek_router,
-    spotify_free_router,
-    spotify_router,
+    spotify_domain_router,
     sync_router,
     system_router,
     watchlist_router,
@@ -53,10 +50,7 @@ def compose_prefix(base: str, *parts: str) -> str:
 
 
 def _build_entries() -> Iterable[RouterEntry]:
-    yield "/spotify", spotify_router, ["Spotify"]
-    yield "/spotify/backfill", backfill_router, ["Spotify Backfill"]
-    yield "", spotify_free_router, []
-    yield "", free_ingest_router, []
+    yield "", spotify_domain_router, []
     yield "", imports_router, []
     yield "/soulseek", soulseek_router, ["Soulseek"]
     yield "/matching", matching_router, ["Matching"]

--- a/app/main.py
+++ b/app/main.py
@@ -433,9 +433,6 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
 
     router_status = {
         "spotify": True,
-        "spotify_backfill": True,
-        "spotify_free": True,
-        "free_ingest": True,
         "imports": True,
         "soulseek": True,
         "matching": True,

--- a/app/routers/__init__.py
+++ b/app/routers/__init__.py
@@ -1,8 +1,6 @@
 from .activity_router import router as activity_router
-from .backfill_router import router as backfill_router
 from .download_router import router as download_router
 from .dlq_router import router as dlq_router
-from .free_ingest_router import router as free_ingest_router
 from .health_router import router as health_router
 from .imports_router import router as imports_router
 from .integrations import router as integrations_router
@@ -11,18 +9,16 @@ from .metadata_router import router as metadata_router
 from .search_router import router as search_router
 from .settings_router import router as settings_router
 from .soulseek_router import router as soulseek_router
-from .spotify_router import router as spotify_router
-from .spotify_free_router import router as spotify_free_router
+from .spotify import legacy_router as spotify_legacy_router
+from .spotify import router as spotify_domain_router
 from .sync_router import router as sync_router
 from .watchlist_router import router as watchlist_router
 from .system_router import router as system_router
 
 __all__ = [
     "activity_router",
-    "backfill_router",
     "download_router",
     "dlq_router",
-    "free_ingest_router",
     "health_router",
     "imports_router",
     "integrations_router",
@@ -31,8 +27,8 @@ __all__ = [
     "search_router",
     "settings_router",
     "soulseek_router",
-    "spotify_router",
-    "spotify_free_router",
+    "spotify_domain_router",
+    "spotify_legacy_router",
     "sync_router",
     "system_router",
     "watchlist_router",

--- a/app/routers/spotify.py
+++ b/app/routers/spotify.py
@@ -1,0 +1,34 @@
+"""Aggregate Spotify related routers under a single module."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter
+
+from app.config import load_config
+from app.routers.backfill_router import router as backfill_router
+from app.routers.free_ingest_router import router as free_ingest_router
+from app.routers.spotify_free_router import router as spotify_free_router
+from app.routers.spotify_router import router as core_router
+
+router = APIRouter()
+router.include_router(core_router, prefix="/spotify", tags=["Spotify"])
+router.include_router(backfill_router, prefix="/spotify/backfill", tags=["Spotify Backfill"])
+router.include_router(spotify_free_router)
+router.include_router(free_ingest_router)
+
+_config = load_config()
+_legacy_router: APIRouter | None = None
+if _config.features.enable_legacy_routes:
+    alias = APIRouter()
+    alias.include_router(core_router, prefix="/spotify", tags=["Spotify"])
+    alias.include_router(backfill_router, prefix="/spotify/backfill", tags=["Spotify Backfill"])
+    alias.include_router(spotify_free_router)
+    alias.include_router(free_ingest_router)
+    _legacy_router = alias
+
+legacy_router = _legacy_router
+
+__all__ = [
+    "router",
+    "legacy_router",
+]

--- a/app/routers/spotify_router.py
+++ b/app/routers/spotify_router.py
@@ -1,21 +1,25 @@
-"""Spotify API endpoints."""
+"""Core Spotify router delegating to :mod:`SpotifyDomainService`."""
 
 from __future__ import annotations
 
-from typing import List, Optional, Literal
+from typing import List, Literal, Optional
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
-from app.config import load_config
+from app.core.soulseek_client import SoulseekClient
 from app.core.spotify_client import SpotifyClient
-from app.dependencies import get_app_config, get_db, get_spotify_client
-from app.models import Playlist
+from app.dependencies import (
+    get_app_config,
+    get_db,
+    get_soulseek_client,
+    get_spotify_client,
+)
 from app.schemas import (
     ArtistReleasesResponse,
-    DiscographyResponse,
     AudioFeaturesResponse,
+    DiscographyResponse,
     FollowedArtistsResponse,
     PlaylistItemsResponse,
     PlaylistResponse,
@@ -26,7 +30,7 @@ from app.schemas import (
     TrackDetailResponse,
     UserProfileResponse,
 )
-from app.utils.settings_store import write_setting
+from app.services.spotify_domain_service import PlaylistItemsResult, SpotifyDomainService
 
 router = APIRouter()
 
@@ -52,148 +56,100 @@ class SpotifyModePayload(BaseModel):
     mode: Literal["FREE", "PRO"]
 
 
+def _get_spotify_service(
+    request: Request,
+    config=Depends(get_app_config),
+    spotify_client: SpotifyClient = Depends(get_spotify_client),
+    soulseek_client: SoulseekClient = Depends(get_soulseek_client),
+) -> SpotifyDomainService:
+    return SpotifyDomainService(
+        config=config,
+        spotify_client=spotify_client,
+        soulseek_client=soulseek_client,
+        app_state=request.app.state,
+    )
+
+
 @router.get("/mode", response_model=SpotifyModeResponse)
-def get_spotify_mode() -> SpotifyModeResponse:
-    config = load_config()
-    return SpotifyModeResponse(mode=config.spotify.mode)
+def get_spotify_mode(service: SpotifyDomainService = Depends(_get_spotify_service)) -> SpotifyModeResponse:
+    return SpotifyModeResponse(mode=service.get_mode())
 
 
 @router.post("/mode")
-def update_spotify_mode(payload: SpotifyModePayload) -> dict[str, bool]:
-    write_setting("SPOTIFY_MODE", payload.mode)
-    get_app_config.cache_clear()
+def update_spotify_mode(
+    payload: SpotifyModePayload,
+    service: SpotifyDomainService = Depends(_get_spotify_service),
+) -> dict[str, bool]:
+    service.update_mode(payload.mode)
     return {"ok": True}
 
 
 @router.get("/status", response_model=StatusResponse)
-def spotify_status(client: SpotifyClient = Depends(get_spotify_client)) -> StatusResponse:
-    status = "connected" if client.is_authenticated() else "unauthenticated"
-    return StatusResponse(status=status)
+def spotify_status(
+    service: SpotifyDomainService = Depends(_get_spotify_service),
+) -> StatusResponse:
+    return StatusResponse(status=service.get_status())
 
 
 @router.get("/search/tracks", response_model=SpotifySearchResponse)
 def search_tracks(
     query: str = Query(..., min_length=1),
-    client: SpotifyClient = Depends(get_spotify_client),
+    service: SpotifyDomainService = Depends(_get_spotify_service),
 ) -> SpotifySearchResponse:
-    response = client.search_tracks(query)
-    items = response.get("tracks", {}).get("items", [])
-    return SpotifySearchResponse(items=items)
+    items = service.search_tracks(query)
+    return SpotifySearchResponse(items=list(items))
 
 
 @router.get("/search/artists", response_model=SpotifySearchResponse)
 def search_artists(
     query: str = Query(..., min_length=1),
-    client: SpotifyClient = Depends(get_spotify_client),
+    service: SpotifyDomainService = Depends(_get_spotify_service),
 ) -> SpotifySearchResponse:
-    response = client.search_artists(query)
-    items = response.get("artists", {}).get("items", [])
-    return SpotifySearchResponse(items=items)
+    items = service.search_artists(query)
+    return SpotifySearchResponse(items=list(items))
 
 
 @router.get("/search/albums", response_model=SpotifySearchResponse)
 def search_albums(
     query: str = Query(..., min_length=1),
-    client: SpotifyClient = Depends(get_spotify_client),
+    service: SpotifyDomainService = Depends(_get_spotify_service),
 ) -> SpotifySearchResponse:
-    response = client.search_albums(query)
-    items = response.get("albums", {}).get("items", [])
-    return SpotifySearchResponse(items=items)
+    items = service.search_albums(query)
+    return SpotifySearchResponse(items=list(items))
 
 
 @router.get("/artists/followed", response_model=FollowedArtistsResponse)
 def get_followed_artists(
-    client: SpotifyClient = Depends(get_spotify_client),
+    service: SpotifyDomainService = Depends(_get_spotify_service),
 ) -> FollowedArtistsResponse:
-    response = client.get_followed_artists()
-    artists_section = response.get("artists") if isinstance(response, dict) else None
-    items = []
-    if isinstance(artists_section, dict):
-        raw_items = artists_section.get("items") or []
-        if isinstance(raw_items, list):
-            items = [item for item in raw_items if isinstance(item, dict)]
-    if not items and isinstance(response, dict):
-        raw_items = response.get("items") or []
-        if isinstance(raw_items, list):
-            items = [item for item in raw_items if isinstance(item, dict)]
-    return FollowedArtistsResponse(artists=items)
+    return FollowedArtistsResponse(artists=list(service.get_followed_artists()))
 
 
 @router.get("/artist/{artist_id}/releases", response_model=ArtistReleasesResponse)
 def get_artist_releases(
     artist_id: str,
-    client: SpotifyClient = Depends(get_spotify_client),
+    service: SpotifyDomainService = Depends(_get_spotify_service),
 ) -> ArtistReleasesResponse:
-    response = client.get_artist_releases(artist_id)
-    raw_items = response.get("items") if isinstance(response, dict) else []
-    releases = [item for item in raw_items or [] if isinstance(item, dict)]
-    return ArtistReleasesResponse(artist_id=artist_id, releases=releases)
+    releases = service.get_artist_releases(artist_id)
+    return ArtistReleasesResponse(artist_id=artist_id, releases=list(releases))
 
 
 @router.get("/artist/{artist_id}/discography", response_model=DiscographyResponse)
 def get_artist_discography(
     artist_id: str,
-    client: SpotifyClient = Depends(get_spotify_client),
+    service: SpotifyDomainService = Depends(_get_spotify_service),
 ) -> DiscographyResponse:
-    response = client.get_artist_discography(artist_id)
-    albums_payload = response.get("albums") if isinstance(response, dict) else []
-    albums = []
-    for entry in albums_payload or []:
-        if not isinstance(entry, dict):
-            continue
-        album_data = entry.get("album") if isinstance(entry.get("album"), dict) else None
-        if album_data is None:
-            album_data = {key: value for key, value in entry.items() if key != "tracks"}
-        tracks = entry.get("tracks")
-        if isinstance(tracks, list):
-            track_items = [track for track in tracks if isinstance(track, dict)]
-        elif isinstance(tracks, dict):
-            items = tracks.get("items") if isinstance(tracks, dict) else []
-            track_items = [track for track in items if isinstance(track, dict)]
-        else:
-            track_items = []
-        albums.append({"album": album_data, "tracks": track_items})
-    return DiscographyResponse(artist_id=artist_id, albums=albums)
+    albums = service.get_artist_discography(artist_id)
+    return DiscographyResponse(artist_id=artist_id, albums=list(albums))
 
 
 @router.get("/playlists", response_model=PlaylistResponse)
-def list_playlists(db: Session = Depends(get_db)) -> PlaylistResponse:
-    playlists = db.query(Playlist).order_by(Playlist.updated_at.desc()).all()
-    return PlaylistResponse(playlists=playlists)
-
-
-@router.get("/track/{track_id}", response_model=TrackDetailResponse)
-def get_track_details(
-    track_id: str,
-    client: SpotifyClient = Depends(get_spotify_client),
-) -> TrackDetailResponse:
-    details = client.get_track_details(track_id)
-    if not details:
-        raise HTTPException(status_code=404, detail="Track not found")
-    return TrackDetailResponse(track=details)
-
-
-@router.get("/audio-features/{track_id}", response_model=AudioFeaturesResponse)
-def get_audio_features(
-    track_id: str,
-    client: SpotifyClient = Depends(get_spotify_client),
-) -> AudioFeaturesResponse:
-    features = client.get_audio_features(track_id)
-    if not features:
-        raise HTTPException(status_code=404, detail="Audio features not found")
-    return AudioFeaturesResponse(audio_features=features)
-
-
-@router.get("/audio-features", response_model=AudioFeaturesResponse)
-def get_multiple_audio_features(
-    ids: str = Query(..., min_length=1),
-    client: SpotifyClient = Depends(get_spotify_client),
-) -> AudioFeaturesResponse:
-    track_ids = [item.strip() for item in ids.split(",") if item.strip()]
-    if not track_ids:
-        raise HTTPException(status_code=400, detail="No track IDs provided")
-    features = client.get_multiple_audio_features(track_ids)
-    return AudioFeaturesResponse(audio_features=features.get("audio_features", []))
+def list_playlists(
+    db: Session = Depends(get_db),
+    service: SpotifyDomainService = Depends(_get_spotify_service),
+) -> PlaylistResponse:
+    playlists = service.list_playlists(db)
+    return PlaylistResponse(playlists=list(playlists))
 
 
 @router.get(
@@ -203,18 +159,10 @@ def get_multiple_audio_features(
 def get_playlist_items(
     playlist_id: str,
     limit: int = Query(100, ge=1, le=100),
-    client: SpotifyClient = Depends(get_spotify_client),
+    service: SpotifyDomainService = Depends(_get_spotify_service),
 ) -> PlaylistItemsResponse:
-    items = client.get_playlist_items(playlist_id, limit=limit)
-    total = items.get("total")
-    if total is None:
-        total = items.get("tracks", {}).get("total")
-    if total is None:
-        total = len(items.get("items", []))
-    return PlaylistItemsResponse(
-        items=items.get("items", []),
-        total=total,
-    )
+    result: PlaylistItemsResult = service.get_playlist_items(playlist_id, limit=limit)
+    return PlaylistItemsResponse(items=list(result.items), total=result.total)
 
 
 @router.post(
@@ -224,11 +172,11 @@ def get_playlist_items(
 def add_tracks_to_playlist(
     playlist_id: str,
     payload: PlaylistTracksPayload,
-    client: SpotifyClient = Depends(get_spotify_client),
+    service: SpotifyDomainService = Depends(_get_spotify_service),
 ) -> StatusResponse:
     if not payload.uris:
         raise HTTPException(status_code=400, detail="No track URIs provided")
-    client.add_tracks_to_playlist(playlist_id, payload.uris)
+    service.add_tracks_to_playlist(playlist_id, payload.uris)
     return StatusResponse(status="tracks-added")
 
 
@@ -239,11 +187,11 @@ def add_tracks_to_playlist(
 def remove_tracks_from_playlist(
     playlist_id: str,
     payload: PlaylistTracksPayload,
-    client: SpotifyClient = Depends(get_spotify_client),
+    service: SpotifyDomainService = Depends(_get_spotify_service),
 ) -> StatusResponse:
     if not payload.uris:
         raise HTTPException(status_code=400, detail="No track URIs provided")
-    client.remove_tracks_from_playlist(playlist_id, payload.uris)
+    service.remove_tracks_from_playlist(playlist_id, payload.uris)
     return StatusResponse(status="tracks-removed")
 
 
@@ -254,9 +202,9 @@ def remove_tracks_from_playlist(
 def reorder_playlist(
     playlist_id: str,
     payload: PlaylistReorderPayload,
-    client: SpotifyClient = Depends(get_spotify_client),
+    service: SpotifyDomainService = Depends(_get_spotify_service),
 ) -> StatusResponse:
-    client.reorder_playlist_items(
+    service.reorder_playlist(
         playlist_id,
         range_start=payload.range_start,
         insert_before=payload.insert_before,
@@ -264,63 +212,95 @@ def reorder_playlist(
     return StatusResponse(status="playlist-reordered")
 
 
+@router.get("/track/{track_id}", response_model=TrackDetailResponse)
+def get_track_details(
+    track_id: str,
+    service: SpotifyDomainService = Depends(_get_spotify_service),
+) -> TrackDetailResponse:
+    details = service.get_track_details(track_id)
+    if not details:
+        raise HTTPException(status_code=404, detail="Track not found")
+    return TrackDetailResponse(track=details)
+
+
+@router.get("/audio-features/{track_id}", response_model=AudioFeaturesResponse)
+def get_audio_features(
+    track_id: str,
+    service: SpotifyDomainService = Depends(_get_spotify_service),
+) -> AudioFeaturesResponse:
+    features = service.get_audio_features(track_id)
+    if not features:
+        raise HTTPException(status_code=404, detail="Audio features not found")
+    return AudioFeaturesResponse(audio_features=features)
+
+
+@router.get("/audio-features", response_model=AudioFeaturesResponse)
+def get_multiple_audio_features(
+    ids: str = Query(..., min_length=1),
+    service: SpotifyDomainService = Depends(_get_spotify_service),
+) -> AudioFeaturesResponse:
+    track_ids = [item.strip() for item in ids.split(",") if item.strip()]
+    if not track_ids:
+        raise HTTPException(status_code=400, detail="No track IDs provided")
+    features = service.get_multiple_audio_features(track_ids)
+    return AudioFeaturesResponse(audio_features=list(features))
+
+
 @router.get("/me/tracks", response_model=SavedTracksResponse)
 def get_saved_tracks(
     limit: int = Query(20, ge=1, le=50),
-    client: SpotifyClient = Depends(get_spotify_client),
+    service: SpotifyDomainService = Depends(_get_spotify_service),
 ) -> SavedTracksResponse:
-    saved = client.get_saved_tracks(limit=limit)
-    return SavedTracksResponse(
-        items=saved.get("items", []), total=saved.get("total", len(saved.get("items", [])))
-    )
+    saved = service.get_saved_tracks(limit=limit)
+    return SavedTracksResponse(items=list(saved["items"]), total=saved["total"])
 
 
 @router.put("/me/tracks", response_model=StatusResponse)
 def save_tracks(
     payload: TrackIdsPayload,
-    client: SpotifyClient = Depends(get_spotify_client),
+    service: SpotifyDomainService = Depends(_get_spotify_service),
 ) -> StatusResponse:
     if not payload.ids:
         raise HTTPException(status_code=400, detail="No track IDs provided")
-    client.save_tracks(payload.ids)
+    service.save_tracks(payload.ids)
     return StatusResponse(status="tracks-saved")
 
 
 @router.delete("/me/tracks", response_model=StatusResponse)
 def remove_saved_tracks(
     payload: TrackIdsPayload,
-    client: SpotifyClient = Depends(get_spotify_client),
+    service: SpotifyDomainService = Depends(_get_spotify_service),
 ) -> StatusResponse:
     if not payload.ids:
         raise HTTPException(status_code=400, detail="No track IDs provided")
-    client.remove_saved_tracks(payload.ids)
+    service.remove_saved_tracks(payload.ids)
     return StatusResponse(status="tracks-removed")
 
 
 @router.get("/me", response_model=UserProfileResponse)
 def get_current_user(
-    client: SpotifyClient = Depends(get_spotify_client),
+    service: SpotifyDomainService = Depends(_get_spotify_service),
 ) -> UserProfileResponse:
-    profile = client.get_current_user()
+    profile = service.get_current_user() or {}
     return UserProfileResponse(profile=profile)
 
 
 @router.get("/me/top/tracks", response_model=SpotifySearchResponse)
 def get_top_tracks(
     limit: int = Query(20, ge=1, le=50),
-    client: SpotifyClient = Depends(get_spotify_client),
+    service: SpotifyDomainService = Depends(_get_spotify_service),
 ) -> SpotifySearchResponse:
-    response = client.get_top_tracks(limit=limit)
-    return SpotifySearchResponse(items=response.get("items", []))
+    items = service.get_top_tracks(limit=limit)
+    return SpotifySearchResponse(items=list(items))
 
 
 @router.get("/me/top/artists", response_model=SpotifySearchResponse)
 def get_top_artists(
     limit: int = Query(20, ge=1, le=50),
-    client: SpotifyClient = Depends(get_spotify_client),
+    service: SpotifyDomainService = Depends(_get_spotify_service),
 ) -> SpotifySearchResponse:
-    response = client.get_top_artists(limit=limit)
-    return SpotifySearchResponse(items=response.get("items", []))
+    items = service.get_top_artists(limit=limit)
+    return SpotifySearchResponse(items=list(items))
 
 
 @router.get("/recommendations", response_model=RecommendationsResponse)
@@ -329,21 +309,24 @@ def get_recommendations(
     seed_artists: Optional[str] = Query(None),
     seed_genres: Optional[str] = Query(None),
     limit: int = Query(20, ge=1, le=100),
-    client: SpotifyClient = Depends(get_spotify_client),
+    service: SpotifyDomainService = Depends(_get_spotify_service),
 ) -> RecommendationsResponse:
-    def _split(value: Optional[str]) -> Optional[List[str]]:
+    def _split(value: Optional[str]) -> Optional[list[str]]:
         if value is None:
             return None
         result = [item.strip() for item in value.split(",") if item.strip()]
         return result or None
 
-    response = client.get_recommendations(
+    payload = service.get_recommendations(
         seed_tracks=_split(seed_tracks),
         seed_artists=_split(seed_artists),
         seed_genres=_split(seed_genres),
         limit=limit,
     )
     return RecommendationsResponse(
-        tracks=response.get("tracks", []),
-        seeds=response.get("seeds", []),
+        tracks=list(payload["tracks"]),
+        seeds=list(payload["seeds"]),
     )
+
+
+__all__ = ["router"]

--- a/app/services/spotify_domain_service.py
+++ b/app/services/spotify_domain_service.py
@@ -1,0 +1,340 @@
+"""Spotify domain service consolidating playlist, ingest and backfill logic."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, Iterable, Literal, Optional, Sequence, cast
+
+from sqlalchemy.orm import Session
+
+from app.config import AppConfig, SpotifyConfig
+from app.core.soulseek_client import SoulseekClient
+from app.core.spotify_client import SpotifyClient
+from app.models import Playlist
+from app.services.backfill_service import (
+    BackfillJobSpec,
+    BackfillJobStatus,
+    BackfillService,
+)
+from app.services.free_ingest_service import (
+    FreeIngestService,
+    IngestSubmission,
+    JobStatus,
+)
+from app.utils.settings_store import write_setting
+from app.dependencies import get_app_config
+from app.workers.backfill_worker import BackfillWorker
+from app.workers.sync_worker import SyncWorker
+
+
+@dataclass(slots=True)
+class PlaylistItemsResult:
+    """Normalized representation of playlist items for API responses."""
+
+    items: Sequence[dict[str, Any]]
+    total: int
+
+
+class SpotifyDomainService:
+    """Aggregate Spotify use-cases across routers and workers."""
+
+    def __init__(
+        self,
+        *,
+        config: AppConfig,
+        spotify_client: SpotifyClient,
+        soulseek_client: SoulseekClient,
+        app_state: Any,
+        free_ingest_factory: Callable[[AppConfig, SoulseekClient, SyncWorker | None], FreeIngestService]
+        | None = None,
+        backfill_service_factory: Callable[[SpotifyConfig, SpotifyClient], BackfillService] | None = None,
+        backfill_worker_factory: Callable[[BackfillService], BackfillWorker] | None = None,
+    ) -> None:
+        self._config = config
+        self._spotify = spotify_client
+        self._soulseek = soulseek_client
+        self._state = app_state
+        self._free_ingest_factory = free_ingest_factory or self._default_free_ingest_factory
+        self._backfill_service_factory = backfill_service_factory or self._default_backfill_service_factory
+        self._backfill_worker_factory = backfill_worker_factory or self._default_backfill_worker_factory
+
+    # Factories ---------------------------------------------------------
+
+    @staticmethod
+    def _default_free_ingest_factory(
+        config: AppConfig, soulseek: SoulseekClient, worker: SyncWorker | None
+    ) -> FreeIngestService:
+        return FreeIngestService(config=config, soulseek_client=soulseek, sync_worker=worker)
+
+    @staticmethod
+    def _default_backfill_service_factory(
+        spotify_config: SpotifyConfig, spotify_client: SpotifyClient
+    ) -> BackfillService:
+        return BackfillService(spotify_config, spotify_client)
+
+    @staticmethod
+    def _default_backfill_worker_factory(service: BackfillService) -> BackfillWorker:
+        return BackfillWorker(service)
+
+    # Core Spotify operations ------------------------------------------
+
+    def get_mode(self) -> Literal["FREE", "PRO"]:
+        return self._config.spotify.mode
+
+    def update_mode(self, mode: Literal["FREE", "PRO"]) -> None:
+        write_setting("SPOTIFY_MODE", mode)
+        get_app_config.cache_clear()
+
+    def get_status(self) -> str:
+        try:
+            authenticated = self._spotify.is_authenticated()
+        except Exception:  # pragma: no cover - defensive guard
+            authenticated = False
+        return "connected" if authenticated else "unauthenticated"
+
+    def is_authenticated(self) -> bool:
+        try:
+            return bool(self._spotify.is_authenticated())
+        except Exception:  # pragma: no cover - defensive guard
+            return False
+
+    def search_tracks(self, query: str) -> Sequence[dict[str, Any]]:
+        response = self._spotify.search_tracks(query)
+        return self._extract_items(response, "tracks")
+
+    def search_artists(self, query: str) -> Sequence[dict[str, Any]]:
+        response = self._spotify.search_artists(query)
+        return self._extract_items(response, "artists")
+
+    def search_albums(self, query: str) -> Sequence[dict[str, Any]]:
+        response = self._spotify.search_albums(query)
+        return self._extract_items(response, "albums")
+
+    def get_followed_artists(self) -> Sequence[dict[str, Any]]:
+        response = self._spotify.get_followed_artists()
+        artists_section = response.get("artists") if isinstance(response, dict) else None
+        items: Sequence[dict[str, Any]] = []
+        if isinstance(artists_section, dict):
+            raw_items = artists_section.get("items") or []
+            if isinstance(raw_items, Iterable):
+                items = [item for item in raw_items if isinstance(item, dict)]
+        if not items and isinstance(response, dict):
+            raw_items = response.get("items") or []
+            if isinstance(raw_items, Iterable):
+                items = [item for item in raw_items if isinstance(item, dict)]
+        return items
+
+    def get_artist_releases(self, artist_id: str) -> Sequence[dict[str, Any]]:
+        response = self._spotify.get_artist_releases(artist_id)
+        raw_items = response.get("items") if isinstance(response, dict) else []
+        if not isinstance(raw_items, Iterable):
+            return []
+        return [item for item in raw_items if isinstance(item, dict)]
+
+    def get_artist_discography(self, artist_id: str) -> Sequence[dict[str, Any]]:
+        response = self._spotify.get_artist_discography(artist_id)
+        albums_payload = response.get("albums") if isinstance(response, dict) else []
+        albums: list[dict[str, Any]] = []
+        for entry in albums_payload or []:
+            if not isinstance(entry, dict):
+                continue
+            album_data = entry.get("album") if isinstance(entry.get("album"), dict) else None
+            if album_data is None:
+                album_data = {key: value for key, value in entry.items() if key != "tracks"}
+            tracks_payload = entry.get("tracks")
+            if isinstance(tracks_payload, list):
+                track_items = [track for track in tracks_payload if isinstance(track, dict)]
+            elif isinstance(tracks_payload, dict):
+                raw_items = tracks_payload.get("items") if isinstance(tracks_payload, dict) else []
+                track_items = [track for track in raw_items if isinstance(track, dict)]
+            else:
+                track_items = []
+            albums.append({"album": album_data, "tracks": track_items})
+        return albums
+
+    def list_playlists(self, session: Session) -> Sequence[Playlist]:
+        return session.query(Playlist).order_by(Playlist.updated_at.desc()).all()
+
+    def get_playlist_items(self, playlist_id: str, *, limit: int) -> PlaylistItemsResult:
+        items = self._spotify.get_playlist_items(playlist_id, limit=limit)
+        total = items.get("total")
+        if total is None:
+            total = items.get("tracks", {}).get("total") if isinstance(items, dict) else None
+        if total is None:
+            raw_items = items.get("items", []) if isinstance(items, dict) else []
+            total = len(raw_items) if isinstance(raw_items, Iterable) else 0
+        raw_items = items.get("items", []) if isinstance(items, dict) else []
+        sequence: Sequence[dict[str, Any]] = [item for item in raw_items if isinstance(item, dict)]
+        return PlaylistItemsResult(items=sequence, total=int(total or 0))
+
+    def add_tracks_to_playlist(self, playlist_id: str, uris: Sequence[str]) -> None:
+        self._spotify.add_tracks_to_playlist(playlist_id, list(uris))
+
+    def remove_tracks_from_playlist(self, playlist_id: str, uris: Sequence[str]) -> None:
+        self._spotify.remove_tracks_from_playlist(playlist_id, list(uris))
+
+    def reorder_playlist(self, playlist_id: str, *, range_start: int, insert_before: int) -> None:
+        self._spotify.reorder_playlist_items(
+            playlist_id,
+            range_start=range_start,
+            insert_before=insert_before,
+        )
+
+    def get_track_details(self, track_id: str) -> Optional[dict[str, Any]]:
+        details = self._spotify.get_track_details(track_id)
+        return details if details else None
+
+    def get_audio_features(self, track_id: str) -> Optional[dict[str, Any]]:
+        features = self._spotify.get_audio_features(track_id)
+        return features if features else None
+
+    def get_multiple_audio_features(self, track_ids: Sequence[str]) -> Sequence[dict[str, Any]]:
+        response = self._spotify.get_multiple_audio_features(list(track_ids))
+        audio_features = response.get("audio_features") if isinstance(response, dict) else []
+        if not isinstance(audio_features, Iterable):
+            return []
+        return [item for item in audio_features if isinstance(item, dict)]
+
+    def get_saved_tracks(self, *, limit: int) -> dict[str, Any]:
+        saved = self._spotify.get_saved_tracks(limit=limit)
+        items = saved.get("items", []) if isinstance(saved, dict) else []
+        total = saved.get("total") if isinstance(saved, dict) else None
+        if total is None and isinstance(items, Iterable):
+            total = len(list(items))
+        return {
+            "items": [item for item in items if isinstance(item, dict)],
+            "total": int(total or 0),
+        }
+
+    def save_tracks(self, track_ids: Sequence[str]) -> None:
+        self._spotify.save_tracks(list(track_ids))
+
+    def remove_saved_tracks(self, track_ids: Sequence[str]) -> None:
+        self._spotify.remove_saved_tracks(list(track_ids))
+
+    def get_current_user(self) -> Optional[dict[str, Any]]:
+        profile = self._spotify.get_current_user()
+        return profile if isinstance(profile, dict) else None
+
+    def get_top_tracks(self, *, limit: int) -> Sequence[dict[str, Any]]:
+        response = self._spotify.get_top_tracks(limit=limit)
+        return self._extract_items(response, "items")
+
+    def get_top_artists(self, *, limit: int) -> Sequence[dict[str, Any]]:
+        response = self._spotify.get_top_artists(limit=limit)
+        return self._extract_items(response, "items")
+
+    def get_recommendations(
+        self,
+        *,
+        seed_tracks: Optional[Sequence[str]] = None,
+        seed_artists: Optional[Sequence[str]] = None,
+        seed_genres: Optional[Sequence[str]] = None,
+        limit: int,
+    ) -> dict[str, Any]:
+        response = self._spotify.get_recommendations(
+            seed_tracks=list(seed_tracks) if seed_tracks else None,
+            seed_artists=list(seed_artists) if seed_artists else None,
+            seed_genres=list(seed_genres) if seed_genres else None,
+            limit=limit,
+        )
+        tracks = response.get("tracks") if isinstance(response, dict) else []
+        seeds = response.get("seeds") if isinstance(response, dict) else []
+        return {
+            "tracks": [track for track in tracks if isinstance(track, dict)],
+            "seeds": [seed for seed in seeds if isinstance(seed, dict)],
+        }
+
+    # FREE ingest -------------------------------------------------------
+
+    async def submit_free_ingest(
+        self,
+        *,
+        playlist_links: Sequence[str] | None = None,
+        tracks: Sequence[str] | None = None,
+        batch_hint: Optional[int] = None,
+    ) -> IngestSubmission:
+        service = self._build_free_ingest_service()
+        return await service.submit(
+            playlist_links=playlist_links,
+            tracks=tracks,
+            batch_hint=batch_hint,
+        )
+
+    def get_free_ingest_job(self, job_id: str) -> Optional[JobStatus]:
+        service = self._build_free_ingest_service()
+        return service.get_job_status(job_id)
+
+    def parse_tracks_from_file(self, content: bytes, filename: str) -> Sequence[str]:
+        return FreeIngestService.parse_tracks_from_file(content, filename)
+
+    # Backfill ----------------------------------------------------------
+
+    def ensure_backfill_service(self) -> BackfillService:
+        service = getattr(self._state, "backfill_service", None)
+        if isinstance(service, BackfillService):
+            return service
+        service = self._backfill_service_factory(self._config.spotify, self._spotify)
+        setattr(self._state, "backfill_service", service)
+        return service
+
+    async def ensure_backfill_worker(self) -> BackfillWorker:
+        worker = getattr(self._state, "backfill_worker", None)
+        if self._is_backfill_worker(worker):
+            typed_worker = cast(BackfillWorker, worker)
+            if not typed_worker.is_running():
+                await typed_worker.start()
+            return typed_worker
+        service = self.ensure_backfill_service()
+        worker = self._backfill_worker_factory(service)
+        setattr(self._state, "backfill_worker", worker)
+        await worker.start()
+        return worker
+
+    def create_backfill_job(
+        self, *, max_items: Optional[int], expand_playlists: bool
+    ) -> BackfillJobSpec:
+        service = self.ensure_backfill_service()
+        return service.create_job(max_items=max_items, expand_playlists=expand_playlists)
+
+    def get_backfill_status(self, job_id: str) -> Optional[BackfillJobStatus]:
+        service = self.ensure_backfill_service()
+        return service.get_status(job_id)
+
+    async def enqueue_backfill_job(self, job: BackfillJobSpec) -> None:
+        worker = await self.ensure_backfill_worker()
+        await worker.enqueue(job)
+
+    # Helpers -----------------------------------------------------------
+
+    def _build_free_ingest_service(self) -> FreeIngestService:
+        sync_worker = getattr(self._state, "sync_worker", None)
+        if not isinstance(sync_worker, SyncWorker):
+            sync_worker = None
+        return self._free_ingest_factory(self._config, self._soulseek, sync_worker)
+
+    @staticmethod
+    def _extract_items(response: Any, key: str) -> Sequence[dict[str, Any]]:
+        if not isinstance(response, dict):
+            return []
+        if key == "items":
+            items = response.get("items", [])
+        else:
+            payload = response.get(key, {})
+            if isinstance(payload, dict):
+                items = payload.get("items", [])
+            else:
+                items = payload
+        if not isinstance(items, Iterable):
+            return []
+        return [item for item in items if isinstance(item, dict)]
+
+    @staticmethod
+    def _is_backfill_worker(candidate: Any) -> bool:
+        if isinstance(candidate, BackfillWorker):
+            return True
+        required = ("start", "enqueue", "is_running")
+        return all(hasattr(candidate, attr) for attr in required)
+
+
+__all__ = ["PlaylistItemsResult", "SpotifyDomainService"]

--- a/tests/routers/test_router_registry.py
+++ b/tests/routers/test_router_registry.py
@@ -3,10 +3,8 @@ from __future__ import annotations
 from app.api.router_registry import compose_prefix, get_domain_routers
 from app.routers import (
     activity_router,
-    backfill_router,
     download_router,
     dlq_router,
-    free_ingest_router,
     health_router,
     imports_router,
     integrations_router,
@@ -15,8 +13,7 @@ from app.routers import (
     search_router,
     settings_router,
     soulseek_router,
-    spotify_free_router,
-    spotify_router,
+    spotify_domain_router,
     sync_router,
     system_router,
     watchlist_router,
@@ -37,10 +34,7 @@ def test_compose_prefix_handles_empty_segments() -> None:
 
 def test_get_domain_routers_matches_expected_configuration() -> None:
     expected = [
-        ("/spotify", spotify_router, ["Spotify"]),
-        ("/spotify/backfill", backfill_router, ["Spotify Backfill"]),
-        ("", spotify_free_router, []),
-        ("", free_ingest_router, []),
+        ("", spotify_domain_router, []),
         ("", imports_router, []),
         ("/soulseek", soulseek_router, ["Soulseek"]),
         ("/matching", matching_router, ["Matching"]),
@@ -61,4 +55,4 @@ def test_get_domain_routers_matches_expected_configuration() -> None:
 
     first_call = get_domain_routers()
     first_call[0][2].append("Extra")
-    assert get_domain_routers()[0][2] == ["Spotify"]
+    assert get_domain_routers()[0][2] == []

--- a/tests/routers/test_spotify_module.py
+++ b/tests/routers/test_spotify_module.py
@@ -1,0 +1,23 @@
+from fastapi import APIRouter
+from fastapi.routing import APIRoute
+
+from app.routers.spotify import legacy_router, router
+
+
+def _route_paths(target: APIRouter) -> set[str]:
+    return {route.path for route in target.routes if isinstance(route, APIRoute)}
+
+
+def test_spotify_router_includes_expected_paths() -> None:
+    paths = _route_paths(router)
+    assert "/spotify/mode" in paths
+    assert "/spotify/backfill/run" in paths
+    assert "/spotify/import/free" in paths
+    assert "/spotify/free/upload" in paths
+
+
+def test_legacy_router_is_optional_alias() -> None:
+    if legacy_router is None:
+        assert legacy_router is None
+    else:
+        assert isinstance(legacy_router, APIRouter)

--- a/tests/services/test_spotify_domain_service.py
+++ b/tests/services/test_spotify_domain_service.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+from app.config import load_config
+from app.services.spotify_domain_service import PlaylistItemsResult, SpotifyDomainService
+
+
+def _make_service(**overrides: Any) -> SpotifyDomainService:
+    config = overrides.get("config", load_config())
+    spotify_client = overrides.get("spotify_client", MagicMock())
+    soulseek_client = overrides.get("soulseek_client", MagicMock())
+    app_state = overrides.get("app_state", SimpleNamespace())
+    return SpotifyDomainService(
+        config=config,
+        spotify_client=spotify_client,
+        soulseek_client=soulseek_client,
+        app_state=app_state,
+        free_ingest_factory=overrides.get("free_ingest_factory"),
+        backfill_service_factory=overrides.get("backfill_service_factory"),
+        backfill_worker_factory=overrides.get("backfill_worker_factory"),
+    )
+
+
+def test_get_playlist_items_uses_fallback_total() -> None:
+    spotify_client = MagicMock()
+    spotify_client.get_playlist_items.return_value = {"items": [{"id": 1}, {"id": 2}]}
+    service = _make_service(spotify_client=spotify_client)
+
+    result = service.get_playlist_items("playlist", limit=10)
+
+    assert isinstance(result, PlaylistItemsResult)
+    assert result.total == 2
+    assert list(result.items) == [{"id": 1}, {"id": 2}]
+
+
+def test_get_artist_discography_merges_tracks() -> None:
+    spotify_client = MagicMock()
+    spotify_client.get_artist_discography.return_value = {
+        "albums": [
+            {
+                "album": {"id": "a1"},
+                "tracks": {"items": [{"name": "Track"}, "invalid", {"name": "Other"}]},
+            },
+            {
+                "name": "Fallback",
+                "tracks": [{"name": "Solo"}, None],
+            },
+        ]
+    }
+    service = _make_service(spotify_client=spotify_client)
+
+    albums = service.get_artist_discography("artist")
+
+    assert len(albums) == 2
+    assert albums[0]["album"]["id"] == "a1"
+    assert [track["name"] for track in albums[0]["tracks"]] == ["Track", "Other"]
+    assert albums[1]["album"]["name"] == "Fallback"
+    assert albums[1]["tracks"][0]["name"] == "Solo"
+
+
+@pytest.mark.asyncio
+async def test_submit_free_ingest_uses_custom_factory() -> None:
+    submit_mock = AsyncMock(return_value="submission")
+
+    class StubFreeIngestService:
+        def __init__(self) -> None:
+            self.submit = submit_mock
+
+        def get_job_status(self, job_id: str) -> None:  # pragma: no cover - not used here
+            return None
+
+    created: dict[str, Any] = {}
+
+    def factory(config, soulseek, worker) -> StubFreeIngestService:  # type: ignore[override]
+        created["worker"] = worker
+        created["config"] = config
+        return StubFreeIngestService()
+
+    service = _make_service(free_ingest_factory=factory)
+
+    result = await service.submit_free_ingest(tracks=["Track 1"])
+
+    assert result == "submission"
+    assert created["worker"] is None
+    submit_mock.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_enqueue_backfill_job_initialises_worker_once() -> None:
+    class StubBackfillService:
+        def __init__(self) -> None:
+            self.created_jobs: list[Any] = []
+
+        def create_job(self, *, max_items, expand_playlists):  # type: ignore[override]
+            job = SimpleNamespace(id="job-1", limit=max_items, expand_playlists=expand_playlists)
+            self.created_jobs.append(job)
+            return job
+
+        def get_status(self, job_id: str):  # pragma: no cover - not used
+            return None
+
+    class StubBackfillWorker:
+        def __init__(self) -> None:
+            self.started = 0
+            self.enqueued: list[Any] = []
+
+        async def start(self) -> None:
+            self.started += 1
+
+        def is_running(self) -> bool:
+            return self.started > 0
+
+        async def enqueue(self, job: Any) -> None:
+            self.enqueued.append(job)
+
+    created_worker: StubBackfillWorker | None = None
+
+    def service_factory(config, client) -> StubBackfillService:  # type: ignore[override]
+        return StubBackfillService()
+
+    def worker_factory(service) -> StubBackfillWorker:  # type: ignore[override]
+        nonlocal created_worker
+        created_worker = StubBackfillWorker()
+        return created_worker
+
+    service = _make_service(
+        backfill_service_factory=service_factory,
+        backfill_worker_factory=worker_factory,
+    )
+
+    job = service.create_backfill_job(max_items=50, expand_playlists=True)
+    await service.enqueue_backfill_job(job)
+    assert created_worker is not None
+    assert created_worker.started == 1
+    assert created_worker.enqueued == [job]
+
+    # second enqueue should reuse running worker
+    await service.enqueue_backfill_job(job)
+    assert created_worker.started == 1
+    assert created_worker.enqueued == [job, job]


### PR DESCRIPTION
## Summary
- introduce a SpotifyDomainService that unifies playlist operations, free ingest coordination, and backfill helpers for reuse across routers
- update Spotify-related routers to depend on the domain service and provide a combined router module for mounting legacy or new paths
- refresh the router registry plus add focused tests around the consolidated routing and service behaviour

## Testing
- pytest tests/routers/test_router_registry.py tests/services/test_spotify_domain_service.py tests/routers/test_spotify_module.py


------
https://chatgpt.com/codex/tasks/task_e_68dc2aa6cbe483219283974a4fc4aa92