### PR TITLE
feat: bootstrap orchestrator runtime

### DIFF
--- a/app/orchestrator/bootstrap.py
+++ b/app/orchestrator/bootstrap.py
@@ -1,0 +1,72 @@
+"""Bootstrap helpers for orchestrator runtime wiring."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Mapping
+
+from app.dependencies import get_app_config, get_matching_engine, get_soulseek_client, get_spotify_client
+from app.orchestrator.dispatcher import Dispatcher, JobHandler, default_handlers
+from app.orchestrator.scheduler import Scheduler
+from app.orchestrator.handlers import ArtworkService, LyricsService, MetadataService
+from app.orchestrator.providers import (
+    build_matching_handler_deps,
+    build_retry_handler_deps,
+    build_sync_handler_deps,
+    build_watchlist_handler_deps,
+)
+
+
+@dataclass(slots=True)
+class OrchestratorRuntime:
+    """Container bundling orchestrator components and resolved dependencies."""
+
+    scheduler: Scheduler
+    dispatcher: Dispatcher
+    handlers: Mapping[str, JobHandler]
+
+
+def bootstrap_orchestrator(
+    *,
+    metadata_service: MetadataService | None = None,
+    artwork_service: ArtworkService | None = None,
+    lyrics_service: LyricsService | None = None,
+) -> OrchestratorRuntime:
+    """Initialise orchestrator components with shared dependencies."""
+
+    config = get_app_config()
+    soulseek_client = get_soulseek_client()
+    spotify_client = get_spotify_client()
+    matching_engine = get_matching_engine()
+
+    sync_deps = build_sync_handler_deps(
+        soulseek_client=soulseek_client,
+        metadata_service=metadata_service,
+        artwork_service=artwork_service,
+        lyrics_service=lyrics_service,
+    )
+    matching_deps = build_matching_handler_deps(engine=matching_engine)
+    retry_deps = build_retry_handler_deps()
+    watchlist_deps = build_watchlist_handler_deps(
+        spotify_client=spotify_client,
+        soulseek_client=soulseek_client,
+        config=config.watchlist,
+    )
+
+    scheduler = Scheduler()
+    handlers = default_handlers(
+        sync_deps,
+        matching_deps=matching_deps,
+        retry_deps=retry_deps,
+        watchlist_deps=watchlist_deps,
+    )
+    dispatcher = Dispatcher(scheduler, handlers)
+
+    return OrchestratorRuntime(
+        scheduler=scheduler,
+        dispatcher=dispatcher,
+        handlers=handlers,
+    )
+
+
+__all__ = ["OrchestratorRuntime", "bootstrap_orchestrator"]

--- a/app/orchestrator/providers.py
+++ b/app/orchestrator/providers.py
@@ -1,0 +1,110 @@
+"""Factories wiring orchestrator handler dependencies."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from contextlib import AbstractContextManager
+
+from sqlalchemy.orm import Session
+
+from app.config import WatchlistWorkerConfig
+from app.core.matching_engine import MusicMatchingEngine
+from app.core.soulseek_client import SoulseekClient
+from app.core.spotify_client import SpotifyClient
+from app.dependencies import (
+    get_app_config,
+    get_matching_engine,
+    get_soulseek_client,
+    get_spotify_client,
+)
+from app.orchestrator.handlers import (
+    ArtworkService,
+    MatchingHandlerDeps,
+    LyricsService,
+    MetadataService,
+    RetryHandlerDeps,
+    SyncHandlerDeps,
+    SyncJobSubmitter,
+    WatchlistHandlerDeps,
+)
+
+
+def build_sync_handler_deps(
+    *,
+    soulseek_client: SoulseekClient | None = None,
+    metadata_service: MetadataService | None = None,
+    artwork_service: ArtworkService | None = None,
+    lyrics_service: LyricsService | None = None,
+    session_factory: Callable[[], AbstractContextManager[Session]] | None = None,
+) -> SyncHandlerDeps:
+    """Construct orchestrator sync handler dependencies using configured clients."""
+
+    client = soulseek_client or get_soulseek_client()
+    kwargs: dict[str, object] = {}
+    if session_factory is not None:
+        kwargs["session_factory"] = session_factory
+    return SyncHandlerDeps(
+        soulseek_client=client,
+        metadata_service=metadata_service,
+        artwork_service=artwork_service,
+        lyrics_service=lyrics_service,
+        **kwargs,
+    )
+
+
+def build_matching_handler_deps(
+    *,
+    engine: MusicMatchingEngine | None = None,
+    session_factory: Callable[[], AbstractContextManager[Session]] | None = None,
+) -> MatchingHandlerDeps:
+    """Return matching handler dependencies bound to the configured engine."""
+
+    resolved_engine = engine or get_matching_engine()
+    kwargs: dict[str, object] = {}
+    if session_factory is not None:
+        kwargs["session_factory"] = session_factory
+    return MatchingHandlerDeps(engine=resolved_engine, **kwargs)
+
+
+def build_retry_handler_deps(
+    *,
+    submit_sync_job: SyncJobSubmitter | None = None,
+    session_factory: Callable[[], AbstractContextManager[Session]] | None = None,
+) -> RetryHandlerDeps:
+    """Create retry handler dependencies with optional overrides."""
+
+    kwargs: dict[str, object] = {}
+    if submit_sync_job is not None:
+        kwargs["submit_sync_job"] = submit_sync_job
+    if session_factory is not None:
+        kwargs["session_factory"] = session_factory
+    return RetryHandlerDeps(**kwargs)
+
+
+def build_watchlist_handler_deps(
+    *,
+    spotify_client: SpotifyClient | None = None,
+    soulseek_client: SoulseekClient | None = None,
+    config: WatchlistWorkerConfig | None = None,
+    submit_sync_job: SyncJobSubmitter | None = None,
+) -> WatchlistHandlerDeps:
+    """Return watchlist handler dependencies bound to configured services."""
+
+    resolved_config = config or get_app_config().watchlist
+    kwargs: dict[str, object] = {}
+    if submit_sync_job is not None:
+        kwargs["submit_sync_job"] = submit_sync_job
+    return WatchlistHandlerDeps(
+        spotify_client=spotify_client or get_spotify_client(),
+        soulseek_client=soulseek_client or get_soulseek_client(),
+        config=resolved_config,
+        **kwargs,
+    )
+
+
+__all__ = [
+    "build_sync_handler_deps",
+    "build_matching_handler_deps",
+    "build_retry_handler_deps",
+    "build_watchlist_handler_deps",
+]


### PR DESCRIPTION
## Summary
- add an orchestrator bootstrap module that wires core clients, handler dependencies, and dispatcher scheduling
- update the FastAPI lifespan to start/stop the orchestrator runtime and keep artwork/lyrics workers as optional companions
- centralize handler dependency construction in orchestrator/providers for dependency-injected factories

## Testing
- pytest tests/orchestrator -q

------
https://chatgpt.com/codex/tasks/task_e_68dd2da01e9c83218b36bdced0b4b16f