### PR TITLE
docs: establish architecture overview and contracts [CODX-ARCH-DOC-301]

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -289,9 +289,11 @@ Starte eine Rückfrage, wenn **mindestens einer** der Punkte zutrifft:
 - Änderungen an Dateien (Neu/Geändert/Gelöscht) als Liste.
 - Testnachweise mit Befehlen/Logs/Screenshots.
 - Verweis auf AGENTS.md-Konformität und ggf. OpenAPI-/ENV-Updates.
+- Nicht triviale Architekturentscheidungen erfordern ein ADR (`docs/architecture/adr/`) inkl. Verweis in der PR.
 
 **PR-Checkliste (muss vollständig im PR abgehakt sein):**
 - [ ] AGENTS.md gelesen und Scope-Guard geprüft.
+- [ ] Architekturübersicht (`docs/architecture/overview.md`) gelesen und bei Änderungen an Flows/Contracts/Flags aktualisiert.
 - [ ] Keine Secrets/`BACKUP`/Lizenzdateien verändert.
 - [ ] Tests grün (`pytest`, `mypy`, `ruff`, `black --check`) bzw. begründete Ausnahme dokumentiert.
 - [ ] OpenAPI/Snapshots aktualisiert, falls API betroffen.
@@ -299,6 +301,7 @@ Starte eine Rückfrage, wenn **mindestens einer** der Punkte zutrifft:
 
 ### CI-/OpenAPI-Gates <a id="ci-openapi-gates"></a>
 
+- Architektur-Dokumentation (`docs/architecture/overview.md`, `docs/architecture/contracts.md`, `docs/architecture/diagrams.md`) muss Flows, Contracts und Feature-Flags widerspruchsfrei abbilden.
 **MUST PASS (lokal oder CI):**
 - `pytest`
 - `mypy`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## v2.0.0 — unreleased
+- docs(architecture): add overview, contracts, diagrams, ADR template [CODX-ARCH-DOC-301]
 - docs: enable Codex full write mode (default implement) [CODX-POL-092]
 - docs: enable Auto-FAST-TRACK for CODX-ORCH-* tasks in AGENTS.md [CODX-DOC-102]
 - feat(orchestrator): configurable priorities, pools, visibility, heartbeat, timer [CODX-ORCH-084]

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ Harmony ist ein FastAPI-Backend, das Spotify, Soulseek (slskd) sowie eine eigene
 
 > **MVP-Hinweis:** Die früheren Plex- und Beets-Integrationen sind vorübergehend deaktiviert und der Quellcode wurde unter `archive/integrations/plex_beets/` abgelegt. Markierte Abschnitte in diesem Dokument beschreiben archivierte Funktionen.
 
+## Architecture
+
+Harmony setzt auf ein geschichtetes Kernsystem (Router → Services → Domain → Integrationen) mit einem zentralen Orchestrator für Hintergrundjobs. Verantwortlichkeiten, Flows, Fehler- und Logging-Verträge sowie Erweiterungspunkte sind in der [Architecture Overview](docs/architecture/overview.md) festgehalten und gelten als verbindliche Referenz für jede Änderung. Ergänzende Diagramme, Contracts und ADRs befinden sich im Ordner `docs/architecture/`.
+
 ## Features
 
 - **Harmony Web UI (React + Vite)** mit Dashboard, Service-Tabs, Tabellen, Karten und Dark-/Light-Mode.

--- a/docs/architecture/adr/0000-template.md
+++ b/docs/architecture/adr/0000-template.md
@@ -1,0 +1,20 @@
+# ADR 0000 - Titel
+
+## Status
+Proposed | Accepted | Superseded | Deprecated (nicht benötigte Stati entfernen)
+
+## Kontext
+_Beschreibe das Problem, die Rahmenbedingungen, Annahmen und Constraints. Welche Teams oder Systeme sind betroffen?_
+
+## Entscheidung
+_Fasse die gewählte Lösung in wenigen Sätzen. Begründe, warum sie besser ist als die Alternativen._
+
+## Alternativen
+- _Alternative A – Warum verworfen?_
+- _Alternative B – Warum verworfen?_
+
+## Konsequenzen
+_Beschreibe positive und negative Auswirkungen (Tech-Debt, Ops-Aufwand, Risiken, Migrationsschritte)._
+
+## Umsetzung & Follow-up
+_Aufgaben, Migrationspfade, betroffene Dokumente (README, Contracts, Diagrams) und Tests._

