### PR TITLE
CODX-P0-MIG-105: align Alembic migrations with queue job schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 - docs(architecture): add overview, contracts, diagrams, ADR template [CODX-ARCH-DOC-301]
 - docs: enable Codex full write mode (default implement) [CODX-POL-092]
 - docs: enable Auto-FAST-TRACK for CODX-ORCH-* tasks in AGENTS.md [CODX-DOC-102]
+- chore(db): align Alembic environment, migrations and queue job schema with the
+  current ORM (additive, idempotent) [CODX-P0-MIG-105]
 - feat(orchestrator): configurable priorities, pools, visibility, heartbeat, timer [CODX-ORCH-084]
   - Dokumentiert den Orchestrator im README, ergänzt Runtime-Guides (Prioritäten, Pools, Heartbeats) und verweist im PR-Template auf Migrations-/ENV-Hinweise.
 - refactor(api): domain router registry, unified middleware chain & error handlers; remove `/metrics` wiring [CODX-API-REF-312]

--- a/app/db.py
+++ b/app/db.py
@@ -24,6 +24,10 @@ class Base(DeclarativeBase):
     pass
 
 
+# Expose metadata so Alembic can import a single canonical reference.
+metadata = Base.metadata
+
+
 _engine: Optional[Engine] = None
 SessionLocal: Optional[sessionmaker[Session]] = None
 _configured_database_url: Optional[str] = None
