### PR TITLE
Add orchestrator worker regression tests [CODX-000]

### DIFF
--- a/app/core/matching_engine.py
+++ b/app/core/matching_engine.py
@@ -466,8 +466,7 @@ class MusicMatchingEngine:
                 or getattr(soulseek_entry, "username", "")
             )
             candidate_artist = str(
-                candidate_mapping.get("artist")
-                or getattr(soulseek_entry, "artist", "")
+                candidate_mapping.get("artist") or getattr(soulseek_entry, "artist", "")
             )
             bitrate_value = (
                 candidate_mapping.get("bitrate")

--- a/app/integrations/contracts.py
+++ b/app/integrations/contracts.py
@@ -137,4 +137,3 @@ __all__ = [
     "SearchQuery",
     "TrackProvider",
 ]
-

--- a/app/integrations/normalizers.py
+++ b/app/integrations/normalizers.py
@@ -60,7 +60,9 @@ def _iter_sequence(obj: Any) -> Iterable[Any]:
     return (obj,)
 
 
-def normalize_spotify_track(payload: Mapping[str, Any] | Any, *, provider: str = "spotify") -> ProviderTrack:
+def normalize_spotify_track(
+    payload: Mapping[str, Any] | Any, *, provider: str = "spotify"
+) -> ProviderTrack:
     """Convert a Spotify track payload into :class:`ProviderTrack`."""
 
     def _get(value: Any, key: str, default: Any = None) -> Any:
@@ -97,11 +99,7 @@ def normalize_spotify_track(payload: Mapping[str, Any] | Any, *, provider: str =
         artist_metadata: dict[str, Any] = {}
         genres = _get(entry, "genres")
         if genres:
-            genre_list = [
-                str(item)
-                for item in _iter_sequence(genres)
-                if _coerce_str(item)
-            ]
+            genre_list = [str(item) for item in _iter_sequence(genres) if _coerce_str(item)]
             if genre_list:
                 artist_metadata["genres"] = tuple(genre_list)
                 aggregated_genres.update(genre_list)
@@ -137,11 +135,7 @@ def normalize_spotify_track(payload: Mapping[str, Any] | Any, *, provider: str =
             album_artist_metadata: dict[str, Any] = {}
             genres = _get(entry, "genres")
             if genres:
-                genre_list = [
-                    str(item)
-                    for item in _iter_sequence(genres)
-                    if _coerce_str(item)
-                ]
+                genre_list = [str(item) for item in _iter_sequence(genres) if _coerce_str(item)]
                 if genre_list:
                     album_artist_metadata["genres"] = tuple(genre_list)
             album_artists.append(
@@ -208,21 +202,14 @@ def normalize_slskd_candidate(
         or _coerce_str(payload.get("filename"))
         or "Unknown Track"
     )
-    artist = (
-        _coerce_str(payload.get("artist"))
-        or _coerce_str(payload.get("uploader"))
-    )
+    artist = _coerce_str(payload.get("artist")) or _coerce_str(payload.get("uploader"))
     format_name = _coerce_str(payload.get("format"))
     if format_name:
         format_name = format_name.upper()
     bitrate = _coerce_int(payload.get("bitrate") or payload.get("bitrate_kbps"))
     if bitrate is not None and bitrate <= 0:
         bitrate = None
-    size = _coerce_int(
-        payload.get("size")
-        or payload.get("size_bytes")
-        or payload.get("filesize")
-    )
+    size = _coerce_int(payload.get("size") or payload.get("size_bytes") or payload.get("filesize"))
     if size is not None and size < 0:
         size = None
     seeders = _coerce_int(

--- a/app/integrations/provider_gateway.py
+++ b/app/integrations/provider_gateway.py
@@ -64,7 +64,9 @@ class ProviderGatewayTimeoutError(ProviderGatewayError):
 
 
 class ProviderGatewayValidationError(ProviderGatewayError):
-    def __init__(self, provider: str, *, status_code: int | None, cause: Exception | None = None) -> None:
+    def __init__(
+        self, provider: str, *, status_code: int | None, cause: Exception | None = None
+    ) -> None:
         super().__init__(provider, f"{provider} rejected the request", cause=cause)
         self.status_code = status_code
 
@@ -86,13 +88,17 @@ class ProviderGatewayRateLimitedError(ProviderGatewayError):
 
 
 class ProviderGatewayNotFoundError(ProviderGatewayError):
-    def __init__(self, provider: str, *, status_code: int | None, cause: Exception | None = None) -> None:
+    def __init__(
+        self, provider: str, *, status_code: int | None, cause: Exception | None = None
+    ) -> None:
         super().__init__(provider, f"{provider} returned no results", cause=cause)
         self.status_code = status_code
 
 
 class ProviderGatewayDependencyError(ProviderGatewayError):
-    def __init__(self, provider: str, *, status_code: int | None, cause: Exception | None = None) -> None:
+    def __init__(
+        self, provider: str, *, status_code: int | None, cause: Exception | None = None
+    ) -> None:
         super().__init__(provider, f"{provider} dependency failure", cause=cause)
         self.status_code = status_code
 
@@ -206,7 +212,9 @@ class ProviderGateway:
                     tracks=tracks,
                 )
             except asyncio.TimeoutError as exc:
-                error = ProviderGatewayTimeoutError(track_provider.name, policy.timeout_ms, cause=exc)
+                error = ProviderGatewayTimeoutError(
+                    track_provider.name, policy.timeout_ms, cause=exc
+                )
             except ProviderTimeoutError as exc:
                 error = ProviderGatewayTimeoutError(track_provider.name, exc.timeout_ms, cause=exc)
             except ProviderValidationError as exc:
@@ -334,4 +342,3 @@ __all__ = [
     "ProviderGatewaySearchResult",
     "ProviderRetryPolicy",
 ]
-

--- a/app/main.py
+++ b/app/main.py
@@ -29,7 +29,12 @@ if sys.version_info < (3, 11):  # pragma: no cover - Python <3.11 fallback
 from app.api.router_registry import compose_prefix as build_router_prefix, get_domain_routers
 from app.config import AppConfig, SecurityConfig
 from app.core.config import DEFAULT_SETTINGS
-from app.dependencies import get_app_config, get_soulseek_client, get_spotify_client, require_api_key
+from app.dependencies import (
+    get_app_config,
+    get_soulseek_client,
+    get_spotify_client,
+    require_api_key,
+)
 from app.db import get_session, init_db
 from app.logging import configure_logging, get_logger
 from app.logging_events import log_event
@@ -329,7 +334,9 @@ def _configure_application(config: AppConfig) -> None:
 def _emit_worker_config_event(config: AppConfig, *, workers_enabled: bool) -> None:
     watchlist_config = config.watchlist
     interval_seconds = _resolve_watchlist_interval(os.getenv("WATCHLIST_INTERVAL"))
-    timer_interval_seconds = _resolve_watchlist_timer_interval(os.getenv("WATCHLIST_TIMER_INTERVAL_S"))
+    timer_interval_seconds = _resolve_watchlist_timer_interval(
+        os.getenv("WATCHLIST_TIMER_INTERVAL_S")
+    )
     timer_enabled = _env_as_bool(os.getenv("WATCHLIST_TIMER_ENABLED"), default=True)
     visibility_timeout = _resolve_visibility_timeout(os.getenv("WORKER_VISIBILITY_TIMEOUT_S"))
 
@@ -506,7 +513,12 @@ async def _stop_orchestrator_workers(app: FastAPI) -> None:
     if tasks:
         await asyncio.gather(*tasks, return_exceptions=True)
 
-    for attribute in ("orchestrator_tasks", "orchestrator_stop_event", "orchestrator_runtime", "watchlist_timer"):
+    for attribute in (
+        "orchestrator_tasks",
+        "orchestrator_stop_event",
+        "orchestrator_runtime",
+        "watchlist_timer",
+    ):
         if hasattr(state, attribute):
             delattr(state, attribute)
 

--- a/app/models.py
+++ b/app/models.py
@@ -278,12 +278,8 @@ class QueueJobStatus(str, Enum):
 class QueueJob(Base):
     __tablename__ = "queue_jobs"
     __table_args__ = (
-        CheckConstraint(
-            "priority >= 0", name="ck_queue_jobs_priority_non_negative"
-        ),
-        CheckConstraint(
-            "attempts >= 0", name="ck_queue_jobs_attempts_non_negative"
-        ),
+        CheckConstraint("priority >= 0", name="ck_queue_jobs_priority_non_negative"),
+        CheckConstraint("attempts >= 0", name="ck_queue_jobs_attempts_non_negative"),
         CheckConstraint(
             "status IN ('pending','leased','completed','failed','cancelled')",
             name="ck_queue_jobs_status_valid",

--- a/app/orchestrator/bootstrap.py
+++ b/app/orchestrator/bootstrap.py
@@ -5,7 +5,12 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Mapping
 
-from app.dependencies import get_app_config, get_matching_engine, get_soulseek_client, get_spotify_client
+from app.dependencies import (
+    get_app_config,
+    get_matching_engine,
+    get_soulseek_client,
+    get_spotify_client,
+)
 from app.orchestrator.dispatcher import Dispatcher, JobHandler, default_handlers
 from app.orchestrator.scheduler import Scheduler
 from app.orchestrator.handlers import ArtworkService, LyricsService, MetadataService

--- a/app/orchestrator/dispatcher.py
+++ b/app/orchestrator/dispatcher.py
@@ -54,6 +54,7 @@ def default_handlers(
         handlers["watchlist"] = build_watchlist_handler(watchlist_deps)
     return handlers
 
+
 _DEFAULT_GLOBAL_CONCURRENCY = 10
 _DEFAULT_BACKOFF_BASE_MS = 500
 _DEFAULT_RETRY_MAX = 3
@@ -118,9 +119,7 @@ class Dispatcher:
         self.started: asyncio.Event = asyncio.Event()
         self.stopped: asyncio.Event = asyncio.Event()
         self.stop_requested: bool = False
-        self._retry_max = _parse_positive_int(
-            os.getenv("EXTERNAL_RETRY_MAX"), _DEFAULT_RETRY_MAX
-        )
+        self._retry_max = _parse_positive_int(os.getenv("EXTERNAL_RETRY_MAX"), _DEFAULT_RETRY_MAX)
         self._backoff_base_ms = _parse_positive_int(
             os.getenv("EXTERNAL_BACKOFF_BASE_MS"), _DEFAULT_BACKOFF_BASE_MS
         )
@@ -214,9 +213,7 @@ class Dispatcher:
                 attempts=int(job.attempts),
             )
             stop_heartbeat = asyncio.Event()
-            heartbeat_task = asyncio.create_task(
-                self._maintain_heartbeat(job, stop_heartbeat)
-            )
+            heartbeat_task = asyncio.create_task(self._maintain_heartbeat(job, stop_heartbeat))
             try:
                 result_payload = await handler(job)
             except MatchingJobError as exc:

--- a/app/orchestrator/events.py
+++ b/app/orchestrator/events.py
@@ -210,4 +210,3 @@ __all__ = [
     "emit_timer_event",
     "format_datetime",
 ]
-

--- a/app/orchestrator/scheduler.py
+++ b/app/orchestrator/scheduler.py
@@ -102,8 +102,14 @@ class Scheduler:
         persistence_module=persistence,
     ) -> None:
         self._priority = priority_config or PriorityConfig.from_env()
-        poll_ms = poll_interval_ms if poll_interval_ms is not None else self._resolve_poll_interval()
-        timeout_s = visibility_timeout if visibility_timeout is not None else self._resolve_visibility_timeout()
+        poll_ms = (
+            poll_interval_ms if poll_interval_ms is not None else self._resolve_poll_interval()
+        )
+        timeout_s = (
+            visibility_timeout
+            if visibility_timeout is not None
+            else self._resolve_visibility_timeout()
+        )
         self._poll_interval = max(0.0, poll_ms / 1000.0)
         self._visibility_timeout = max(1, timeout_s)
         self._persistence = persistence_module

--- a/app/orchestrator/timer.py
+++ b/app/orchestrator/timer.py
@@ -54,8 +54,9 @@ class WatchlistTimer:
         persistence_module=persistence,
         now_factory: Callable[[], datetime] = datetime.utcnow,
         time_source: Callable[[], float] = time.perf_counter,
-        on_jobs_enqueued: Callable[[Sequence[persistence.QueueJobDTO]], Awaitable[None] | None]
-        | None = None,
+        on_jobs_enqueued: (
+            Callable[[Sequence[persistence.QueueJobDTO]], Awaitable[None] | None] | None
+        ) = None,
     ) -> None:
         self._config = config
         self._interval = _coerce_interval(interval_seconds, _DEFAULT_INTERVAL_SECONDS)
@@ -252,9 +253,7 @@ class WatchlistTimer:
             cutoff=cutoff,
         )
 
-    async def _enqueue_artist(
-        self, artist: WatchlistArtistRow
-    ) -> persistence.QueueJobDTO | None:
+    async def _enqueue_artist(self, artist: WatchlistArtistRow) -> persistence.QueueJobDTO | None:
         payload: dict[str, object] = {"artist_id": int(artist.id)}
         cutoff = artist.last_checked.isoformat() if artist.last_checked else None
         if cutoff:

--- a/app/routers/search_router.py
+++ b/app/routers/search_router.py
@@ -175,9 +175,7 @@ def _collect_candidates(
     return aggregated, failures
 
 
-def _build_candidates_from_track(
-    track: ProviderTrack, source: SourceLiteral
-) -> list[Candidate]:
+def _build_candidates_from_track(track: ProviderTrack, source: SourceLiteral) -> list[Candidate]:
     track_artists = [artist.name for artist in track.artists if artist.name]
     album_name = track.album.name if track.album else None
     track_metadata = _mapping_to_dict(track.metadata)

--- a/app/routers/spotify_router.py
+++ b/app/routers/spotify_router.py
@@ -71,7 +71,9 @@ def _get_spotify_service(
 
 
 @router.get("/mode", response_model=SpotifyModeResponse)
-def get_spotify_mode(service: SpotifyDomainService = Depends(_get_spotify_service)) -> SpotifyModeResponse:
+def get_spotify_mode(
+    service: SpotifyDomainService = Depends(_get_spotify_service),
+) -> SpotifyModeResponse:
     return SpotifyModeResponse(mode=service.get_mode())
 
 

--- a/app/routers/system_router.py
+++ b/app/routers/system_router.py
@@ -245,9 +245,7 @@ def _matching_queue_size(_: Request) -> int:
             .select_from(QueueJob)
             .where(
                 QueueJob.type == "matching",
-                QueueJob.status.in_(
-                    [QueueJobStatus.PENDING.value, QueueJobStatus.LEASED.value]
-                ),
+                QueueJob.status.in_([QueueJobStatus.PENDING.value, QueueJobStatus.LEASED.value]),
             )
         )
         count = result.scalar_one_or_none()
@@ -262,8 +260,12 @@ _WORKERS: Dict[str, WorkerDescriptor] = {
     "watchlist": WorkerDescriptor(attr="watchlist_worker", queue_literal="n/a"),
     "artwork": WorkerDescriptor(attr="artwork_worker", queue_literal="n/a"),
     "lyrics": WorkerDescriptor(attr="lyrics_worker", queue_literal="n/a"),
-    "scheduler": WorkerDescriptor(attr=None, queue_literal="n/a", orchestrator_component="scheduler"),
-    "dispatcher": WorkerDescriptor(attr=None, queue_literal="n/a", orchestrator_component="dispatcher"),
+    "scheduler": WorkerDescriptor(
+        attr=None, queue_literal="n/a", orchestrator_component="scheduler"
+    ),
+    "dispatcher": WorkerDescriptor(
+        attr=None, queue_literal="n/a", orchestrator_component="dispatcher"
+    ),
     "watchlist_timer": WorkerDescriptor(
         attr=None,
         queue_literal="n/a",

--- a/app/services/health.py
+++ b/app/services/health.py
@@ -72,9 +72,7 @@ class HealthService:
             if normalized not in dependency_names:
                 dependency_names.append(normalized)
         self._dependency_names = tuple(dict.fromkeys(dependency_names))
-        self._dependency_probes = {
-            name.lower(): probe for name, probe in resolved_probes.items()
-        }
+        self._dependency_probes = {name.lower(): probe for name, probe in resolved_probes.items()}
 
     def liveness(self) -> HealthSummary:
         """Return process information for the liveness probe."""

--- a/app/services/integration_service.py
+++ b/app/services/integration_service.py
@@ -100,7 +100,9 @@ class IntegrationService:
             raise DependencyError(f"{provider} search timed out.") from exc
         except ProviderGatewayDependencyError as exc:
             meta = {"provider_status": exc.status_code} if exc.status_code is not None else None
-            raise DependencyError(f"{provider} search is currently unavailable.", meta=meta) from exc
+            raise DependencyError(
+                f"{provider} search is currently unavailable.", meta=meta
+            ) from exc
         except ProviderGatewayInternalError as exc:
             raise InternalServerError(f"Failed to process {provider} search results.") from exc
         except ProviderGatewayError as exc:  # pragma: no cover - defensive guard
@@ -132,4 +134,3 @@ class IntegrationService:
 
 
 __all__ = ["IntegrationService", "ProviderHealth"]
-

--- a/app/services/spotify_domain_service.py
+++ b/app/services/spotify_domain_service.py
@@ -47,9 +47,12 @@ class SpotifyDomainService:
         spotify_client: SpotifyClient,
         soulseek_client: SoulseekClient,
         app_state: Any,
-        free_ingest_factory: Callable[[AppConfig, SoulseekClient, SyncWorker | None], FreeIngestService]
-        | None = None,
-        backfill_service_factory: Callable[[SpotifyConfig, SpotifyClient], BackfillService] | None = None,
+        free_ingest_factory: (
+            Callable[[AppConfig, SoulseekClient, SyncWorker | None], FreeIngestService] | None
+        ) = None,
+        backfill_service_factory: (
+            Callable[[SpotifyConfig, SpotifyClient], BackfillService] | None
+        ) = None,
         backfill_worker_factory: Callable[[BackfillService], BackfillWorker] | None = None,
     ) -> None:
         self._config = config
@@ -57,8 +60,12 @@ class SpotifyDomainService:
         self._soulseek = soulseek_client
         self._state = app_state
         self._free_ingest_factory = free_ingest_factory or self._default_free_ingest_factory
-        self._backfill_service_factory = backfill_service_factory or self._default_backfill_service_factory
-        self._backfill_worker_factory = backfill_worker_factory or self._default_backfill_worker_factory
+        self._backfill_service_factory = (
+            backfill_service_factory or self._default_backfill_service_factory
+        )
+        self._backfill_worker_factory = (
+            backfill_worker_factory or self._default_backfill_worker_factory
+        )
 
     # Factories ---------------------------------------------------------
 

--- a/app/workers/persistence.py
+++ b/app/workers/persistence.py
@@ -530,4 +530,3 @@ __all__ = [
     "update_priority",
     "count_active_leases",
 ]
-

--- a/app/workers/sync_worker.py
+++ b/app/workers/sync_worker.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import os
 import random
-from datetime import datetime, timedelta
+from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Mapping, Optional, Set, Tuple
 
@@ -18,12 +18,7 @@ from app.utils.activity import (
     record_worker_started,
     record_worker_stopped,
 )
-from app.utils.events import (
-    DOWNLOAD_RETRY_COMPLETED,
-    DOWNLOAD_RETRY_FAILED,
-    DOWNLOAD_RETRY_SCHEDULED,
-    WORKER_STOPPED,
-)
+from app.utils.events import WORKER_STOPPED
 from app.utils.settings_store import increment_counter, read_setting, write_setting
 from app.utils.worker_health import mark_worker_status, record_worker_heartbeat
 from app.workers.artwork_worker import ArtworkWorker

--- a/app/workers/watchlist_worker.py
+++ b/app/workers/watchlist_worker.py
@@ -76,7 +76,9 @@ class WatchlistWorker:
         task = self._task
         if task is not None:
             try:
-                await asyncio.wait_for(asyncio.shield(task), timeout=self._config.shutdown_grace_ms / 1000.0)
+                await asyncio.wait_for(
+                    asyncio.shield(task), timeout=self._config.shutdown_grace_ms / 1000.0
+                )
             except asyncio.TimeoutError:
                 task.cancel()
                 with contextlib.suppress(asyncio.CancelledError):

--- a/tests/integrations/test_provider_gateway.py
+++ b/tests/integrations/test_provider_gateway.py
@@ -40,14 +40,18 @@ class _StubProvider:
         return result
 
 
-def _make_config(*, retry_max: int = 2, backoff_ms: int = 10, jitter: float = 0.0) -> ProviderGatewayConfig:
+def _make_config(
+    *, retry_max: int = 2, backoff_ms: int = 10, jitter: float = 0.0
+) -> ProviderGatewayConfig:
     policy = ProviderRetryPolicy(
         timeout_ms=100,
         retry_max=retry_max,
         backoff_base_ms=backoff_ms,
         jitter_pct=jitter,
     )
-    return ProviderGatewayConfig(max_concurrency=5, default_policy=policy, provider_policies={"stub": policy})
+    return ProviderGatewayConfig(
+        max_concurrency=5, default_policy=policy, provider_policies={"stub": policy}
+    )
 
 
 def _search_query() -> SearchQuery:
@@ -89,8 +93,14 @@ async def test_gateway_times_out_long_running_provider() -> None:
     config = _make_config(retry_max=0)
     config = ProviderGatewayConfig(
         max_concurrency=1,
-        default_policy=ProviderRetryPolicy(timeout_ms=10, retry_max=0, backoff_base_ms=10, jitter_pct=0.0),
-        provider_policies={"stub": ProviderRetryPolicy(timeout_ms=10, retry_max=0, backoff_base_ms=10, jitter_pct=0.0)},
+        default_policy=ProviderRetryPolicy(
+            timeout_ms=10, retry_max=0, backoff_base_ms=10, jitter_pct=0.0
+        ),
+        provider_policies={
+            "stub": ProviderRetryPolicy(
+                timeout_ms=10, retry_max=0, backoff_base_ms=10, jitter_pct=0.0
+            )
+        },
     )
     gateway = ProviderGateway(providers={"stub": provider}, config=config)
 
@@ -102,7 +112,10 @@ async def test_gateway_times_out_long_running_provider() -> None:
 @pytest.mark.parametrize(
     "provider_error, expected_error",
     [
-        (ProviderValidationError("stub", "invalid", status_code=400), ProviderGatewayValidationError),
+        (
+            ProviderValidationError("stub", "invalid", status_code=400),
+            ProviderGatewayValidationError,
+        ),
         (
             ProviderRateLimitedError(
                 "stub",
@@ -125,4 +138,3 @@ async def test_gateway_maps_provider_errors(
 
     with pytest.raises(expected_error):
         await gateway.search_tracks("stub", _search_query())
-

--- a/tests/orchestrator/test_dispatcher.py
+++ b/tests/orchestrator/test_dispatcher.py
@@ -11,7 +11,6 @@ from sqlalchemy import select
 
 from app.core.matching_engine import MusicMatchingEngine
 from app.models import QueueJobStatus
-from app.orchestrator import dispatcher as dispatcher_module
 from app.orchestrator.dispatcher import Dispatcher, default_handlers
 from app.orchestrator.handlers import MatchingHandlerDeps, SyncHandlerDeps, SyncRetryPolicy
 from app.workers import persistence

--- a/tests/orchestrator/test_scheduler.py
+++ b/tests/orchestrator/test_scheduler.py
@@ -22,7 +22,9 @@ class StubPersistence:
         self.fetch_calls: list[str] = []
         self.lease_calls: list[tuple[int, str, int | None]] = []
 
-    def fetch_ready(self, job_type: str, *, limit: int = 100) -> list[QueueJobDTO]:  # noqa: D401 - signature parity
+    def fetch_ready(
+        self, job_type: str, *, limit: int = 100
+    ) -> list[QueueJobDTO]:  # noqa: D401 - signature parity
         self.fetch_calls.append(job_type)
         return list(self._ready.pop(job_type, []))
 
@@ -57,7 +59,7 @@ def make_job(job_id: int, job_type: str, priority: int, available_delta: int) ->
 
 def test_priority_config_prefers_json_over_csv() -> None:
     env = {
-        "ORCH_PRIORITY_JSON": "{\"sync\": 200, \"matching\": 100}",
+        "ORCH_PRIORITY_JSON": '{"sync": 200, "matching": 100}',
         "ORCH_PRIORITY_CSV": "sync:1,matching:1",
     }
     config = PriorityConfig.from_env(env)

--- a/tests/orchestrator/test_sync_handler.py
+++ b/tests/orchestrator/test_sync_handler.py
@@ -1,6 +1,6 @@
 import random
 from pathlib import Path
-from typing import Any, Dict, List, Mapping, Optional
+from typing import Any, List, Mapping, Optional
 
 import pytest
 
@@ -291,4 +291,3 @@ async def test_fanout_download_completion_invokes_services(
         assert refreshed.state == "completed"
         assert refreshed.organized_path == str(organized_path)
         assert refreshed.artwork_url == "https://example.com/art.jpg"
-

--- a/tests/services/test_integration_service.py
+++ b/tests/services/test_integration_service.py
@@ -44,7 +44,9 @@ class _StubRegistry:
             raise KeyError(name)
         return self._providers[normalized]
 
-    def track_providers(self) -> dict[str, _StubTrackProvider]:  # pragma: no cover - unused by tests
+    def track_providers(
+        self,
+    ) -> dict[str, _StubTrackProvider]:  # pragma: no cover - unused by tests
         return dict(self._providers)
 
     @property
@@ -146,4 +148,3 @@ async def test_integration_service_normalises_gateway_errors(
 
     with pytest.raises(expected_error):
         await service.search_tracks("slskd", "query")
-

--- a/tests/test_download_retry.py
+++ b/tests/test_download_retry.py
@@ -179,9 +179,7 @@ async def test_retry_enqueues_when_due(monkeypatch: pytest.MonkeyPatch) -> None:
     assert payload["files"][0]["download_id"] == download_id
     assert payload["idempotency_key"] == f"retry:{download_id}"
     assert submission["key"] == f"retry:{download_id}"
-    assert result["scheduled"] == [
-        {"download_id": download_id, "retry_count": 1}
-    ]
+    assert result["scheduled"] == [{"download_id": download_id, "retry_count": 1}]
 
     with session_scope() as session:
         refreshed = session.get(Download, download_id)

--- a/tests/test_e2e_smoke.py
+++ b/tests/test_e2e_smoke.py
@@ -15,7 +15,6 @@ def test_e2e_download_dispatcher_executes(client) -> None:
     assert runtime is not None, "expected orchestrator runtime to be initialised"
 
     dispatcher = runtime.dispatcher
-    scheduler = runtime.scheduler
 
     processed: list[int] = []
 
@@ -82,10 +81,7 @@ def test_e2e_download_dispatcher_executes(client) -> None:
     activity_response = client.get("/activity")
     assert activity_response.status_code == 200
     activity_items = activity_response.json()["items"]
-    assert any(
-        item["type"] == "download" and item["status"] == "queued"
-        for item in activity_items
-    )
+    assert any(item["type"] == "download" and item["status"] == "queued" for item in activity_items)
 
 
 @pytest.mark.lifespan_workers

--- a/tests/test_workers.py
+++ b/tests/test_workers.py
@@ -37,7 +37,9 @@ async def test_sync_worker_persists_jobs() -> None:
         session.flush()
         download_id = download.id
 
-    await worker.enqueue({"username": "tester", "files": [{"id": download_id, "download_id": download_id}]})
+    await worker.enqueue(
+        {"username": "tester", "files": [{"id": download_id, "download_id": download_id}]}
+    )
 
     assert client.downloads, "Download should be triggered even when worker is stopped"
 
@@ -47,5 +49,3 @@ async def test_sync_worker_persists_jobs() -> None:
         assert job.attempts == 1
 
     assert read_setting("metrics.sync.jobs_completed") == "1"
-
-

--- a/tests/workers/test_idempotency.py
+++ b/tests/workers/test_idempotency.py
@@ -18,9 +18,7 @@ def test_idempotent_processing_prevents_duplicates() -> None:
     assert first.id == second.id
 
     with session_scope() as session:
-        stmt = select(QueueJob).where(
-            QueueJob.type == "matching", QueueJob.id == first.id
-        )
+        stmt = select(QueueJob).where(QueueJob.type == "matching", QueueJob.id == first.id)
         jobs = session.execute(stmt).scalars().all()
         assert len(jobs) == 1
         assert jobs[0].payload["payload"]["value"] == 42

--- a/tests/workers/test_matching_worker.py
+++ b/tests/workers/test_matching_worker.py
@@ -99,7 +99,11 @@ async def test_handle_matching_no_candidates_above_threshold() -> None:
 
     payload = {
         "type": "spotify-to-soulseek",
-        "spotify_track": {"id": "track-1", "name": "Sample Song", "artists": [{"name": "Sample Artist"}]},
+        "spotify_track": {
+            "id": "track-1",
+            "name": "Sample Song",
+            "artists": [{"name": "Sample Artist"}],
+        },
         "candidates": [
             {"id": "cand-1", "filename": "Sample Song.mp3", "username": "dj", "bitrate": 192},
         ],

--- a/tests/workers/test_orchestrator_pools.py
+++ b/tests/workers/test_orchestrator_pools.py
@@ -1,0 +1,92 @@
+"""Tests covering dispatcher pool concurrency controls."""
+
+from __future__ import annotations
+
+import asyncio
+import random
+
+import pytest
+
+from app.orchestrator.dispatcher import Dispatcher
+
+
+class _StubScheduler:
+    def __init__(self, jobs: list) -> None:
+        self._jobs = jobs
+        self.poll_interval = 0.01
+
+    def lease_ready_jobs(self):
+        if not self._jobs:
+            return []
+        jobs, self._jobs = self._jobs, []
+        return jobs
+
+    def request_stop(self) -> None:  # pragma: no cover - compatibility shim
+        self._jobs.clear()
+
+
+@pytest.mark.asyncio
+async def test_dispatcher_respects_pool_limits(
+    queue_job_factory,
+    stub_queue_persistence,
+) -> None:
+    jobs = [
+        queue_job_factory(job_id=1, job_type="sync", lease_timeout_seconds=20),
+        queue_job_factory(job_id=2, job_type="sync", lease_timeout_seconds=20),
+    ]
+    scheduler = _StubScheduler(jobs)
+    max_running = 0
+    running = 0
+    completed = 0
+    done = asyncio.Event()
+
+    async def handler(job):  # type: ignore[no-untyped-def]
+        nonlocal max_running, running, completed
+        running += 1
+        max_running = max(max_running, running)
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        running -= 1
+        completed += 1
+        if completed == len(jobs):
+            done.set()
+        return {"job_id": job.id}
+
+    dispatcher = Dispatcher(
+        scheduler,
+        handlers={"sync": handler},
+        persistence_module=stub_queue_persistence,
+        global_concurrency=2,
+        pool_concurrency={"sync": 1},
+        rng=random.Random(42),
+    )
+
+    task = asyncio.create_task(dispatcher.run())
+    await asyncio.wait_for(done.wait(), timeout=1.0)
+    dispatcher.request_stop()
+    await asyncio.wait_for(task, timeout=1.0)
+
+    assert max_running == 1
+    assert stub_queue_persistence.completed == [1, 2]
+
+
+def test_dispatcher_resolves_pool_limit_from_environment(
+    monkeypatch: pytest.MonkeyPatch,
+    stub_queue_persistence,
+) -> None:
+    monkeypatch.setenv("ORCH_POOL_SYNC", "7")
+
+    async def noop(job):  # type: ignore[no-untyped-def]
+        return None
+
+    dispatcher = Dispatcher(
+        _StubScheduler([]),
+        handlers={"sync": noop},
+        persistence_module=stub_queue_persistence,
+        global_concurrency=5,
+    )
+
+    semaphore = dispatcher._get_pool_semaphore("sync")
+
+    assert dispatcher._pool_limits["sync"] == 7
+    assert semaphore._value == 7  # type: ignore[attr-defined]

--- a/tests/workers/test_orchestrator_priority.py
+++ b/tests/workers/test_orchestrator_priority.py
@@ -1,0 +1,39 @@
+"""Tests for orchestrator priority configuration parsing."""
+
+from __future__ import annotations
+
+import json
+
+from app.orchestrator.scheduler import PriorityConfig
+
+
+def test_priority_config_prefers_json_payload() -> None:
+    payload = {"sync": 100, "matching": "60", "retry": 5}
+    env: dict[str, str] = {"ORCH_PRIORITY_JSON": json.dumps(payload)}
+
+    config = PriorityConfig.from_env(env)
+
+    assert config.priorities == {"sync": 100, "matching": 60, "retry": 5}
+    assert config.job_types == ("sync", "matching", "retry")
+
+
+def test_priority_config_invalid_json_falls_back_to_csv() -> None:
+    env = {
+        "ORCH_PRIORITY_JSON": "{not valid",
+        "ORCH_PRIORITY_CSV": "sync:10, retry:5, matching:5",
+    }
+
+    config = PriorityConfig.from_env(env)
+
+    assert config.priorities == {"sync": 10, "retry": 5, "matching": 5}
+    # matching and retry share a priority value, alphabetical order decides
+    assert config.job_types == ("sync", "matching", "retry")
+
+
+def test_priority_config_csv_parser_ignores_invalid_entries() -> None:
+    env = {"ORCH_PRIORITY_CSV": "sync:10, invalid, :5, retry:foo, matching:15"}
+
+    config = PriorityConfig.from_env(env)
+
+    assert config.priorities == {"sync": 10, "matching": 15, "retry": 0}
+    assert config.job_types == ("matching", "sync", "retry")

--- a/tests/workers/test_orchestrator_retries.py
+++ b/tests/workers/test_orchestrator_retries.py
@@ -1,0 +1,63 @@
+"""Retry and dead-letter behaviour for the orchestrator dispatcher."""
+
+from __future__ import annotations
+
+import asyncio
+import random
+
+import pytest
+
+from app.orchestrator.dispatcher import Dispatcher
+
+
+class _StubScheduler:
+    def __init__(self, jobs: list) -> None:
+        self._jobs = jobs
+        self.poll_interval = 0.01
+
+    def lease_ready_jobs(self):
+        if not self._jobs:
+            return []
+        jobs, self._jobs = self._jobs, []
+        return jobs
+
+    def request_stop(self) -> None:  # pragma: no cover - compatibility shim
+        self._jobs.clear()
+
+
+@pytest.mark.asyncio
+async def test_dispatcher_sends_job_to_dlq_after_max_retries(
+    monkeypatch: pytest.MonkeyPatch,
+    queue_job_factory,
+    stub_queue_persistence,
+) -> None:
+    monkeypatch.setenv("EXTERNAL_RETRY_MAX", "2")
+    job = queue_job_factory(job_id=11, job_type="sync", attempts=2, lease_timeout_seconds=30)
+    scheduler = _StubScheduler([job])
+
+    async def failing_handler(job):  # type: ignore[no-untyped-def]
+        raise RuntimeError("boom")
+
+    dispatcher = Dispatcher(
+        scheduler,
+        handlers={"sync": failing_handler},
+        persistence_module=stub_queue_persistence,
+        rng=random.Random(1234),
+    )
+
+    task = asyncio.create_task(dispatcher.run())
+
+    async def _wait_for_dead_letter() -> None:
+        while not stub_queue_persistence.dead_lettered:
+            await asyncio.sleep(0)
+
+    await asyncio.wait_for(_wait_for_dead_letter(), timeout=1.0)
+    dispatcher.request_stop()
+    await asyncio.wait_for(task, timeout=1.0)
+
+    assert stub_queue_persistence.dead_lettered
+    record = stub_queue_persistence.dead_lettered[0]
+    assert record["job_id"] == 11
+    assert record["job_type"] == "sync"
+    assert record["reason"] == "max_retries_exhausted"
+    assert record["payload"]["attempts"] == 2

--- a/tests/workers/test_orchestrator_visibility.py
+++ b/tests/workers/test_orchestrator_visibility.py
@@ -1,0 +1,101 @@
+"""Scheduler and heartbeat behaviour for orchestrator workers."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+import pytest
+
+from app.db import session_scope
+from app.models import QueueJob, QueueJobStatus
+from app.orchestrator.scheduler import PriorityConfig, Scheduler
+from app.workers import persistence
+
+
+def test_scheduler_orders_jobs_by_priority_and_time(
+    queue_job_factory,
+    stub_queue_persistence,
+) -> None:
+    base = datetime(2024, 1, 1, 12, 0, 0)
+    job_retry = queue_job_factory(
+        job_id=1,
+        job_type="retry",
+        priority=10,
+        available_at=base + timedelta(seconds=5),
+    )
+    job_sync_early = queue_job_factory(
+        job_id=2,
+        job_type="sync",
+        priority=20,
+        available_at=base + timedelta(seconds=1),
+    )
+    job_sync_late = queue_job_factory(
+        job_id=3,
+        job_type="sync",
+        priority=20,
+        available_at=base + timedelta(seconds=3),
+    )
+    job_watchlist = queue_job_factory(
+        job_id=4,
+        job_type="watchlist",
+        priority=50,
+        available_at=base + timedelta(seconds=2),
+    )
+
+    for job in (job_retry, job_sync_early, job_sync_late, job_watchlist):
+        stub_queue_persistence.add_ready(job)
+
+    config = PriorityConfig(priorities={"retry": 90, "sync": 60, "watchlist": 30})
+    scheduler = Scheduler(
+        priority_config=config,
+        poll_interval_ms=10,
+        visibility_timeout=30,
+        persistence_module=stub_queue_persistence,
+    )
+
+    leased = scheduler.lease_ready_jobs()
+
+    assert [job.id for job in leased] == [4, 2, 3, 1]
+    assert all(call[2] == 30 for call in stub_queue_persistence.leases)
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_failure_releases_job_for_redelivery(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    current = datetime(2024, 1, 1, 8, 0, 0)
+
+    def fake_now() -> datetime:
+        return current
+
+    monkeypatch.setattr("app.workers.persistence._utcnow", fake_now)
+    scheduler = Scheduler(
+        priority_config=PriorityConfig(priorities={"sync": 100}),
+        poll_interval_ms=0,
+        visibility_timeout=10,
+    )
+
+    job = persistence.enqueue("sync", {"priority": 5, "visibility_timeout": 10})
+
+    first_lease = scheduler.lease_ready_jobs()
+    assert first_lease and first_lease[0].id == job.id
+
+    current = current + timedelta(seconds=5)
+    assert persistence.heartbeat(job.id, job_type="sync") is True
+
+    with session_scope() as session:
+        db_job = session.get(QueueJob, job.id)
+        assert db_job is not None
+        assert db_job.lease_expires_at is not None
+        assert db_job.status == QueueJobStatus.LEASED.value
+
+    current = current + timedelta(seconds=20)
+    assert persistence.heartbeat(job.id, job_type="sync") is False
+
+    second_lease = scheduler.lease_ready_jobs()
+
+    assert any(item.id == job.id for item in second_lease)
+    with session_scope() as session:
+        db_job = session.get(QueueJob, job.id)
+        assert db_job is not None
+        assert db_job.status == QueueJobStatus.LEASED.value

--- a/tests/workers/test_watchlist_defaults.py
+++ b/tests/workers/test_watchlist_defaults.py
@@ -62,13 +62,7 @@ async def test_worker_enqueues_due_artists() -> None:
     assert all(outcome.enqueued for outcome in outcomes)
 
     with session_scope() as session:
-        jobs = (
-            session.execute(
-                select(QueueJob).where(QueueJob.type == "watchlist")
-            )
-            .scalars()
-            .all()
-        )
+        jobs = session.execute(select(QueueJob).where(QueueJob.type == "watchlist")).scalars().all()
         assert len(jobs) == 3
         keys = {job.idempotency_key for job in jobs}
         assert len(keys) == 3
@@ -96,13 +90,7 @@ async def test_worker_idempotency_prevents_duplicates() -> None:
     assert second_run[0].enqueued
 
     with session_scope() as session:
-        jobs = (
-            session.execute(
-                select(QueueJob).where(QueueJob.type == "watchlist")
-            )
-            .scalars()
-            .all()
-        )
+        jobs = session.execute(select(QueueJob).where(QueueJob.type == "watchlist")).scalars().all()
         assert len(jobs) == 1
         job = jobs[0]
         assert job.idempotency_key is not None

--- a/tests/workers/test_watchlist_timer.py
+++ b/tests/workers/test_watchlist_timer.py
@@ -1,0 +1,123 @@
+"""Tests for the watchlist orchestrator timer behaviour."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime
+
+import pytest
+
+from app.config import WatchlistWorkerConfig
+from app.db import session_scope
+from app.models import QueueJob
+from app.orchestrator.timer import WatchlistTimer
+from app.services.watchlist_dao import WatchlistArtistRow
+
+
+class _StubWatchlistDAO:
+    def __init__(self, artists: list[WatchlistArtistRow]) -> None:
+        self._artists = artists
+        self.calls = 0
+
+    def load_batch(self, limit: int, *, cutoff: datetime | None = None):
+        self.calls += 1
+        return list(self._artists[:limit])
+
+
+class _BlockingWatchlistDAO:
+    def __init__(self, artists: list[WatchlistArtistRow], gate: asyncio.Event) -> None:
+        self._artists = artists
+        self._gate = gate
+        self.started = asyncio.Event()
+
+    async def load_batch(self, limit: int, *, cutoff: datetime | None = None):
+        self.started.set()
+        await self._gate.wait()
+        return list(self._artists[:limit])
+
+
+def _timer_config() -> WatchlistWorkerConfig:
+    return WatchlistWorkerConfig(
+        max_concurrency=3,
+        max_per_tick=5,
+        spotify_timeout_ms=1000,
+        slskd_search_timeout_ms=1000,
+        tick_budget_ms=1000,
+        backoff_base_ms=100,
+        retry_max=3,
+        jitter_pct=0.0,
+        shutdown_grace_ms=0,
+        db_io_mode="async",
+        retry_budget_per_artist=3,
+        cooldown_minutes=0,
+    )
+
+
+@pytest.mark.asyncio
+async def test_watchlist_timer_enqueues_idempotently(monkeypatch: pytest.MonkeyPatch) -> None:
+    artist = WatchlistArtistRow(
+        id=101,
+        spotify_artist_id="artist-101",
+        name="Test Artist",
+        last_checked=None,
+        retry_block_until=None,
+    )
+    dao = _StubWatchlistDAO([artist])
+
+    async def immediate_to_thread(func, /, *args, **kwargs):  # type: ignore[no-untyped-def]
+        return func(*args, **kwargs)
+
+    monkeypatch.setattr("asyncio.to_thread", immediate_to_thread)
+
+    timer = WatchlistTimer(
+        config=_timer_config(),
+        interval_seconds=0,
+        dao=dao,
+        now_factory=lambda: datetime(2024, 1, 1, 0, 0, 0),
+        time_source=lambda: 0.0,
+    )
+
+    first = await timer.trigger()
+    second = await timer.trigger()
+
+    assert first and first[0].payload["artist_id"] == 101
+    assert second and second[0].id == first[0].id
+    assert dao.calls == 2
+
+    with session_scope() as session:
+        jobs = session.query(QueueJob).filter(QueueJob.type == "watchlist").all()
+        assert len(jobs) == 1
+
+
+@pytest.mark.asyncio
+async def test_watchlist_timer_skips_reentrant_trigger(monkeypatch: pytest.MonkeyPatch) -> None:
+    artist = WatchlistArtistRow(
+        id=202,
+        spotify_artist_id="artist-202",
+        name="Artist",
+        last_checked=None,
+        retry_block_until=None,
+    )
+    gate = asyncio.Event()
+    dao = _BlockingWatchlistDAO([artist], gate)
+
+    async def immediate_to_thread(func, /, *args, **kwargs):  # type: ignore[no-untyped-def]
+        return func(*args, **kwargs)
+
+    monkeypatch.setattr("asyncio.to_thread", immediate_to_thread)
+
+    timer = WatchlistTimer(
+        config=_timer_config(),
+        interval_seconds=0,
+        dao=dao,
+        now_factory=lambda: datetime(2024, 1, 1, 0, 0, 0),
+        time_source=lambda: 0.0,
+    )
+
+    first_task = asyncio.create_task(timer.trigger())
+    await dao.started.wait()
+    second = await timer.trigger()
+    assert second == []
+    gate.set()
+    first_result = await first_task
+    assert first_result and first_result[0].payload["artist_id"] == 202

--- a/tests/workers/test_watchlist_worker.py
+++ b/tests/workers/test_watchlist_worker.py
@@ -225,7 +225,9 @@ def _force_ready(job_id: int) -> None:
 
 
 @pytest.mark.asyncio
-async def test_watchlist_handler_moves_to_dlq_after_retries(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_watchlist_handler_moves_to_dlq_after_retries(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     monkeypatch.setenv("EXTERNAL_RETRY_MAX", "2")
     artist_id = _insert_artist("artist-3")
 


### PR DESCRIPTION
## Summary
- add regression coverage for orchestrator priority parsing, scheduling order, pool limits, retry DLQ handling, and watchlist timer behaviour with focused worker tests
- extend shared test fixtures with a stub queue persistence implementation and queue job factory to drive orchestrator scenarios without external services
- apply Black formatting across app and test modules to satisfy the repository formatting gate

## Testing
- pytest -q
- mypy app
- ruff check .
- black --check .

------
https://chatgpt.com/codex/tasks/task_e_68dd6076f92883218b3bc75e84cc56e3