--- a/docs/architecture/adr/0001-architecture-style.md
+++ b/docs/architecture/adr/0001-architecture-style.md
@@ -1,0 +1,25 @@
+# ADR 0001 - Layered Services mit Orchestrator-Pattern
+
+## Status
+Accepted — 2025-10-02
+
+## Kontext
+Harmony integriert mehrere Domänenstränge (Spotify, Soulseek, Matching, Watchlist) über eine gemeinsame API. Nach dem Umbau von Orchestrator und Gateway fehlt eine versionierte Beschreibung des Zielbildes. Ohne klare Layer-Aufteilung drohen Service- und Router-Drift, duplizierte Fehlerbehandlungen sowie inkonsistente Idempotenz- und Retry-Strategien. Außerdem muss der ProviderGateway die heterogenen Integrationen kapseln, damit neue Provider ohne Refactoring der Services angebunden werden können.
+
+## Entscheidung
+Wir behalten ein klassisches Layered-Architecture-Modell (API → Application → Domain → Infrastructure) bei und kombinieren es mit einem eigenständigen Orchestrator-Pattern für Hintergrundjobs. Die Providerkommunikation erfolgt ausschließlich über den `ProviderGateway`, der DTOs validiert und Fehler auf die gemeinsame Taxonomie mappt. Structured Logging ist das primäre Observability-Mittel und folgt einem festen Schema. Neue Architekturentscheidungen werden via ADR festgehalten.
+
+## Alternativen
+- Monolithische Service-Layer ohne ProviderGateway: verworfen, da Integrationen dann domänenspezifische Codepfade in Services/Core platzieren würden und Idempotenz-/Retry-Logik nicht zentral versioniert wäre.
+- Event-getriebene Microservices: verworfen, weil der aktuelle Scope (eine Deployable-Einheit) die bestehende Operations-Komplexität nicht rechtfertigt und zusätzliche Infrastruktur (Event-Bus, Outbox) benötigen würde.
+
+## Konsequenzen
+- Klare Verantwortlichkeiten pro Schicht, weniger Risiko für Architekturdrift.
+- Provider-spezifische Anpassungen landen ausschließlich im Gateway oder dedizierten Adaptern, wodurch neue Provider reproduzierbar eingebunden werden können.
+- Das Orchestrator-Pattern bleibt Quelle der Wahrheit für Jobs (Visibility, Heartbeats, DLQ) und benötigt regelmäßige Dokumentationspflege.
+- Structured Logs ersetzen klassische Metriken; externe Observability-Systeme müssen JSON-Events konsumieren.
+
+## Umsetzung & Follow-up
+- Architekturübersicht, Verträge und Diagramme in `docs/architecture/` veröffentlichen und als Pflichtlektüre verankern.
+- PR-Checkliste um Prüfung/Aktualisierung der Architektur-Dokumente erweitern.
+- Neue Architekturentscheidungen über ADRs versionieren; Änderungen an Flows/Contracts sofort in `overview.md`, `contracts.md` und `diagrams.md` reflektieren.

