### PR TITLE
fix: preserve backfill worker queue across restarts

### DIFF
--- a/app/workers/backfill_worker.py
+++ b/app/workers/backfill_worker.py
@@ -52,7 +52,6 @@ class BackfillWorker:
         mark_worker_status("spotify_backfill", WORKER_STOPPED)
         if was_running:
             record_worker_stopped("spotify_backfill")
-        self._queue = None
         self._loop = None
 
     async def enqueue(self, job: BackfillJobSpec) -> None:

--- a/tests/workers/test_backfill_worker.py
+++ b/tests/workers/test_backfill_worker.py
@@ -17,7 +17,9 @@ class StubBackfillService:
 
 
 @pytest.mark.asyncio
-async def test_backfill_worker_processes_jobs_enqueued_before_start(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_backfill_worker_processes_jobs_enqueued_before_start(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     service = StubBackfillService()
     worker = BackfillWorker(service)
 
@@ -31,6 +33,52 @@ async def test_backfill_worker_processes_jobs_enqueued_before_start(monkeypatch:
     await worker.enqueue(job)
 
     assert service.executed == []
+
+    await worker.start()
+    await asyncio.wait_for(worker.wait_until_idle(), timeout=1)
+
+    assert service.executed == [job]
+
+    await worker.stop()
+
+
+@pytest.mark.asyncio
+async def test_backfill_worker_preserves_queue_across_restart(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = StubBackfillService()
+    worker = BackfillWorker(service)
+
+    monkeypatch.setattr(worker_module, "record_worker_started", lambda *args, **kwargs: None)
+    monkeypatch.setattr(worker_module, "mark_worker_status", lambda *args, **kwargs: None)
+    monkeypatch.setattr(worker_module, "record_worker_heartbeat", lambda *args, **kwargs: None)
+    monkeypatch.setattr(worker_module, "record_worker_stopped", lambda *args, **kwargs: None)
+
+    original_run = worker_module.BackfillWorker._run
+    start_gate = asyncio.Event()
+
+    async def gated_run(self: BackfillWorker, queue: asyncio.Queue[BackfillJobSpec]) -> None:
+        await start_gate.wait()
+        await original_run(self, queue)
+
+    monkeypatch.setattr(worker_module.BackfillWorker, "_run", gated_run)
+
+    job = BackfillJobSpec(id="job-preserved", limit=1, expand_playlists=False)
+
+    await worker.enqueue(job)
+    await worker.start()
+
+    # Allow the worker task to reach the gate before stopping it again.
+    await asyncio.sleep(0)
+
+    assert service.executed == []
+
+    await worker.stop()
+
+    # The job should not have been processed while the worker was stopped.
+    assert service.executed == []
+
+    start_gate.set()
 
     await worker.start()
     await asyncio.wait_for(worker.wait_until_idle(), timeout=1)


### PR DESCRIPTION
## Kurzfassung
**Was/Warum:** Preserve queued backfill jobs across worker restarts so pending jobs are not lost.
**TASK_ID:** N/A (direct request)

## Änderungen (Dateien)
- Geändert: app/workers/backfill_worker.py, tests/workers/test_backfill_worker.py

## Tests & Nachweise
- Befehle/Logs/Screens:
  - `pytest tests/workers/test_backfill_worker.py`
  - `ruff check app/workers/backfill_worker.py tests/workers/test_backfill_worker.py`
  - `black --check app/workers/backfill_worker.py tests/workers/test_backfill_worker.py`
  - `mypy app`
- Coverage (geänderte Module): nicht gemessen (bestehende Unit-Tests decken Änderungen ab)

## Verträge
- Public-API: unverändert
- DB/Migration: nein

## Migration & Deployment
- Migration ausgeführt (`alembic upgrade head`): nein – nicht erforderlich
- ENV-Defaults geprüft/kommuniziert (siehe README „Orchestrator & Queue-Steuerung“, `docs/workers.md`): nicht erforderlich (keine Änderungen)

## Doku & ToDo
- README/CHANGELOG/ADR aktualisiert: nein – nicht erforderlich
- ToDo.md aktualisiert (Nachweis-Link): N/A

## Checkliste
- [x] AGENTS.md gelesen & Scope-Guard geprüft
- [x] Keine Secrets/`BACKUP`/Lizenzdateien verändert
- [x] `pytest -q`, `mypy app`, `ruff`, `black --check` grün oder Ausnahme dokumentiert

------
https://chatgpt.com/codex/tasks/task_e_68dda01c83b0832189ea19e04e62f349