### PR TITLE
feat: orchestrate spotify free import flow

### DIFF
--- a/app/orchestrator/handlers.py
+++ b/app/orchestrator/handlers.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
-from typing import Optional
+from typing import Optional, Sequence
 
 from app.services.backfill_service import BackfillJobStatus
+from app.services.free_ingest_service import IngestSubmission, JobStatus
 from app.services.spotify_domain_service import SpotifyDomainService
 
 
@@ -32,7 +33,33 @@ def get_spotify_backfill_status(
     return service.get_backfill_status(job_id)
 
 
+async def enqueue_spotify_free_import(
+    service: SpotifyDomainService,
+    *,
+    playlist_links: Sequence[str] | None,
+    tracks: Sequence[str] | None,
+    batch_hint: int | None,
+) -> IngestSubmission:
+    """Schedule a Spotify FREE import job via the domain service."""
+
+    return await service._submit_free_import(  # pragma: no cover - exercised via service tests
+        playlist_links=playlist_links,
+        tracks=tracks,
+        batch_hint=batch_hint,
+    )
+
+
+def get_spotify_free_import_job(
+    service: SpotifyDomainService, job_id: str
+) -> Optional[JobStatus]:
+    """Fetch the current state for a Spotify FREE import job."""
+
+    return service.get_free_ingest_job(job_id)
+
+
 __all__ = [
     "enqueue_spotify_backfill",
     "get_spotify_backfill_status",
+    "enqueue_spotify_free_import",
+    "get_spotify_free_import_job",
 ]

--- a/app/routers/free_ingest_router.py
+++ b/app/routers/free_ingest_router.py
@@ -145,7 +145,7 @@ async def submit_free_ingest(
         raise ValidationAppError("playlist_links or tracks required")
 
     try:
-        result = await service.submit_free_ingest(
+        result = await service.free_import(
             playlist_links=payload.playlist_links,
             tracks=payload.tracks,
             batch_hint=payload.batch_hint,
@@ -185,7 +185,7 @@ async def upload_free_ingest(
     if not tracks:
         raise ValidationAppError("no tracks found in file")
 
-    result = await service.submit_free_ingest(tracks=tracks)
+    result = await service.free_import(tracks=tracks)
     response = _build_submission_response(result)
     status_code = _submission_status_code(result)
     return JSONResponse(status_code=status_code, content=response.model_dump())

--- a/tests/routers/test_spotify_free_import.py
+++ b/tests/routers/test_spotify_free_import.py
@@ -1,0 +1,66 @@
+from typing import Any
+
+import pytest
+
+from app.services.free_ingest_service import IngestAccepted, IngestSkipped, IngestSubmission
+from tests.simple_client import SimpleTestClient
+
+
+def test_free_import_invokes_orchestrator_and_logs(
+    monkeypatch: pytest.MonkeyPatch, client: SimpleTestClient
+) -> None:
+    submission = IngestSubmission(
+        ok=True,
+        job_id="job-test",
+        accepted=IngestAccepted(playlists=1, tracks=2, batches=1),
+        skipped=IngestSkipped(playlists=0, tracks=0, reason=None),
+        error=None,
+    )
+    captured: dict[str, Any] = {}
+
+    async def fake_enqueue(service, **kwargs: Any):  # type: ignore[override]
+        captured["service"] = service
+        captured["kwargs"] = kwargs
+        return submission
+
+    events: list[dict[str, Any]] = []
+
+    def fake_log_event(logger: Any, event: str, /, **fields: Any) -> None:
+        events.append({"event": event, **fields})
+
+    monkeypatch.setattr(
+        "app.orchestrator.handlers.enqueue_spotify_free_import",
+        fake_enqueue,
+    )
+    monkeypatch.setattr("app.services.spotify_domain_service.log_event", fake_log_event)
+
+    response = client.post(
+        "/spotify/import/free",
+        json={
+            "playlist_links": ["https://open.spotify.com/playlist/abc123"],
+            "tracks": ["Artist - Track"],
+            "batch_hint": 4,
+        },
+    )
+
+    assert response.status_code == 202
+    payload = response.json()
+    assert payload["ok"] is True
+    assert payload["job_id"] == submission.job_id
+    assert payload["accepted"]["tracks"] == submission.accepted.tracks
+    assert payload["skipped"]["tracks"] == submission.skipped.tracks
+
+    assert captured["kwargs"] == {
+        "playlist_links": ["https://open.spotify.com/playlist/abc123"],
+        "tracks": ["Artist - Track"],
+        "batch_hint": 4,
+    }
+    assert "service" in captured
+
+    matching_events = [event for event in events if event.get("event") == "spotify.free_import"]
+    assert matching_events, "expected spotify.free_import log event"
+    logged = matching_events[0]
+    assert logged["status"] == "ok"
+    assert logged["accepted_tracks"] == submission.accepted.tracks
+    assert logged["skipped_tracks"] == submission.skipped.tracks
+    assert "duration_ms" in logged


### PR DESCRIPTION
## Summary
- update the free ingest API to submit jobs through `SpotifyDomainService.free_import` so the orchestrator handles execution
- wire up orchestrator helpers and structured logging for the new flow
- extend service and router tests to exercise the orchestrator call and logging contract

## Testing
- pytest tests/services/test_spotify_domain_service.py tests/routers/test_spotify_free_import.py

------
https://chatgpt.com/codex/tasks/task_e_68dc34982b10832197794b1a4409329b