--- a/docs/architecture/contracts.md
+++ b/docs/architecture/contracts.md
@@ -1,0 +1,92 @@
+# Architecture Contracts
+
+Dieses Dokument präzisiert die verbindlichen Verträge für Logging, Fehler, DTOs, Idempotenz, Retries und Dead-Letter-Queues. Die Verträge gelten für API-Router, Services, Core, Integrationen und Worker gleichermaßen und werden im Rahmen jedes PR-Reviews überprüft.
+
+## Structured Logging Contract
+
+### Pflichtfelder
+| Feld | Typ | Beschreibung |
+| --- | --- | --- |
+| `event` | `str` | Event-Kategorie (siehe Tabelle unten). |
+| `component` | `str` | Modul oder technische Komponente (`router.spotify`, `service.watchlist`, `worker.ingest`). |
+| `status` | `str` | `received`, `in_progress`, `completed`, `failed`, `skipped`, `timeout`. |
+| `duration_ms` | `int` | Dauer in Millisekunden (0 wenn unbekannt). |
+| `entity_id` | `str` | Domänen- oder Job-Identifikator (`track:123`, `job:watchlist:42`). |
+| `request_id` | `str` | Korrelations-ID (API Request oder Job Lease). |
+| `meta` | `dict[str, Any]` | Zusätzliche strukturierte Informationen (Flags, Retry-Count, Provider, HTTP-Status). |
+
+### Event-Typen
+| `event` | Auslöser | Pflicht-Meta |
+| --- | --- | --- |
+| `request` | Eingang/Antwort eines HTTP-Requests. | `method`, `path`, `status_code`. |
+| `service.call` | Aufruf einer Service-Methode. | `service`, `operation`. |
+| `integration_call` | ProviderGateway ruft externen Provider auf. | `provider`, `operation`, `attempt`, `timeout_ms`. |
+| `worker_job` | Worker startet/beendet Job. | `job_type`, `attempt`, `queue`. |
+| `worker.heartbeat` | Lease-Heartbeat vom Handler. | `job_type`, `lease_id`, `visibility_timeout_ms`. |
+| `orchestrator.scheduler` | Scheduler holt/vergibt Leases. | `queue`, `priority`, `leased_count`. |
+| `dlq.transition` | Job geht in/aus DLQ. | `job_type`, `reason`. |
+| `feature_flag` | Feature-Flag Evaluierung. | `flag`, `value`, `source`. |
+
+Logs müssen JSON-formatiert sein und alle Pflichtfelder enthalten. Fehler-Events setzen `status=failed` und referenzieren die Fehlertaxonomie (`meta.error_code`).
+
+## Fehler-Taxonomie
+
+| Code | Beschreibung | HTTP-Mapping | Logging-Kriterien |
+| --- | --- | --- | --- |
+| `VALIDATION_ERROR` | Eingaben verletzen Schema, Pflichtfelder oder Grenzen. | `400` | `meta.fields`, `meta.detail` beschreiben Validierungsfehler. |
+| `NOT_FOUND` | Angefragte Ressource existiert nicht oder ist nicht verfügbar. | `404` | `meta.resource` und ggf. `meta.provider` ergänzen Kontext. |
+| `DEPENDENCY_ERROR` | Fehler in externen Diensten oder Integrationen (inkl. Zeitüberschreitungen). | `502` oder `504` | `meta.provider`, `meta.dependency_status`, `meta.retryable` verpflichtend. |
+| `INTERNAL_ERROR` | Unbekannter Fehler, ungehandelte Exceptions. | `500` | `meta.exception_type`, `meta.retryable=false`. |
+
+Alle Router wandeln Exceptions in einen Fehler-Envelope (`{"ok": false, "error": {"code", "message", "meta"}}`). Services signalisieren wiederholbare Fehler durch `meta.retryable=true`.
+
+## ProviderGateway DTO-Kontrakte
+
+### ProviderRequest
+| Feld | Typ | Beschreibung |
+| --- | --- | --- |
+| `operation` | `Literal["search", "download", "status", "metadata"]` | Gateway-Operation. |
+| `payload` | `dict[str, Any]` | Normalisierter Input (Artists, Titel, Album, Query-Parameter). |
+| `context` | `dict[str, Any]` | Aufrufkontext (`request_id`, `idempotency_key`, Feature-Flags). |
+| `timeout_ms` | `int` | Zeitlimit pro Provider-Aufruf. |
+
+### ProviderResponse
+| Feld | Typ | Beschreibung |
+| --- | --- | --- |
+| `status` | `Literal["ok", "partial", "error"]` | Ergebnisstatus. |
+| `data` | `Union[dict[str, Any], list[dict[str, Any]], None]` | Ergebnisdaten (Tracks, Download-IDs, Health). |
+| `error` | `Optional[dict[str, Any]]` | Enthält `code` (Taxonomie), `message`, `provider_status`. |
+| `meta` | `dict[str, Any]` | Retry-/Rate-Limit-Hinweise, Quoten, Cache-Hits. |
+
+### Track DTO (Normalform)
+| Feld | Beschreibung |
+| --- | --- |
+| `track_id` | Provider-interne ID oder Harmony-ID. |
+| `title` | Normalisierter Track-Titel. |
+| `artists` | Liste normalisierter Künstlernamen. |
+| `album` | Albumtitel in Normalform. |
+| `duration_ms` | Dauer in Millisekunden. |
+| `isrc` | Optional, wenn verfügbar. |
+| `bitrate` | Für Downloads relevant (Soulseek). |
+
+Gateway-Adapter müssen DTOs vor Rückgabe validieren, fehlende Pflichtfelder führen zu `VALIDATION_ERROR`.
+
+## Idempotenz, Visibility & Heartbeats
+- **API-Requests:** Header `Idempotency-Key` wird in Persistence (z. B. `ingest_jobs.idempotency_key`) gespeichert. Schlüssel-Format: `<domain>:<entity-id>:<epoch-ms>`. Kollisionen führen zu `409` mit bestehender Response.
+- **Queue-Jobs:** Jeder Job enthält `idempotency_key` (gleiche Struktur). Services prüfen vor Enqueue auf bestehende Jobs (persistierte `job_keys`).
+- **Visibility Timeout:** Default 30 s, konfigurierbar per `WORKER_VISIBILITY_TIMEOUT_MS`. Heartbeats spätestens bei 2/3 der Sichtbarkeitsdauer. Ausbleibende Heartbeats lösen Requeue mit erhöhtem `attempt` aus.
+- **Lease-Erneuerung:** Handler, die länger laufen, senden `worker.heartbeat`-Events mit aktualisiertem `visibility_timeout_ms`.
+- **DLQ:** Nach Ausschöpfen von `WORKER_MAX_ATTEMPTS` landet der Job in `dlq_jobs`. Jeder Übergang erzeugt `event=dlq.transition` mit `status=entered` oder `status=requeued`.
+
+## Retry- und Backoff-Regeln
+- **Exponentiell mit Jitter:** `next_retry_at = now + base * 2^(attempt-1) ± 20%` (Deckel laut Konfiguration, z. B. 5 s bei Watchlist).
+- **Retry-Budgets:** Konfigurierbar pro Job-Typ (`WATCHLIST_RETRY_MAX`, `INGEST_RETRY_MAX`). Budgetverletzung setzt `meta.retryable=false`.
+- **Dependency Errors:** Provider-Adapter kennzeichnen `DEPENDENCY_ERROR` als wiederholbar, solange Quoten/Rate-Limits dies erlauben (`meta.retry_after_ms`).
+- **Manual DLQ Requeue:** `/api/v1/dlq` nutzt denselben Contract und setzt neue Lease + `idempotency_key`.
+
+## Visibility & Feature Flags
+- Feature-Flags werden im Service-Layer ausgewertet; Router dürfen Flags nur lesen.
+- Jede Flag-Änderung erzeugt `event=feature_flag` mit `status=updated`.
+- Flags mit Laufzeitauswirkung müssen im Runtime-Config-Guide und in der Architekturübersicht referenziert werden.
+
+Diese Verträge sind Grundlage für Tests und Reviews. Änderungen müssen per ADR dokumentiert, in `overview.md` und relevanten Guides nachgezogen und in der PR-Checkliste erwähnt werden.

