### PR TITLE
fix: refresh queue lease release timing

### DIFF
--- a/app/routers/download_router.py
+++ b/app/routers/download_router.py
@@ -33,7 +33,7 @@ from app.utils.events import (
     DOWNLOAD_BLOCKED,
 )
 from app.utils.service_health import collect_missing_credentials
-from app.workers.persistence import PersistentJobQueue
+from app.workers.persistence import update_priority
 from app.errors import AppError, ValidationAppError
 
 router = APIRouter(tags=["Download"])
@@ -178,14 +178,12 @@ def update_download_priority(
     )
 
     job_id = download.job_id
-    if job_id:
-        queue = PersistentJobQueue("sync")
-        if not queue.update_priority(job_id, new_priority):
-            logger.error(
-                "Failed to update worker job priority for download %s (job %s)",
-                download_id,
-                job_id,
-            )
+    if job_id and not update_priority(job_id, new_priority, job_type="sync"):
+        logger.error(
+            "Failed to update worker job priority for download %s (job %s)",
+            download_id,
+            job_id,
+        )
 
     return DownloadEntryResponse.model_validate(download)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -447,6 +447,12 @@ class StubSoulseekClient:
             self.downloads[identifier] = entry
         return {"status": "queued"}
 
+    async def cancel_download(self, download_id: str) -> Dict[str, Any]:
+        identifier = int(download_id)
+        if identifier in self.downloads:
+            self.downloads[identifier]["state"] = "failed"
+        return {"cancelled": download_id}
+
 
 class StubSearchGateway:
     def __init__(self, spotify: StubSpotifyClient, soulseek: StubSoulseekClient) -> None:

--- a/tests/test_download_priority.py
+++ b/tests/test_download_priority.py
@@ -6,9 +6,9 @@ from typing import Any, Dict, List
 import pytest
 
 from app.db import init_db, reset_engine_for_tests, session_scope
-from app.models import Download, WorkerJob
+from app.models import Download, QueueJob, QueueJobStatus
 from app.utils.activity import activity_manager
-from app.workers.persistence import PersistentJobQueue
+from app.workers.persistence import enqueue, update_priority
 from app.workers.sync_worker import SyncWorker
 
 
@@ -93,23 +93,23 @@ def test_priority_can_be_updated_via_api(client) -> None:
         session.add(download)
         session.flush()
         download_id = download.id
-        job = WorkerJob(
-            worker="sync",
-            payload={
-                "username": "tester",
-                "files": [{"download_id": download_id, "priority": 0}],
-                "priority": 0,
-            },
-            state="queued",
-        )
-        session.add(job)
-        session.flush()
+
+    job_payload = {
+        "username": "tester",
+        "files": [{"download_id": download_id, "priority": 0}],
+        "priority": 0,
+    }
+    job = enqueue("sync", job_payload)
+
+    with session_scope() as session:
+        download = session.get(Download, download_id)
+        assert download is not None
         download.job_id = str(job.id)
         payload_copy = dict(download.request_payload or {})
         payload_copy.update({"download_id": download_id, "priority": 0})
         download.request_payload = payload_copy
         session.add(download)
