### PR TITLE
feat(backfill): orchestrate spotify jobs [CODX-000]

### DIFF
--- a/app/orchestrator/__init__.py
+++ b/app/orchestrator/__init__.py
@@ -1,0 +1,5 @@
+"""Worker orchestration helpers."""
+
+from .handlers import enqueue_spotify_backfill, get_spotify_backfill_status
+
+__all__ = ["enqueue_spotify_backfill", "get_spotify_backfill_status"]

--- a/app/orchestrator/handlers.py
+++ b/app/orchestrator/handlers.py
@@ -1,0 +1,38 @@
+"""Utilities coordinating Spotify-specific background work."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from app.services.backfill_service import BackfillJobStatus
+from app.services.spotify_domain_service import SpotifyDomainService
+
+
+async def enqueue_spotify_backfill(
+    service: SpotifyDomainService,
+    *,
+    max_items: int | None,
+    expand_playlists: bool,
+) -> str:
+    """Schedule a Spotify backfill job and return its identifier."""
+
+    job = service.create_backfill_job(
+        max_items=max_items,
+        expand_playlists=expand_playlists,
+    )
+    await service.enqueue_backfill(job)
+    return job.id
+
+
+def get_spotify_backfill_status(
+    service: SpotifyDomainService, job_id: str
+) -> Optional[BackfillJobStatus]:
+    """Return the current status for the given Spotify backfill job."""
+
+    return service.get_backfill_status(job_id)
+
+
+__all__ = [
+    "enqueue_spotify_backfill",
+    "get_spotify_backfill_status",
+]

--- a/app/services/backfill_service.py
+++ b/app/services/backfill_service.py
@@ -116,7 +116,7 @@ class BackfillService:
         """Run a backfill job asynchronously inside a worker thread."""
 
         loop = asyncio.get_running_loop()
-        await loop.run_in_executor(None, self._run_job, job)
+        await loop.run_in_executor(None, self.run_job, job)
 
     def get_status(self, job_id: str) -> Optional[BackfillJobStatus]:
         """Return a snapshot of the persisted job state."""
@@ -143,7 +143,7 @@ class BackfillService:
 
     # Core processing ----------------------------------------------------
 
-    def _run_job(self, job: BackfillJobSpec) -> None:
+    def run_job(self, job: BackfillJobSpec) -> None:
         start_time = time.perf_counter()
         processed = 0
         matched = 0

--- a/app/services/spotify_domain_service.py
+++ b/app/services/spotify_domain_service.py
@@ -301,7 +301,7 @@ class SpotifyDomainService:
         service = self.ensure_backfill_service()
         return service.get_status(job_id)
 
-    async def enqueue_backfill_job(self, job: BackfillJobSpec) -> None:
+    async def enqueue_backfill(self, job: BackfillJobSpec) -> None:
         worker = await self.ensure_backfill_worker()
         await worker.enqueue(job)
 

--- a/tests/services/test_spotify_domain_service.py
+++ b/tests/services/test_spotify_domain_service.py
@@ -91,7 +91,7 @@ async def test_submit_free_ingest_uses_custom_factory() -> None:
 
 
 @pytest.mark.asyncio
-async def test_enqueue_backfill_job_initialises_worker_once() -> None:
+async def test_enqueue_backfill_initialises_worker_once() -> None:
     class StubBackfillService:
         def __init__(self) -> None:
             self.created_jobs: list[Any] = []
@@ -134,12 +134,12 @@ async def test_enqueue_backfill_job_initialises_worker_once() -> None:
     )
 
     job = service.create_backfill_job(max_items=50, expand_playlists=True)
-    await service.enqueue_backfill_job(job)
+    await service.enqueue_backfill(job)
     assert created_worker is not None
     assert created_worker.started == 1
     assert created_worker.enqueued == [job]
 
     # second enqueue should reuse running worker
-    await service.enqueue_backfill_job(job)
+    await service.enqueue_backfill(job)
     assert created_worker.started == 1
     assert created_worker.enqueued == [job, job]


### PR DESCRIPTION
## Summary
- add a dedicated orchestrator module with Spotify backfill enqueue/status helpers
- route the backfill API through the orchestrator and expose a synchronous `run_job` helper
- refresh fixtures and tests to avoid worker usage within request contexts

## Testing
- pytest tests/test_backfill_service.py tests/test_backfill_router.py tests/services/test_spotify_domain_service.py


------
https://chatgpt.com/codex/tasks/task_e_68dc31cbd22c83219a3c387b84bd28b0