--- a/docs/architecture/diagrams.md
+++ b/docs/architecture/diagrams.md
@@ -1,0 +1,40 @@
+# Architecture Diagrams
+
+## Request Flow
+```mermaid
+sequenceDiagram
+    participant Client as Client
+    participant Router as API Router
+    participant Service as Application Service
+    participant Gateway as ProviderGateway
+    participant Provider as External Provider
+    participant Core as Domain/Core
+
+    Client->>Router: HTTP Request
+    Router->>Service: Validated DTO + Idempotency-Key
+    Service->>Core: Domain Operation (normalize/match)
+    Core-->>Service: Domain Result
+    Service->>Gateway: ProviderRequest DTO
+    Gateway->>Provider: API Call (with timeout)
+    Provider-->>Gateway: ProviderResponse
+    Gateway-->>Service: Normalized DTO
+    Service-->>Router: Response Payload
+    Router-->>Client: JSON Response + Error Envelope on failure
+```
+
+## Orchestrator Flow
+```mermaid
+flowchart LR
+    Scheduler[Scheduler\n(prioritised fetch)] -->|Lease job| Dispatcher[Dispatcher]
+    Dispatcher --> Pools{Worker Pools}
+    Pools -->|Dispatch| Handler[Job Handler]
+    Handler -->|Process| Gateway
+    Gateway[ProviderGateway/Services]
+    Handler -->|Heartbeat| LeaseStore[(Visibility Store)]
+    Handler -->|Ack success| Scheduler
+    Handler -->|Fail w/ retry budget| RetryQueue[[Retry Queue]]
+    RetryQueue --> Scheduler
+    Handler -->|Exhausted budget| DLQ[(Dead Letter Queue)]
+    DLQ --> Observability[Structured Logs\n`event=worker_job`]
+    LeaseStore -->|Timeout| Scheduler
+```

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -1,0 +1,71 @@
+# Harmony Architecture Overview
+
+Diese Übersicht definiert den gemeinsamen Bezugsrahmen für Router, Services, Core-Domain und Orchestrator. Sie stellt Prinzipien, Flows und Verträge bereit, die bei jeder Änderung geprüft werden müssen. Ergänzende Details finden sich in `docs/architecture/contracts.md`, `docs/architecture/diagrams.md` sowie den ADRs unter `docs/architecture/adr/`.
+
+## Zweck & Leitprinzipien
+- **Simplicity First:** Kleine, klar abgegrenzte Komponenten, die ohne versteckte Kopplungen funktionieren.
+- **Idempotenz als Standard:** Jede Anfrage und jeder Job darf gefahrlos erneut laufen (Queue-Redelivery, API-Retries, Deployments).
+- **DRY & KISS:** Fachlogik liegt im Core bzw. dedizierten Services; Router und Integrationen bleiben dünne Adapter.
+- **Least-Privilege:** Integrationen nutzen nur die benötigten Scopes, Worker erhalten minimale Rechte auf Queues und Provider.
+- **Strukturiertes Logging:** Jede Entscheidung erzeugt nachvollziehbare, schemakonforme Events (siehe Contracts-Dokument).
+
+## Schichtenmodell
+
+| Schicht | Verantwortung | Beispielmodule | Anti-Patterns |
+| --- | --- | --- | --- |
+| **API (Router)** | HTTP-/CLI-Oberfläche, Request-Validierung, Fehler-Envelope, Auth. | `app/routers/*`, FastAPI Dependencies | Business-Logik, Direktzugriff auf Datenbank oder Provider |
+| **Application (Services)** | Orchestriert Use-Cases, kapselt Transaktionen, orchestriert mehrere Integrationen. | `app/services/*`, `app/workers/*` | Zustandsbehaftete globale Variablen, direkte Response-Objekte |
+| **Domain (Core)** | Reine Fachlogik, Matching, Normalisierung, Fehlerklassen. | `app/core/*`, `app/errors.py` | Provider-spezifische DTOs, Side-Effects |
+| **Infrastructure** | Integrationen, Persistence, Messaging, Konfiguration. | `app/integrations/*`, `app/db.py`, `app/models.py` | Domain-Logik in Adapter verschieben |
+| **Orchestrator/Workers** | Zeit-/Event-gesteuerte Jobs, Dispatch, Visibility-Handling, Heartbeats. | `app/workers/*`, `app/services/dlq_service.py` | API-Calls ohne Idempotenz, ungeplante Retries |
+
+## Modulverantwortungen
+
+| Modul/Komponente | Rolle | Owners | Qualitätskriterien |
+| --- | --- | --- | --- |
+| Router (`app/routers/*`) | Übersetzt HTTP-Requests in Service-Aufrufe, validiert Input und mappt Fehlercodes. | API-Team | FastAPI-Schemata gepflegt, kein Datenbankzugriff, Logging `event=request`. |
+| Services (`app/services/*`) | Enthält Anwendungs-Use-Cases, koordiniert Integrationen und Domain-Komponenten. | Core-Team | Idempotente Methoden, Transaktionsgrenzen dokumentiert, Retry-fähig. |
+| Core (`app/core/*`) | Domain-Modelle, Matching, Normalisierung, Fehler. | Domain-Team | Reine Funktionen, deterministische Tests, keine Provider-Aufrufe. |
+| Integrationen (`app/integrations/*`) | Provider-spezifische Adapters, Mapping von DTOs, Timeout/Retries. | Integrations-Team | Logging `event=integration_call`, Fehler auf Taxonomie gemappt. |
+| Orchestrator (`app/workers/*`, `app/services/dlq_service.py`) | Job-Planung, Dispatch, Visibility, Dead-Letter-Handling. | Platform-Team | Lease-Verträge eingehalten, Heartbeat-Events, DLQ gepflegt. |
+
+## Kern-Flows
+
+### Request → Response
+1. Router validiert Payload, prüft Authentifizierung und erzeugt `event=request` mit `status=received`.
+2. Router ruft den passenden Service auf und übergibt normalisierte DTOs (siehe Contracts).
+3. Services orchestrieren Core-Logik und Integrationen, loggen `event=service.call` und `event=integration_call` mit Dauer.
+4. Fehler werden auf die Taxonomie (`VALIDATION_ERROR`, `NOT_FOUND`, `DEPENDENCY_ERROR`, `INTERNAL_ERROR`) gemappt.
+5. Router wandelt Domain- oder Service-Resultate in Response-DTOs um und emittiert `event=request` mit `status=completed`.
+
+### Job Lifecycle (Queue)
+1. Service oder Timer enqueued einen Job mit Idempotency-Key (`<job-type>:<entity-id>:<timestamp-epoch>`).
+2. Orchestrator-Scheduler reserviert Jobs nach Priorität, setzt Visibility Timeout und vergibt eine Lease.
+3. Dispatcher übergibt den Job an einen Worker-Pool; Handler bestätigt Heartbeats innerhalb des Visibility-Fensters.
+4. Bei Erfolg acked der Handler den Job, loggt `event=worker_job` mit `status=completed`.
+5. Bei Fehlern: Retry mit exponentiellem Backoff (Budget aus Config), Überschreitung landet im DLQ (`event=worker_job`, `status=failed`).
+
+### Watchlist Timer → Enqueue → Handler
+1. Timer löst gemäß `WATCHLIST_INTERVAL` aus, liest Artists mit fälligem `last_checked`.
+2. Service erstellt pro Artist einen Job (`watchlist.sync`) und setzt Idempotency-Key `watchlist:<artist-id>:<tick-start>`.
+3. Worker lädt Spotify-Releases, mappt auf Downloads und triggert Soulseek-Enqueue über den ProviderGateway.
+4. Erfolgreiche Läufe löschen Retry-Cooldowns (`event=watchlist.cooldown.clear`), Fehler loggen `event=watchlist.cooldown.skip` und respektieren Budget/Backoff.
+
+## Fehler-, Retry- und Idempotenzverträge
+- **Logging-Contract:** Jedes Event enthält `event`, `component`, `status`, `duration_ms`, `entity_id` (siehe `contracts.md`).
+- **Fehlertaxonomie:** Konsistent zu FastAPI/Error-Envelope (`code`, `message`, optional `meta`).
+- **Retries:** Services definieren maximale Versuche, Backoff-Strategien und DLQ-Hand-Off; Werte dokumentiert in `docs/architecture/contracts.md`.
+- **Idempotenz:** API-Clients übermitteln `Idempotency-Key`-Header; Worker nutzen Queue-Keys und Persistenz, um Doppelverarbeitung zu verhindern.
+- **Visibility & Heartbeat:** Jede Lease setzt `visibility_timeout` und fordert Heartbeats (`event=worker.heartbeat`) innerhalb 2/3 der Lease-Dauer.
+
+## Konfiguration & Feature-Flags
+- **Konfigurationsmatrix:** `docs/ops/runtime-config.md` listet relevante ENV-Variablen (Ingest, Watchlist, Provider, Orchestrator). Neue Parameter dort und in dieser Übersicht verlinken.
+- **Feature-Flags:** `ENABLE_LYRICS`, `ENABLE_ARTWORK`, `INGEST_MAX_PENDING_JOBS`, `WATCHLIST_MAX_CONCURRENCY` u. a. werden in Services geprüft und müssen hier dokumentiert bleiben.
+- **Observability:** Structured Logs sind primär, Metriken entfallen. Externe Systeme abonnieren `event=request`, `event=worker_job`, `event=integration_call`.
+
+## Erweiterungspunkte
+- **Neue Provider:** Implementiere `MusicProvider`-Adapter, ergänze Mapping in `ProviderGateway`, schreibe ADR bei signifikanten Schnittstellenänderungen.
+- **Neue Job-Typen:** Definiere Worker-Handler inkl. Visibility-, Retry- und DLQ-Strategie, erweitere Orchestrator-Konfiguration und dokumentiere den Flow.
+- **Neue APIs:** Router delegieren strikt an bestehende Services oder neue Use-Case-Services; Fehler und Logging folgen dem Contract.
+
+Änderungen an Architektur, Flows oder Verträgen erfordern ein ADR (siehe Template) und eine Aktualisierung dieser Übersicht.


### PR DESCRIPTION
## Summary
- add a versioned architecture overview with principles, layers, flows and extension guidance
- publish sequence/flow diagrams plus logging, error, DTO and retry contracts for router, services and orchestrator
- provide ADR template and initial architecture-style ADR while linking the docs via README, AGENTS gates and CHANGELOG entry

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68dda326f9c88321859341130a1e98ff