### PR TITLE
feat: add orchestrator dispatcher runtime

### DIFF
--- a/app/orchestrator/__init__.py
+++ b/app/orchestrator/__init__.py
@@ -1,9 +1,11 @@
 """Worker orchestration helpers."""
 
+from .dispatcher import Dispatcher
 from .handlers import enqueue_spotify_backfill, get_spotify_backfill_status
 from .scheduler import PriorityConfig, Scheduler
 
 __all__ = [
+    "Dispatcher",
     "enqueue_spotify_backfill",
     "get_spotify_backfill_status",
     "PriorityConfig",

--- a/app/orchestrator/dispatcher.py
+++ b/app/orchestrator/dispatcher.py
@@ -1,0 +1,351 @@
+"""Asynchronous dispatcher coordinating orchestrated queue jobs."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import os
+import random
+import time
+from collections.abc import Awaitable, Callable, Mapping
+from dataclasses import dataclass
+from typing import Any
+
+from app.logging import get_logger
+from app.logging_events import log_event
+from app.orchestrator.scheduler import Scheduler
+from app.workers import persistence
+
+
+JobHandler = Callable[[persistence.QueueJobDTO], Awaitable[Mapping[str, Any] | None]]
+
+_DEFAULT_GLOBAL_CONCURRENCY = 10
+_DEFAULT_BACKOFF_BASE_MS = 500
+_DEFAULT_RETRY_MAX = 3
+_DEFAULT_JITTER = 0.2
+_MAX_BACKOFF_EXPONENT = 10
+_HEARTBEAT_FRACTION = 0.5
+_STOP_REASON_MAX_RETRIES = "max_retries_exhausted"
+
+
+@dataclass(slots=True)
+class _PoolLimits:
+    global_limit: int
+    pool: dict[str, int]
+
+
+def _parse_positive_int(value: str | None, default: int) -> int:
+    if value is None:
+        return default
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return default
+    return parsed if parsed > 0 else default
+
+
+def _parse_non_negative_float(value: str | None, default: float) -> float:
+    if value is None:
+        return default
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return default
+    return parsed if parsed >= 0 else default
+
+
+class Dispatcher:
+    """Coordinate leased queue jobs and execute handlers with concurrency control."""
+
+    def __init__(
+        self,
+        scheduler: Scheduler,
+        handlers: Mapping[str, JobHandler],
+        *,
+        persistence_module=persistence,
+        global_concurrency: int | None = None,
+        pool_concurrency: Mapping[str, int] | None = None,
+        rng: random.Random | None = None,
+    ) -> None:
+        self._scheduler = scheduler
+        self._handlers = {job_type: handler for job_type, handler in handlers.items()}
+        self._persistence = persistence_module
+        self._logger = get_logger(__name__)
+        self._rng = rng or random.Random()
+        limits = self._resolve_limits(global_concurrency, pool_concurrency)
+        self._global_limit = limits.global_limit
+        self._global_semaphore = asyncio.Semaphore(self._global_limit)
+        self._pool_limits = limits.pool
+        self._pool_semaphores: dict[str, asyncio.Semaphore] = {}
+        self._tasks: set[asyncio.Task[None]] = set()
+        self._stop_event = asyncio.Event()
+        self._retry_max = _parse_positive_int(
+            os.getenv("EXTERNAL_RETRY_MAX"), _DEFAULT_RETRY_MAX
+        )
+        self._backoff_base_ms = _parse_positive_int(
+            os.getenv("EXTERNAL_BACKOFF_BASE_MS"), _DEFAULT_BACKOFF_BASE_MS
+        )
+        self._retry_jitter_pct = _parse_non_negative_float(
+            os.getenv("EXTERNAL_JITTER_PCT"), _DEFAULT_JITTER
+        )
+
+    async def run(self, lifespan: asyncio.Event | None = None) -> None:
+        """Run the dispatcher loop until a stop signal or lifespan event is set."""
+
+        self._stop_event = asyncio.Event()
+        try:
+            while not self._should_stop(lifespan):
+                leased = self._scheduler.lease_ready_jobs()
+                for job in leased:
+                    self._start_job(job)
+                self._collect_finished_tasks()
+                if not leased:
+                    await asyncio.sleep(self._scheduler.poll_interval)
+        finally:
+            self._stop_event.set()
+            await self._await_all_tasks()
+
+    def request_stop(self) -> None:
+        """Signal the dispatcher to exit the run loop."""
+
+        self._stop_event.set()
+
+    def _should_stop(self, lifespan: asyncio.Event | None) -> bool:
+        if self._stop_event.is_set():
+            return True
+        if lifespan is not None and lifespan.is_set():
+            return True
+        return False
+
+    def _start_job(self, job: persistence.QueueJobDTO) -> None:
+        handler = self._handlers.get(job.type)
+        if handler is None:
+            log_event(
+                self._logger,
+                "orchestrator.dlq",
+                job_type=job.type,
+                job_id=job.id,
+                status="missing_handler",
+            )
+            self._persistence.to_dlq(
+                job.id,
+                job_type=job.type,
+                reason="handler_missing",
+                payload=job.payload,
+            )
+            return
+
+        task = asyncio.create_task(self._execute_job(job, handler))
+        self._tasks.add(task)
+        task.add_done_callback(self._tasks.discard)
+
+    async def _execute_job(
+        self,
+        job: persistence.QueueJobDTO,
+        handler: JobHandler,
+    ) -> None:
+        async with self._acquire_slots(job.type):
+            start = time.perf_counter()
+            log_event(
+                self._logger,
+                "orchestrator.dispatch",
+                job_type=job.type,
+                job_id=job.id,
+                attempts=int(job.attempts),
+            )
+            stop_heartbeat = asyncio.Event()
+            heartbeat_task = asyncio.create_task(
+                self._maintain_heartbeat(job, stop_heartbeat)
+            )
+            try:
+                result_payload = await handler(job)
+            except asyncio.CancelledError:
+                stop_heartbeat.set()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await heartbeat_task
+                raise
+            except Exception as exc:
+                stop_heartbeat.set()
+                await self._handle_failure(job, exc, start)
+            else:
+                stop_heartbeat.set()
+                await self._handle_success(job, result_payload, start)
+            finally:
+                heartbeat_task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await heartbeat_task
+
+    async def _handle_success(
+        self,
+        job: persistence.QueueJobDTO,
+        result_payload: Mapping[str, Any] | None,
+        start: float,
+    ) -> None:
+        duration_ms = int((time.perf_counter() - start) * 1000)
+        self._persistence.complete(
+            job.id,
+            job_type=job.type,
+            result_payload=result_payload,
+        )
+        log_event(
+            self._logger,
+            "orchestrator.commit",
+            job_type=job.type,
+            job_id=job.id,
+            status="succeeded",
+            attempts=int(job.attempts),
+            duration_ms=duration_ms,
+        )
+
+    async def _handle_failure(
+        self,
+        job: persistence.QueueJobDTO,
+        exc: Exception,
+        start: float,
+    ) -> None:
+        duration_ms = int((time.perf_counter() - start) * 1000)
+        message = self._truncate_error(str(exc))
+        attempts = int(job.attempts)
+        if attempts >= self._retry_max:
+            self._persistence.to_dlq(
+                job.id,
+                job_type=job.type,
+                reason=_STOP_REASON_MAX_RETRIES,
+                payload={"error": message, "attempts": attempts},
+            )
+            log_event(
+                self._logger,
+                "orchestrator.dlq",
+                job_type=job.type,
+                job_id=job.id,
+                status="dead_letter",
+                attempts=attempts,
+                duration_ms=duration_ms,
+                stop_reason=_STOP_REASON_MAX_RETRIES,
+                error=message,
+            )
+            return
+
+        retry_delay = max(1, int(self._calculate_backoff_seconds(attempts)))
+        self._persistence.fail(
+            job.id,
+            job_type=job.type,
+            error=message,
+            retry_in=retry_delay,
+        )
+        log_event(
+            self._logger,
+            "orchestrator.commit",
+            job_type=job.type,
+            job_id=job.id,
+            status="retry",
+            attempts=attempts,
+            duration_ms=duration_ms,
+            retry_in=retry_delay,
+            error=message,
+        )
+
+    async def _maintain_heartbeat(
+        self, job: persistence.QueueJobDTO, stop_signal: asyncio.Event
+    ) -> None:
+        interval = self._heartbeat_interval(job)
+        while True:
+            try:
+                await asyncio.wait_for(stop_signal.wait(), timeout=interval)
+            except asyncio.TimeoutError:
+                ok = self._persistence.heartbeat(
+                    job.id,
+                    job_type=job.type,
+                    lease_seconds=job.lease_timeout_seconds,
+                )
+                if not ok:
+                    log_event(
+                        self._logger,
+                        "orchestrator.dispatch",
+                        job_type=job.type,
+                        job_id=job.id,
+                        status="heartbeat_failed",
+                    )
+                continue
+            break
+
+    def _heartbeat_interval(self, job: persistence.QueueJobDTO) -> float:
+        timeout = max(1, int(job.lease_timeout_seconds or 60))
+        return max(1.0, timeout * _HEARTBEAT_FRACTION)
+
+    def _collect_finished_tasks(self) -> None:
+        finished = {task for task in self._tasks if task.done()}
+        for task in finished:
+            try:
+                task.result()
+            except asyncio.CancelledError:  # pragma: no cover - cancellation path
+                pass
+            except Exception:  # pragma: no cover - defensive logging
+                self._logger.exception("Unhandled dispatch task error")
+        self._tasks.difference_update(finished)
+
+    async def _await_all_tasks(self) -> None:
+        if not self._tasks:
+            return
+        await asyncio.gather(*self._tasks, return_exceptions=True)
+        self._tasks.clear()
+
+    @contextlib.asynccontextmanager
+    async def _acquire_slots(self, job_type: str):
+        async with self._global_semaphore:
+            pool_sem = self._get_pool_semaphore(job_type)
+            async with pool_sem:
+                yield
+
+    def _get_pool_semaphore(self, job_type: str) -> asyncio.Semaphore:
+        semaphore = self._pool_semaphores.get(job_type)
+        if semaphore is not None:
+            return semaphore
+        limit = self._pool_limits.get(job_type)
+        if limit is None:
+            limit = self._resolve_pool_limit(job_type)
+            self._pool_limits[job_type] = limit
+        semaphore = asyncio.Semaphore(limit)
+        self._pool_semaphores[job_type] = semaphore
+        return semaphore
+
+    def _resolve_limits(
+        self,
+        global_concurrency: int | None,
+        pool_concurrency: Mapping[str, int] | None,
+    ) -> _PoolLimits:
+        resolved_global = global_concurrency or _parse_positive_int(
+            os.getenv("ORCH_GLOBAL_CONCURRENCY"), _DEFAULT_GLOBAL_CONCURRENCY
+        )
+        resolved_global = max(1, resolved_global)
+        pool: dict[str, int] = {}
+        if pool_concurrency:
+            for job_type, limit in pool_concurrency.items():
+                pool[job_type] = max(1, int(limit))
+        return _PoolLimits(global_limit=resolved_global, pool=pool)
+
+    def _resolve_pool_limit(self, job_type: str) -> int:
+        env_key = f"ORCH_POOL_{job_type.upper()}"
+        env_value = os.getenv(env_key)
+        limit = _parse_positive_int(env_value, self._global_limit)
+        return max(1, limit)
+
+    def _calculate_backoff_seconds(self, attempts: int) -> float:
+        exponent = max(0, min(attempts - 1, _MAX_BACKOFF_EXPONENT))
+        base_ms = max(1, self._backoff_base_ms)
+        delay_ms = base_ms * (2**exponent)
+        if self._retry_jitter_pct:
+            jitter = self._rng.uniform(1 - self._retry_jitter_pct, 1 + self._retry_jitter_pct)
+        else:
+            jitter = 1.0
+        return max(0.0, delay_ms * jitter) / 1000.0
+
+    @staticmethod
+    def _truncate_error(message: str, limit: int = 512) -> str:
+        text = message.strip()
+        if len(text) <= limit:
+            return text
+        return text[: limit - 1] + "…"
+
+
+__all__ = ["Dispatcher", "JobHandler"]

--- a/tests/orchestrator/test_dispatcher.py
+++ b/tests/orchestrator/test_dispatcher.py
@@ -1,0 +1,238 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timedelta
+from typing import Any, Iterable, Mapping
+
+import pytest
+
+from app.models import QueueJobStatus
+from app.orchestrator import dispatcher as dispatcher_module
+from app.orchestrator.dispatcher import Dispatcher
+from app.workers import persistence
+
+
+class StubScheduler:
+    def __init__(self, batches: Iterable[Iterable[persistence.QueueJobDTO]]) -> None:
+        self._batches = [list(batch) for batch in batches]
+        self.poll_interval = 0.01
+
+    def lease_ready_jobs(self) -> list[persistence.QueueJobDTO]:
+        if not self._batches:
+            return []
+        return list(self._batches.pop(0))
+
+
+class StubPersistence:
+    def __init__(self) -> None:
+        self.complete_calls: list[tuple[int, str, Mapping[str, Any] | None]] = []
+        self.fail_calls: list[tuple[int, str, str | None, int | None]] = []
+        self.dlq_calls: list[tuple[int, str, str, Mapping[str, Any] | None]] = []
+        self.heartbeat_calls: list[tuple[int, str, int | None]] = []
+
+    def complete(
+        self,
+        job_id: int,
+        *,
+        job_type: str,
+        result_payload: Mapping[str, Any] | None = None,
+    ) -> bool:
+        self.complete_calls.append((job_id, job_type, result_payload))
+        return True
+
+    def fail(
+        self,
+        job_id: int,
+        *,
+        job_type: str,
+        error: str | None = None,
+        retry_in: int | None = None,
+        available_at: datetime | None = None,
+    ) -> bool:
+        self.fail_calls.append((job_id, job_type, error, retry_in))
+        return True
+
+    def to_dlq(
+        self,
+        job_id: int,
+        *,
+        job_type: str,
+        reason: str,
+        payload: Mapping[str, Any] | None = None,
+    ) -> bool:
+        self.dlq_calls.append((job_id, job_type, reason, payload))
+        return True
+
+    def heartbeat(
+        self,
+        job_id: int,
+        *,
+        job_type: str,
+        lease_seconds: int | None = None,
+    ) -> bool:
+        self.heartbeat_calls.append((job_id, job_type, lease_seconds))
+        return True
+
+
+@pytest.fixture
+def captured_events(monkeypatch: pytest.MonkeyPatch) -> list[tuple[str, Mapping[str, Any]]]:
+    events: list[tuple[str, Mapping[str, Any]]] = []
+
+    def recorder(logger: Any, event: str, /, **fields: Any) -> None:  # noqa: ANN401 - test helper
+        events.append((event, dict(fields)))
+
+    monkeypatch.setattr(dispatcher_module, "log_event", recorder)
+    return events
+
+
+def make_job(
+    job_id: int,
+    job_type: str,
+    *,
+    attempts: int,
+    lease_timeout: int = 2,
+    payload: Mapping[str, Any] | None = None,
+) -> persistence.QueueJobDTO:
+    now = datetime.utcnow()
+    return persistence.QueueJobDTO(
+        id=job_id,
+        type=job_type,
+        payload=dict(payload or {}),
+        priority=10,
+        attempts=attempts,
+        available_at=now,
+        lease_expires_at=now + timedelta(seconds=lease_timeout),
+        status=QueueJobStatus.LEASED,
+        idempotency_key=None,
+        last_error=None,
+        result_payload=None,
+        lease_timeout_seconds=lease_timeout,
+    )
+
+
+@pytest.mark.asyncio
+async def test_dispatcher_executes_job_and_marks_complete(
+    caplog: pytest.LogCaptureFixture, captured_events: list[tuple[str, Mapping[str, Any]]]
+) -> None:
+    caplog.set_level("INFO", logger="app.orchestrator.dispatcher")
+    job = make_job(1, "sync", attempts=1, payload={"foo": "bar"})
+    scheduler = StubScheduler([[job], []])
+    storage = StubPersistence()
+    executed = asyncio.Event()
+
+    async def handler(record: persistence.QueueJobDTO) -> Mapping[str, Any]:
+        executed.set()
+        return {"handled": record.id}
+
+    dispatcher = Dispatcher(scheduler, {"sync": handler}, persistence_module=storage)
+
+    task = asyncio.create_task(dispatcher.run())
+    await asyncio.wait_for(executed.wait(), timeout=1)
+    dispatcher.request_stop()
+    await asyncio.wait_for(task, timeout=1)
+
+    assert storage.complete_calls == [(1, "sync", {"handled": 1})]
+    assert storage.fail_calls == []
+    assert storage.dlq_calls == []
+
+    assert captured_events
+    event_name, payload = captured_events[-1]
+    assert event_name == "orchestrator.commit"
+    assert payload["job_type"] == "sync"
+    assert payload["job_id"] == 1
+    assert payload["status"] == "succeeded"
+    assert payload["attempts"] == 1
+
+
+@pytest.mark.asyncio
+async def test_dispatcher_retries_with_backoff(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    captured_events: list[tuple[str, Mapping[str, Any]]],
+) -> None:
+    caplog.set_level("INFO", logger="app.orchestrator.dispatcher")
+    monkeypatch.setenv("EXTERNAL_RETRY_MAX", "3")
+    monkeypatch.setenv("EXTERNAL_BACKOFF_BASE_MS", "1000")
+    monkeypatch.setenv("EXTERNAL_JITTER_PCT", "0")
+
+    job = make_job(2, "sync", attempts=1)
+    scheduler = StubScheduler([[job], []])
+    storage = StubPersistence()
+    failed = asyncio.Event()
+
+    async def handler(_: persistence.QueueJobDTO) -> Mapping[str, Any]:
+        raise RuntimeError("transient failure")
+
+    def fail_hook(*args: Any, **kwargs: Any) -> bool:
+        result = StubPersistence.fail(storage, *args, **kwargs)
+        failed.set()
+        return result
+
+    storage.fail = fail_hook  # type: ignore[assignment]
+
+    dispatcher = Dispatcher(scheduler, {"sync": handler}, persistence_module=storage)
+
+    task = asyncio.create_task(dispatcher.run())
+    await asyncio.wait_for(failed.wait(), timeout=1)
+    dispatcher.request_stop()
+    await asyncio.wait_for(task, timeout=1)
+
+    assert storage.fail_calls == [(2, "sync", "transient failure", 1)]
+    assert storage.dlq_calls == []
+    assert storage.complete_calls == []
+
+    assert captured_events
+    event_name, payload = captured_events[-1]
+    assert event_name == "orchestrator.commit"
+    assert payload["status"] == "retry"
+    assert payload["retry_in"] == 1
+
+
+@pytest.mark.asyncio
+async def test_dispatcher_moves_job_to_dlq_when_retries_exhausted(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    captured_events: list[tuple[str, Mapping[str, Any]]],
+) -> None:
+    caplog.set_level("INFO", logger="app.orchestrator.dispatcher")
+    monkeypatch.setenv("EXTERNAL_RETRY_MAX", "2")
+    monkeypatch.setenv("EXTERNAL_BACKOFF_BASE_MS", "100")
+    monkeypatch.setenv("EXTERNAL_JITTER_PCT", "0")
+
+    job = make_job(3, "sync", attempts=2)
+    scheduler = StubScheduler([[job], []])
+    storage = StubPersistence()
+    dead_lettered = asyncio.Event()
+
+    async def handler(_: persistence.QueueJobDTO) -> Mapping[str, Any]:
+        raise RuntimeError("dependency failed")
+
+    def dlq_hook(*args: Any, **kwargs: Any) -> bool:
+        result = StubPersistence.to_dlq(storage, *args, **kwargs)
+        dead_lettered.set()
+        return result
+
+    storage.to_dlq = dlq_hook  # type: ignore[assignment]
+
+    dispatcher = Dispatcher(scheduler, {"sync": handler}, persistence_module=storage)
+
+    task = asyncio.create_task(dispatcher.run())
+    await asyncio.wait_for(dead_lettered.wait(), timeout=1)
+    dispatcher.request_stop()
+    await asyncio.wait_for(task, timeout=1)
+
+    assert storage.dlq_calls == [
+        (
+            3,
+            "sync",
+            "max_retries_exhausted",
+            {"error": "dependency failed", "attempts": 2},
+        )
+    ]
+    assert storage.fail_calls == []
+    assert storage.complete_calls == []
+
+    assert captured_events
+    event_name, payload = captured_events[-1]
+    assert event_name == "orchestrator.dlq"
+    assert payload["stop_reason"] == "max_retries_exhausted"


### PR DESCRIPTION
## Summary
- add an asynchronous Dispatcher that coordinates queue jobs with concurrency guards, heartbeats, and retry/DLQ handling
- expose scheduler helpers so the dispatcher can lease ready jobs using the existing priority logic
- cover the new dispatcher workflow with unit tests for success, retry, and DLQ paths

## Testing
- pytest tests/orchestrator/test_scheduler.py tests/orchestrator/test_dispatcher.py

------
https://chatgpt.com/codex/tasks/task_e_68dd03a200308321b23ca311f9164126