### PR TITLE
feat(orchestrator): add queue scheduler

### DIFF
--- a/app/orchestrator/__init__.py
+++ b/app/orchestrator/__init__.py
@@ -1,5 +1,11 @@
 """Worker orchestration helpers."""
 
 from .handlers import enqueue_spotify_backfill, get_spotify_backfill_status
+from .scheduler import PriorityConfig, Scheduler
 
-__all__ = ["enqueue_spotify_backfill", "get_spotify_backfill_status"]
+__all__ = [
+    "enqueue_spotify_backfill",
+    "get_spotify_backfill_status",
+    "PriorityConfig",
+    "Scheduler",
+]

--- a/app/orchestrator/scheduler.py
+++ b/app/orchestrator/scheduler.py
@@ -1,0 +1,230 @@
+"""Queue orchestration scheduler for Harmony background workers."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import os
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Mapping
+
+from app.logging import get_logger
+from app.logging_events import log_event
+from app.workers import persistence
+
+
+def _coerce_int(value: object, default: int) -> int:
+    try:
+        parsed = int(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return default
+    return parsed
+
+
+@dataclass(slots=True)
+class PriorityConfig:
+    """Configuration for orchestrator job type polling priorities."""
+
+    priorities: dict[str, int]
+
+    _DEFAULT_CSV = "sync:100"
+
+    @classmethod
+    def from_env(cls, env: Mapping[str, str] | None = None) -> "PriorityConfig":
+        """Load a priority configuration from environment variables."""
+
+        source = env if env is not None else os.environ
+        json_blob = source.get("ORCH_PRIORITY_JSON")
+        if json_blob:
+            try:
+                parsed = json.loads(json_blob)
+            except json.JSONDecodeError:
+                parsed = None
+            else:
+                if isinstance(parsed, Mapping):
+                    mapping: dict[str, int] = {}
+                    for key, value in parsed.items():
+                        name = str(key).strip()
+                        if not name:
+                            continue
+                        mapping[name] = _coerce_int(value, 0)
+                    return cls(priorities=mapping)
+                parsed = None
+            if parsed is None:
+                # Invalid JSON falls back to CSV parsing.
+                pass
+
+        csv_blob = source.get("ORCH_PRIORITY_CSV", cls._DEFAULT_CSV)
+        return cls(priorities=cls._parse_csv(csv_blob))
+
+    @staticmethod
+    def _parse_csv(value: str | None) -> dict[str, int]:
+        priorities: dict[str, int] = {}
+        if not value:
+            return priorities
+        for chunk in value.split(","):
+            item = chunk.strip()
+            if not item or ":" not in item:
+                continue
+            name, priority_text = item.split(":", 1)
+            name = name.strip()
+            if not name:
+                continue
+            priorities[name] = _coerce_int(priority_text.strip(), 0)
+        return priorities
+
+    @property
+    def job_types(self) -> tuple[str, ...]:
+        """Return configured job types ordered by configured priority."""
+
+        return tuple(
+            sorted(
+                self.priorities.keys(),
+                key=lambda item: (-self.priorities[item], item),
+            )
+        )
+
+    def get(self, job_type: str, default: int = 0) -> int:
+        return self.priorities.get(job_type, default)
+
+
+class Scheduler:
+    """Asynchronous queue scheduler orchestrating worker leases."""
+
+    def __init__(
+        self,
+        *,
+        priority_config: PriorityConfig | None = None,
+        poll_interval_ms: int | None = None,
+        visibility_timeout: int | None = None,
+        persistence_module=persistence,
+    ) -> None:
+        self._priority = priority_config or PriorityConfig.from_env()
+        poll_ms = poll_interval_ms if poll_interval_ms is not None else self._resolve_poll_interval()
+        timeout_s = visibility_timeout if visibility_timeout is not None else self._resolve_visibility_timeout()
+        self._poll_interval = max(0.0, poll_ms / 1000.0)
+        self._visibility_timeout = max(1, timeout_s)
+        self._persistence = persistence_module
+        self._logger = get_logger(__name__)
+        self._stop_signal: asyncio.Event | None = None
+
+    @staticmethod
+    def _resolve_poll_interval() -> int:
+        env_value = os.getenv("ORCH_POLL_INTERVAL_MS")
+        return max(10, _coerce_int(env_value, 250))
+
+    @staticmethod
+    def _resolve_visibility_timeout() -> int:
+        env_value = os.getenv("ORCH_VISIBILITY_TIMEOUT_S")
+        return max(5, _coerce_int(env_value, 60))
+
+    def request_stop(self) -> None:
+        if self._stop_signal is not None:
+            self._stop_signal.set()
+
+    async def run(self, lifespan: asyncio.Event | None = None) -> None:
+        """Run the scheduler loop until a stop or lifespan signal triggers."""
+
+        self._stop_signal = asyncio.Event()
+        try:
+            while not self._should_stop(lifespan):
+                await self._tick()
+                await self._sleep(lifespan)
+        finally:
+            if self._stop_signal is not None:
+                self._stop_signal.set()
+
+    def _should_stop(self, lifespan: asyncio.Event | None) -> bool:
+        if self._stop_signal is not None and self._stop_signal.is_set():
+            return True
+        if lifespan is not None and lifespan.is_set():
+            return True
+        return False
+
+    async def _tick(self) -> None:
+        jobs = self._collect_ready_jobs()
+        for job in jobs:
+            log_event(
+                self._logger,
+                "orchestrator.schedule",
+                job_type=job.type,
+                job_id=job.id,
+                priority=int(job.priority),
+                available_at=self._format_dt(job.available_at),
+                attempts=int(job.attempts),
+            )
+            leased = self._persistence.lease(
+                job.id,
+                job_type=job.type,
+                lease_seconds=self._visibility_timeout,
+            )
+            status = "leased" if leased is not None else "skipped"
+            log_event(
+                self._logger,
+                "orchestrator.lease",
+                job_type=job.type,
+                job_id=job.id,
+                status=status,
+                priority=int(job.priority),
+                lease_timeout=self._visibility_timeout,
+            )
+
+    def _collect_ready_jobs(self) -> list[persistence.QueueJobDTO]:
+        ready: list[persistence.QueueJobDTO] = []
+        job_types = self._priority.job_types or ("sync",)
+        for job_type in job_types:
+            fetched = self._persistence.fetch_ready(job_type)
+            if not fetched:
+                continue
+            ready.extend(fetched)
+        ready.sort(key=self._job_sort_key)
+        return ready
+
+    @staticmethod
+    def _job_sort_key(job: persistence.QueueJobDTO) -> tuple[int, datetime, int]:
+        return (-int(job.priority), job.available_at, int(job.id))
+
+    @staticmethod
+    def _format_dt(value: datetime | None) -> str | None:
+        if value is None:
+            return None
+        return value.isoformat()
+
+    async def _sleep(self, lifespan: asyncio.Event | None) -> None:
+        timeout = self._poll_interval
+        if timeout <= 0:
+            await asyncio.sleep(0)
+            return
+
+        waiters: list[asyncio.Task[None]] = []
+        if lifespan is not None:
+            waiters.append(asyncio.create_task(lifespan.wait()))
+        if self._stop_signal is not None:
+            waiters.append(asyncio.create_task(self._stop_signal.wait()))
+        try:
+            if waiters:
+                done, pending = await asyncio.wait(
+                    waiters,
+                    timeout=timeout,
+                    return_when=asyncio.FIRST_COMPLETED,
+                )
+                for task in done:
+                    with contextlib.suppress(asyncio.CancelledError):
+                        task.result()
+                for task in pending:
+                    task.cancel()
+                    with contextlib.suppress(asyncio.CancelledError):
+                        await task
+            else:
+                await asyncio.sleep(timeout)
+        finally:
+            for task in waiters:
+                if not task.done():
+                    task.cancel()
+                    with contextlib.suppress(asyncio.CancelledError):
+                        await task
+
+
+__all__ = ["PriorityConfig", "Scheduler"]

--- a/tests/orchestrator/test_scheduler.py
+++ b/tests/orchestrator/test_scheduler.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timedelta
+from typing import Mapping
+
+import pytest
+
+from app.models import QueueJobStatus
+from app.orchestrator.scheduler import PriorityConfig, Scheduler
+from app.workers.persistence import QueueJobDTO
+
+
+class StubPersistence:
+    def __init__(self, ready: Mapping[str, list[QueueJobDTO]]) -> None:
+        self._ready: dict[str, list[QueueJobDTO]] = {
+            job_type: list(jobs) for job_type, jobs in ready.items()
+        }
+        self._jobs: dict[int, QueueJobDTO] = {
+            job.id: job for jobs in ready.values() for job in jobs
+        }
+        self.fetch_calls: list[str] = []
+        self.lease_calls: list[tuple[int, str, int | None]] = []
+
+    def fetch_ready(self, job_type: str, *, limit: int = 100) -> list[QueueJobDTO]:  # noqa: D401 - signature parity
+        self.fetch_calls.append(job_type)
+        return list(self._ready.pop(job_type, []))
+
+    def lease(
+        self,
+        job_id: int,
+        *,
+        job_type: str,
+        lease_seconds: int | None = None,
+    ) -> QueueJobDTO | None:  # noqa: D401 - signature parity
+        self.lease_calls.append((job_id, job_type, lease_seconds))
+        return self._jobs.get(job_id)
+
+
+def make_job(job_id: int, job_type: str, priority: int, available_delta: int) -> QueueJobDTO:
+    available_at = datetime.utcnow() + timedelta(seconds=available_delta)
+    return QueueJobDTO(
+        id=job_id,
+        type=job_type,
+        payload={},
+        priority=priority,
+        attempts=0,
+        available_at=available_at,
+        lease_expires_at=None,
+        status=QueueJobStatus.PENDING,
+        idempotency_key=None,
+        last_error=None,
+        result_payload=None,
+        lease_timeout_seconds=60,
+    )
+
+
+def test_priority_config_prefers_json_over_csv() -> None:
+    env = {
+        "ORCH_PRIORITY_JSON": "{\"sync\": 200, \"matching\": 100}",
+        "ORCH_PRIORITY_CSV": "sync:1,matching:1",
+    }
+    config = PriorityConfig.from_env(env)
+    assert config.priorities == {"sync": 200, "matching": 100}
+    assert config.job_types == ("sync", "matching")
+
+
+def test_priority_config_falls_back_to_csv(monkeypatch: pytest.MonkeyPatch) -> None:
+    env: dict[str, str] = {
+        "ORCH_PRIORITY_JSON": "{invalid}",
+        "ORCH_PRIORITY_CSV": "sync:50,matching:25",
+    }
+    config = PriorityConfig.from_env(env)
+    assert config.priorities == {"sync": 50, "matching": 25}
+
+
+@pytest.mark.asyncio
+async def test_scheduler_leases_jobs_in_priority_order(caplog: pytest.LogCaptureFixture) -> None:
+    caplog.set_level("INFO", logger="app.orchestrator.scheduler")
+
+    jobs = {
+        "sync": [make_job(1, "sync", 200, 5), make_job(2, "sync", 150, 3)],
+        "matching": [make_job(3, "matching", 250, 1)],
+    }
+    stub = StubPersistence(jobs)
+    config = PriorityConfig(priorities={"sync": 1, "matching": 1})
+    scheduler = Scheduler(
+        priority_config=config,
+        poll_interval_ms=10,
+        visibility_timeout=42,
+        persistence_module=stub,
+    )
+
+    lifespan = asyncio.Event()
+    run_task = asyncio.create_task(scheduler.run(lifespan))
+
+    while len(stub.lease_calls) < 3:
+        await asyncio.sleep(0)
+
+    scheduler.request_stop()
+    await run_task
+
+    assert stub.fetch_calls == ["matching", "sync"]
+    assert [call[:2] for call in stub.lease_calls] == [
+        (3, "matching"),
+        (1, "sync"),
+        (2, "sync"),
+    ]
+    assert all(call[2] == 42 for call in stub.lease_calls)
+
+    lease_events = [
+        (record.job_type, record.job_id, record.status)
+        for record in caplog.records
+        if getattr(record, "event", "") == "orchestrator.lease"
+    ]
+    assert lease_events == [
+        ("matching", 3, "leased"),
+        ("sync", 1, "leased"),
+        ("sync", 2, "leased"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_scheduler_stops_when_lifespan_signal_set() -> None:
+    config = PriorityConfig(priorities={"sync": 1})
+    stub = StubPersistence({"sync": []})
+    scheduler = Scheduler(priority_config=config, poll_interval_ms=10, persistence_module=stub)
+
+    lifespan = asyncio.Event()
+    task = asyncio.create_task(scheduler.run(lifespan))
+    lifespan.set()
+    await asyncio.wait_for(task, timeout=1)


### PR DESCRIPTION
## Summary
- add a PriorityConfig parser that prefers ORCH_PRIORITY_JSON with CSV fallback
- implement an async orchestrator Scheduler that leases jobs with structured logging
- expose the scheduler package API and cover it with unit tests

## Testing
- pytest tests/orchestrator/test_scheduler.py

------
https://chatgpt.com/codex/tasks/task_e_68dcfe8610c883218e6b50d6a577a68b