-        job_id = job.id
+    job_id = job.id
 
     response = client.patch(
         f"/download/{download_id}/priority",
@@ -129,86 +129,86 @@ def test_priority_can_be_updated_via_api(client) -> None:
         refreshed_download = session.get(Download, download_id)
         assert refreshed_download is not None
         assert refreshed_download.request_payload.get("priority") == 7
-        refreshed_job = session.get(WorkerJob, job_id)
+        refreshed_job = session.get(QueueJob, job_id)
         assert refreshed_job is not None
         assert refreshed_job.payload.get("priority") == 7
         files = refreshed_job.payload.get("files", [])
         assert files and files[0].get("priority") == 7
-        assert refreshed_job.state == "queued"
+        assert refreshed_job.status == QueueJobStatus.PENDING.value
 
 
-@pytest.mark.parametrize("state", ["queued", "retrying"])
-def test_job_queue_priority_update_allows_requeue(state: str) -> None:
+@pytest.mark.parametrize(
+    "status",
+    [QueueJobStatus.PENDING.value, QueueJobStatus.FAILED.value],
+)
+def test_job_queue_priority_update_allows_requeue(status: str) -> None:
     reset_engine_for_tests()
     init_db()
-    queue = PersistentJobQueue("sync")
+    job = enqueue(
+        "sync",
+        {"priority": 1, "files": [{"download_id": 1, "priority": 1}]},
+    )
 
     with session_scope() as session:
-        job = WorkerJob(
-            worker="sync",
-            payload={
-                "priority": 1,
-                "files": [{"download_id": 1, "priority": 1}],
-            },
-            state=state,
-        )
-        session.add(job)
-        session.flush()
-        job_id = str(job.id)
-        original_updated_at = job.updated_at
+        db_job = session.get(QueueJob, job.id)
+        assert db_job is not None
+        db_job.status = status
+        session.add(db_job)
 
-    result = queue.update_priority(job_id, 5)
+    with session_scope() as session:
+        original = session.get(QueueJob, job.id)
+        assert original is not None
+        original_updated_at = original.updated_at
+
+    result = update_priority(job.id, 5, job_type="sync")
     assert result is True
 
     with session_scope() as session:
-        refreshed = session.get(WorkerJob, int(job_id))
+        refreshed = session.get(QueueJob, job.id)
         assert refreshed is not None
         assert refreshed.payload.get("priority") == 5
         assert all(
             isinstance(item, dict) and item.get("priority") == 5
             for item in refreshed.payload.get("files", [])
         )
-        assert refreshed.state == "queued"
+        assert refreshed.status == QueueJobStatus.PENDING.value
         assert refreshed.updated_at >= original_updated_at
 
 
-@pytest.mark.parametrize("state", ["running", "completed"])
-def test_job_queue_priority_update_rejects_disallowed_states(state: str) -> None:
+@pytest.mark.parametrize(
+    "status",
+    [QueueJobStatus.LEASED.value, QueueJobStatus.COMPLETED.value],
+)
+def test_job_queue_priority_update_rejects_disallowed_states(status: str) -> None:
     reset_engine_for_tests()
     init_db()
-    queue = PersistentJobQueue("sync")
+    job = enqueue(
+        "sync",
+        {"priority": 2, "files": [{"download_id": 1, "priority": 2}]},
+    )
 
     with session_scope() as session:
-        job = WorkerJob(
-            worker="sync",
-            payload={
-                "priority": 2,
-                "files": [{"download_id": 1, "priority": 2}],
-            },
-            state=state,
-        )
-        session.add(job)
-        session.flush()
-        job_id = str(job.id)
+        db_job = session.get(QueueJob, job.id)
+        assert db_job is not None
+        db_job.status = status
+        session.add(db_job)
 
-    result = queue.update_priority(job_id, 9)
+    result = update_priority(job.id, 9, job_type="sync")
     assert result is False
 
     with session_scope() as session:
-        refreshed = session.get(WorkerJob, int(job_id))
+        refreshed = session.get(QueueJob, job.id)
         assert refreshed is not None
         assert refreshed.payload.get("priority") == 2
         assert all(
             isinstance(item, dict) and item.get("priority") == 2
             for item in refreshed.payload.get("files", [])
         )
-        assert refreshed.state == state
+        assert refreshed.status == status
 
 
 def test_job_queue_priority_update_handles_missing_job() -> None:
     reset_engine_for_tests()
     init_db()
-    queue = PersistentJobQueue("sync")
-
-    result = queue.update_priority("9999", 3)
+    result = update_priority("9999", 3, job_type="sync")
     assert result is False

--- a/tests/test_workers.py
+++ b/tests/test_workers.py
@@ -3,7 +3,7 @@ from sqlalchemy import select
 
 from app.core.matching_engine import MusicMatchingEngine
 from app.db import init_db, reset_engine_for_tests, session_scope
-from app.models import Match, WorkerJob
+from app.models import Match, QueueJob, QueueJobStatus
 from app.utils.settings_store import read_setting
 from app.workers.matching_worker import MatchingWorker
 from app.workers.sync_worker import SyncWorker
@@ -32,8 +32,8 @@ async def test_sync_worker_persists_jobs() -> None:
     assert client.downloads, "Download should be triggered even when worker is stopped"
 
     with session_scope() as session:
-        job = session.execute(select(WorkerJob)).scalar_one()
-        assert job.state == "completed"
+        job = session.execute(select(QueueJob)).scalar_one()
+        assert job.status == QueueJobStatus.COMPLETED.value
         assert job.attempts == 1
 
     assert read_setting("metrics.sync.jobs_completed") == "1"

--- a/tests/workers/test_idempotency.py
+++ b/tests/workers/test_idempotency.py
@@ -1,26 +1,25 @@
-"""Tests for job idempotency behaviour in the worker persistence queue."""
+"""Tests for job idempotency behaviour in the queue persistence layer."""
 
 from __future__ import annotations
 
 from sqlalchemy import select
 
 from app.db import session_scope
-from app.models import WorkerJob
-from app.workers.persistence import PersistentJobQueue
+from app.models import QueueJob
+from app.workers.persistence import enqueue
 
 
 def test_idempotent_processing_prevents_duplicates() -> None:
-    queue = PersistentJobQueue("matching")
     payload = {"idempotency_key": "match-123", "payload": {"value": 42}}
 
-    first = queue.enqueue(payload)
-    second = queue.enqueue(payload)
+    first = enqueue("matching", payload)
+    second = enqueue("matching", payload)
 
     assert first.id == second.id
 
     with session_scope() as session:
-        stmt = select(WorkerJob).where(
-            WorkerJob.worker == "matching", WorkerJob.job_key == first.job_key
+        stmt = select(QueueJob).where(
+            QueueJob.type == "matching", QueueJob.id == first.id
         )
         jobs = session.execute(stmt).scalars().all()
         assert len(jobs) == 1

--- a/tests/workers/test_retries_and_backoff.py
+++ b/tests/workers/test_retries_and_backoff.py
@@ -1,32 +1,28 @@
-"""Tests for retry and scheduling helpers in the worker persistence layer."""
+"""Tests for retry and scheduling helpers in the queue persistence layer."""
 
 from __future__ import annotations
 
 from datetime import datetime
 
 from app.db import session_scope
-from app.models import WorkerJob
-from app.workers.persistence import PersistentJobQueue
+from app.models import QueueJob, QueueJobStatus
+from app.workers.persistence import enqueue, fail, lease
 
 
 def test_retry_failure_requeues_with_delay() -> None:
-    queue = PersistentJobQueue("sync")
-    job = queue.enqueue({"idempotency_key": "retry-job", "priority": 1})
+    job = enqueue("sync", {"idempotency_key": "retry-job", "priority": 1})
 
-    queue.mark_running(job.id, visibility_timeout=5)
-    queue.mark_failed(
-        job.id,
-        "dependency timeout",
-        redeliver=True,
-        delay_seconds=15,
-        stop_reason="dependency_error",
-    )
+    leased = lease(job.id, job_type="sync", lease_seconds=5)
+    assert leased is not None
+
+    fail(job.id, job_type="sync", error="dependency timeout", retry_in=15)
 
     with session_scope() as session:
-        db_job = session.get(WorkerJob, job.id)
+        db_job = session.get(QueueJob, job.id)
         assert db_job is not None
-        assert db_job.state == "queued"
+        assert db_job.status == QueueJobStatus.PENDING.value
         assert db_job.last_error == "dependency timeout"
-        assert db_job.stop_reason == "dependency_error"
-        assert db_job.scheduled_at is not None
-        assert db_job.scheduled_at >= datetime.utcnow()
+        assert db_job.lease_expires_at is None
+        assert db_job.available_at is not None
+        remaining = (db_job.available_at - datetime.utcnow()).total_seconds()
+        assert remaining >= 14

--- a/tests/workers/test_visibility_timeout.py
+++ b/tests/workers/test_visibility_timeout.py
@@ -1,33 +1,33 @@
-"""Tests for worker job visibility timeouts and redelivery."""
+"""Tests for queue job visibility timeouts and redelivery."""
 
 from __future__ import annotations
 
 from datetime import datetime, timedelta
 
 from app.db import session_scope
-from app.models import WorkerJob
-from app.workers.persistence import PersistentJobQueue
+from app.models import QueueJob, QueueJobStatus
+from app.workers.persistence import enqueue, fetch_ready, lease
 
 
 def test_visibility_timeout_redelivery() -> None:
-    queue = PersistentJobQueue("sync")
-    job = queue.enqueue({"idempotency_key": "job-1", "priority": 2, "visibility_timeout": 5})
+    job = enqueue("sync", {"idempotency_key": "job-1", "priority": 2, "visibility_timeout": 5})
 
-    queue.mark_running(job.id, visibility_timeout=5)
+    leased = lease(job.id, job_type="sync", lease_seconds=5)
+    assert leased is not None
 
     expired_at = datetime.utcnow() - timedelta(seconds=1)
     with session_scope() as session:
-        db_job = session.get(WorkerJob, job.id)
+        db_job = session.get(QueueJob, job.id)
         assert db_job is not None
         db_job.lease_expires_at = expired_at
-        db_job.state = "running"
+        db_job.status = QueueJobStatus.LEASED.value
         session.add(db_job)
 
-    pending = queue.list_pending()
+    pending = fetch_ready("sync")
     assert any(item.id == job.id for item in pending)
 
     with session_scope() as session:
-        db_job = session.get(WorkerJob, job.id)
+        db_job = session.get(QueueJob, job.id)
         assert db_job is not None
-        assert db_job.state == "queued"
+        assert db_job.status == QueueJobStatus.PENDING.value
         assert db_job.lease_expires_at is None


### PR DESCRIPTION
## Summary
- refresh expired lease handling in the queue persistence helpers so reclaimed jobs become immediately eligible
- adjust worker and router integrations plus tests to reflect the function-based queue API and new DTO usage

## Testing
- pytest tests/workers/test_visibility_timeout.py
- pytest tests/workers/test_retries_and_backoff.py tests/workers/test_idempotency.py tests/workers/test_graceful_shutdown.py
- pytest tests/test_download_priority.py

------
https://chatgpt.com/codex/tasks/task_e_68dcecfc306083218ae48091c05b099b