@@ -153,6 +157,7 @@ def _configure_alembic(database_url: str) -> Config:
 
 __all__ = [
     "Base",
+    "metadata",
     "SessionLocal",
     "get_session",
     "session_scope",

--- a/app/migrations/README.md
+++ b/app/migrations/README.md
@@ -1,0 +1,61 @@
+# Database migrations
+
+This project uses [Alembic](https://alembic.sqlalchemy.org/) to manage schema
+changes. All migration scripts live under `app/migrations` and are executed via
+`alembic` commands. Migrations **must** remain additive and idempotent so that
+they can run on both SQLite (the default development database) and PostgreSQL
+(the production database).
+
+## Running migrations
+
+```bash
+alembic upgrade head
+alembic downgrade -1  # or "base" to reset everything
+```
+
+The Alembic configuration resolves the database URL from environment
+configuration. Override the target database with the `sqlalchemy.url` value or
+`DATABASE_URL` environment variable when necessary.
+
+## Creating a new migration
+
+1. Import all models before generating a revision so Alembic can inspect the
+   declarative metadata: `from app import models  # noqa: F401`.
+2. Create a revision using Alembic's CLI:
+
+   ```bash
+   alembic revision --autogenerate -m "describe change"
+   ```
+
+3. Review the generated script. Ensure every operation is **additive** and uses
+   explicit guards (`has_table`, `get_columns`, `get_indexes`, …) so the script
+   can run more than once without failing.
+4. Provide downgrade steps. If a non-lossy downgrade is impossible, leave a
+   documented `no-op` explaining why.
+
+### Dialect compatibility
+
+* Use SQLAlchemy types that work on both SQLite and PostgreSQL. For JSON data,
+  prefer `sa.JSON().with_variant(sa.Text(), "sqlite")`.
+* Avoid database-specific DDL unless wrapped in dialect checks.
+* When adding NOT NULL columns to existing tables, fill historic rows and apply
+  the constraint via `batch_alter_table` to keep SQLite compatible.
+
+### Naming conventions
+
+* Indices: `ix_<table>_<column_names>` (columns joined with underscores).
+* Constraints: keep the existing `ck_`, `uq_`, `fk_` prefixes.
+* Revisions: use a timestamp-like prefix and a concise slug describing the
+  change, for example `202406141200_add_queue_jobs_fields_and_indexes.py`.
+
+## Testing migrations
+
+Run the dedicated migration smoke tests to ensure both SQLite and PostgreSQL
+coverage:
+
+```bash
+pytest tests/migrations -q
+```
+
+The PostgreSQL test requires `DATABASE_URL` to point to a PostgreSQL instance.
+It automatically creates and drops an isolated schema for the test run.

--- a/app/migrations/env.py
+++ b/app/migrations/env.py
@@ -10,7 +10,7 @@ from alembic.config import Config
 from sqlalchemy import engine_from_config, pool
 
 from app.config import load_config
-from app.db import Base
+from app.db import metadata
 
 # Import models for metadata registration
 from app import models  # noqa: F401
@@ -21,7 +21,7 @@ config = _context_config if _context_config is not None else Config()
 if getattr(config, "config_file_name", None):
     fileConfig(config.config_file_name)
 
-target_metadata = Base.metadata
+target_metadata = metadata
 
 
 def _resolve_database_url(alembic_config: Optional[Config]) -> str:

--- a/app/migrations/versions/202406141200_add_queue_jobs_fields_and_indexes.py
+++ b/app/migrations/versions/202406141200_add_queue_jobs_fields_and_indexes.py
@@ -1,0 +1,104 @@
+"""Add queue job payload_json and stop_reason columns with guards."""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import text
+from sqlalchemy.engine import Connection
+from sqlalchemy.exc import NoSuchTableError
+
+# revision identifiers, used by Alembic.
+revision = "202406141200"
+down_revision = "8f43f3f38e0b"
+branch_labels = None
+depends_on = None
+
+
+_TABLE_NAME = "queue_jobs"
+
+
+def _get_column_names(connection: Connection) -> set[str]:
+    try:
+        inspector = sa.inspect(connection)
+        return {column["name"] for column in inspector.get_columns(_TABLE_NAME)}
+    except NoSuchTableError:
+        return set()
+
+
+def _get_index_names(connection: Connection) -> set[str]:
+    try:
+        inspector = sa.inspect(connection)
+        return {index["name"] for index in inspector.get_indexes(_TABLE_NAME)}
+    except NoSuchTableError:
+        return set()
+
+
+def _has_table(connection: Connection) -> bool:
+    return connection.dialect.has_table(connection, _TABLE_NAME)
+
+
+def upgrade() -> None:
+    connection = op.get_bind()
+    if not _has_table(connection):
+        return
+
+    json_type = sa.JSON().with_variant(sa.Text(), "sqlite")
+
+    column_names = _get_column_names(connection)
+
+    if "payload_json" not in column_names:
+        op.add_column(
+            _TABLE_NAME,
+            sa.Column("payload_json", json_type, nullable=True),
+        )
+        column_names.add("payload_json")
+
+        if "payload" in column_names:
+            op.execute(
+                text("UPDATE queue_jobs SET payload_json = payload " "WHERE payload_json IS NULL")
+            )
+
+        with op.batch_alter_table(_TABLE_NAME) as batch_op:
+            batch_op.alter_column(
+                "payload_json",
+                existing_type=json_type,
+                nullable=False,
+            )
+
+    if "stop_reason" not in column_names:
+        op.add_column(
+            _TABLE_NAME,
+            sa.Column("stop_reason", sa.String(length=64), nullable=True),
+        )
+
+    existing_indexes = _get_index_names(connection)
+    desired_indexes: dict[str, Iterable[str]] = {
+        "ix_queue_jobs_type_status_available_at": ("type", "status", "available_at"),
+        "ix_queue_jobs_lease_expires_at": ("lease_expires_at",),
+        "ix_queue_jobs_idempotency_key": ("idempotency_key",),
+    }
+
+    for index_name, columns in desired_indexes.items():
+        if index_name not in existing_indexes:
+            op.create_index(index_name, _TABLE_NAME, list(columns))
+
+
+def downgrade() -> None:
+    connection = op.get_bind()
+    if not _has_table(connection):
+        return
+
+    column_names = _get_column_names(connection)
+
+    if "stop_reason" in column_names:
+        op.drop_column(_TABLE_NAME, "stop_reason")
+
+    if "payload_json" in column_names:
+        with op.batch_alter_table(_TABLE_NAME) as batch_op:
+            batch_op.drop_column("payload_json")
+
+    # Indexes existed in the previous revision already; downgrade intentionally
+    # leaves them untouched to avoid destructive churn.

--- a/app/models.py
+++ b/app/models.py
@@ -302,13 +302,14 @@ class QueueJob(Base):
         default=QueueJobStatus.PENDING.value,
         index=True,
     )
-    payload = Column(JSON, nullable=False, default=dict)
+    payload = Column("payload_json", JSON, nullable=False, default=dict)
     priority = Column(Integer, nullable=False, default=0)
     attempts = Column(Integer, nullable=False, default=0)
     available_at = Column(DateTime, nullable=False, default=datetime.utcnow)
     lease_expires_at = Column(DateTime, nullable=True)
     idempotency_key = Column(String(128), nullable=True)
     last_error = Column(Text, nullable=True)
+    stop_reason = Column(String(64), nullable=True)
     result_payload = Column(JSON, nullable=True)
     created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
     updated_at = Column(

--- a/tests/migrations/helpers.py
+++ b/tests/migrations/helpers.py
@@ -1,0 +1,50 @@
+"""Shared helpers for database migration tests."""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic.config import Config
+
+_REQUIRED_QUEUE_COLUMNS = {
+    "id",
+    "type",
+    "status",
+    "payload_json",
+    "priority",
+    "attempts",
+    "available_at",
+    "lease_expires_at",
+    "idempotency_key",
+    "last_error",
+    "stop_reason",
+    "updated_at",
+}
+
+_REQUIRED_QUEUE_INDEXES = {
+    "ix_queue_jobs_type_status_available_at",
+    "ix_queue_jobs_lease_expires_at",
+    "ix_queue_jobs_idempotency_key",
+}
+
+
+def make_config(database_url: str) -> Config:
+    """Return an Alembic config bound to the given database URL."""
+
+    config = Config("alembic.ini")
+    config.set_main_option("script_location", "app/migrations")
+    config.set_main_option("sqlalchemy.url", database_url)
+    config.attributes["configure_logger"] = False
+    return config
+
+
+def assert_queue_jobs_schema(engine: sa.Engine) -> None:
+    """Ensure the queue_jobs table contains the expected schema objects."""
+
+    inspector = sa.inspect(engine)
+    columns = {column["name"] for column in inspector.get_columns("queue_jobs")}
+    missing_columns: set[str] = _REQUIRED_QUEUE_COLUMNS - columns
+    assert not missing_columns, f"Missing columns: {sorted(missing_columns)}"
+
+    indexes = {index["name"] for index in inspector.get_indexes("queue_jobs")}
+    missing_indexes: set[str] = _REQUIRED_QUEUE_INDEXES - indexes
+    assert not missing_indexes, f"Missing indexes: {sorted(missing_indexes)}"

--- a/tests/migrations/test_upgrade_downgrade_postgres.py
+++ b/tests/migrations/test_upgrade_downgrade_postgres.py
@@ -1,0 +1,60 @@
+"""Migration smoke tests against PostgreSQL when available."""
+
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+import sqlalchemy as sa
+from alembic import command
+from sqlalchemy.engine import make_url
+from sqlalchemy.exc import ProgrammingError
+from sqlalchemy.schema import CreateSchema, DropSchema
+
+from .helpers import assert_queue_jobs_schema, make_config
+
+
+@pytest.mark.skipif(
+    not os.getenv("DATABASE_URL"),
+    reason="DATABASE_URL is not configured for PostgreSQL tests",
+)
+def test_upgrade_downgrade_postgres() -> None:
+    database_url = os.environ["DATABASE_URL"]
+    url = make_url(database_url)
+    if url.get_backend_name() != "postgresql":
+        pytest.skip("PostgreSQL URL required for migration smoke test")
+
+    schema_name = f"test_migrations_{uuid.uuid4().hex}"
+    base_engine = sa.create_engine(url)
+    try:
+        with base_engine.connect() as connection:
+            connection.execute(CreateSchema(schema_name))
+            connection.commit()
+
+        scoped_url = url.set(query={**url.query, "options": f"-csearch_path={schema_name}"})
+        config = make_config(str(scoped_url))
+
+        command.upgrade(config, "head")
+        engine = sa.create_engine(scoped_url)
+        try:
+            assert_queue_jobs_schema(engine)
+        finally:
+            engine.dispose()
+
+        command.downgrade(config, "base")
+        command.upgrade(config, "head")
+
+        engine = sa.create_engine(scoped_url)
+        try:
+            assert_queue_jobs_schema(engine)
+        finally:
+            engine.dispose()
+    finally:
+        with base_engine.connect() as connection:
+            try:
+                connection.execute(DropSchema(schema_name, cascade=True))
+                connection.commit()
+            except ProgrammingError:
+                connection.rollback()
+        base_engine.dispose()

--- a/tests/migrations/test_upgrade_downgrade_sqlite.py
+++ b/tests/migrations/test_upgrade_downgrade_sqlite.py
@@ -1,0 +1,33 @@
+"""Migration smoke tests against SQLite."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import sqlalchemy as sa
+from alembic import command
+
+from .helpers import assert_queue_jobs_schema, make_config
+
+
+def test_upgrade_downgrade_sqlite(tmp_path: Path) -> None:
+    database_path = tmp_path / "sqlite.db"
+    database_url = f"sqlite:///{database_path}"
+
+    config = make_config(database_url)
+    command.upgrade(config, "head")
+
+    engine = sa.create_engine(database_url)
+    try:
+        assert_queue_jobs_schema(engine)
+    finally:
+        engine.dispose()
+
+    command.downgrade(config, "base")
+    command.upgrade(config, "head")
+
+    engine = sa.create_engine(database_url)
+    try:
+        assert_queue_jobs_schema(engine)
+    finally:
+        engine.dispose()


### PR DESCRIPTION
## Summary
- expose the canonical SQLAlchemy metadata for Alembic and update the migration environment to reference it
- add an additive migration that introduces queue_jobs.payload_json and queue_jobs.stop_reason with data backfill and guards, keeping the ORM/persistence layer in sync
- document the migration workflow, add SQLite/PostgreSQL smoke tests, and note the change in the changelog

## Testing
- `ruff check .`
- `black --check .`
- `mypy app`
- `pytest tests/migrations -q`
- `pytest -q` *(fails because the full suite requires additional feature flags/fixtures; see log for baseline failures)*

------
https://chatgpt.com/codex/tasks/task_e_68de4f3a012c8321bf61e4417875f228