### PR TITLE
feat(schemas): add canonical schema skeletons [CODX-P1-SCHEMA-321]

### DIFF
--- a/app/schemas/common.py
+++ b/app/schemas/common.py
@@ -1,0 +1,151 @@
+"""Common schema primitives shared across API surface."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any, Dict, Optional
+from urllib.parse import urlparse
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+
+class ID(str):
+    """Identifier exposed via the public API."""
+
+    @classmethod
+    def __get_validators__(cls):  # pragma: no cover - pydantic hook
+        yield cls.validate
+
+    @classmethod
+    def validate(cls, value: Any) -> "ID":
+        if isinstance(value, cls):
+            return value
+        if isinstance(value, (bytes, bytearray)):
+            value = value.decode()
+        if not isinstance(value, str):
+            raise TypeError("identifier must be a string")
+        stripped = value.strip()
+        if not stripped:
+            raise ValueError("identifier must not be empty")
+        return cls(stripped)
+
+
+class URI(str):
+    """Simple URI wrapper performing light validation."""
+
+    @classmethod
+    def __get_validators__(cls):  # pragma: no cover - pydantic hook
+        yield cls.validate
+
+    @classmethod
+    def validate(cls, value: Any) -> "URI":
+        if isinstance(value, cls):
+            return value
+        if isinstance(value, (bytes, bytearray)):
+            value = value.decode()
+        if not isinstance(value, str):
+            raise TypeError("uri must be a string")
+        stripped = value.strip()
+        if not stripped:
+            raise ValueError("uri must not be empty")
+        parsed = urlparse(stripped)
+        if not parsed.scheme or not parsed.netloc:
+            raise ValueError("uri must include scheme and host")
+        return cls(stripped)
+
+
+class ISODateTime(str):
+    """Datetime serialised to ISO8601 string."""
+
+    @classmethod
+    def __get_validators__(cls):  # pragma: no cover - pydantic hook
+        yield cls.validate
+
+    @classmethod
+    def validate(cls, value: Any) -> "ISODateTime":
+        if isinstance(value, cls):
+            return value
+        if isinstance(value, datetime):
+            if value.tzinfo is None:
+                value = value.replace(tzinfo=timezone.utc)
+            return cls(value.isoformat())
+        if isinstance(value, (bytes, bytearray)):
+            value = value.decode()
+        if not isinstance(value, str):
+            raise TypeError("datetime must be string or datetime")
+        stripped = value.strip()
+        if not stripped:
+            raise ValueError("datetime must not be empty")
+        candidate = stripped.replace("Z", "+00:00")
+        try:
+            parsed = datetime.fromisoformat(candidate)
+        except ValueError as exc:  # pragma: no cover - defensive
+            raise ValueError("invalid ISO 8601 datetime") from exc
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        return cls(parsed.isoformat())
+
+
+class SourceEnum(str, Enum):
+    SPOTIFY = "spotify"
+    SOULSEEK = "soulseek"
+    LOCAL = "local"
+
+
+class SortOrder(str, Enum):
+    ASC = "asc"
+    DESC = "desc"
+
+
+class Sort(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    field: str = Field(..., min_length=1)
+    order: SortOrder = Field(default=SortOrder.ASC)
+
+
+class Paging(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    limit: int = Field(..., ge=0)
+    offset: int = Field(..., ge=0)
+    total: int = Field(..., ge=0)
+
+
+class ProblemDetail(BaseModel):
+    """Canonical error payload."""
+
+    code: str
+    message: str
+    details: Optional[Dict[str, Any]] = None
+    timestamp: ISODateTime = Field(default_factory=lambda: ISODateTime.validate(datetime.now(timezone.utc)))
+
+    @field_validator("code", "message")
+    @classmethod
+    def _ensure_text(cls, value: str) -> str:
+        stripped = value.strip()
+        if not stripped:
+            raise ValueError("value must not be empty")
+        return stripped
+
+    @field_validator("details", mode="before")
+    @classmethod
+    def _normalise_details(cls, value: Any) -> Optional[Dict[str, Any]]:
+        if value is None:
+            return None
+        if isinstance(value, dict):
+            return dict(value)
+        raise TypeError("details must be a mapping if provided")
+
+
+__all__ = [
+    "ID",
+    "ISODateTime",
+    "Paging",
+    "ProblemDetail",
+    "Sort",
+    "SortOrder",
+    "SourceEnum",
+    "URI",
+]

--- a/app/schemas/errors.py
+++ b/app/schemas/errors.py
@@ -1,0 +1,37 @@
+"""Error schema definitions reused across routers."""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any, Dict, Optional
+
+from pydantic import BaseModel
+
+from app.schemas.common import ProblemDetail
+
+
+class ErrorCode(str, Enum):
+    VALIDATION_ERROR = "VALIDATION_ERROR"
+    NOT_FOUND = "NOT_FOUND"
+    RATE_LIMITED = "RATE_LIMITED"
+    DEPENDENCY_ERROR = "DEPENDENCY_ERROR"
+    INTERNAL_ERROR = "INTERNAL_ERROR"
+
+
+class ApiError(BaseModel):
+    """API error payload conforming to the canonical contract."""
+
+    error: ProblemDetail
+
+    @classmethod
+    def from_components(
+        cls,
+        *,
+        code: ErrorCode,
+        message: str,
+        details: Optional[Dict[str, Any]] = None,
+    ) -> "ApiError":
+        return cls(error=ProblemDetail(code=code.value, message=message, details=details))
+
+
+__all__ = ["ApiError", "ErrorCode"]

--- a/app/schemas/provider.py
+++ b/app/schemas/provider.py
@@ -1,0 +1,79 @@
+"""Canonical provider DTO definitions."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from app.schemas.common import ID, ISODateTime, URI
+
+
+class ProviderArtist(BaseModel):
+    """Artist metadata normalised across providers."""
+
+    model_config = ConfigDict(frozen=True)
+
+    id: Optional[ID] = None
+    name: str
+    uri: Optional[URI] = None
+    genres: List[str] = Field(default_factory=list)
+    metadata: Dict[str, Any] = Field(default_factory=dict)
+
+    @field_validator("name")
+    @classmethod
+    def _ensure_name(cls, value: str) -> str:
+        stripped = value.strip()
+        if not stripped:
+            raise ValueError("artist name must not be empty")
+        return stripped
+
+
+class ProviderAlbum(BaseModel):
+    """Album metadata normalised across providers."""
+
+    model_config = ConfigDict(frozen=True)
+
+    id: Optional[ID] = None
+    name: str
+    uri: Optional[URI] = None
+    artists: List[ProviderArtist] = Field(default_factory=list)
+    release_date: Optional[ISODateTime] = None
+    total_tracks: Optional[int] = Field(default=None, ge=0)
+    metadata: Dict[str, Any] = Field(default_factory=dict)
+
+    @field_validator("name")
+    @classmethod
+    def _ensure_name(cls, value: str) -> str:
+        stripped = value.strip()
+        if not stripped:
+            raise ValueError("album name must not be empty")
+        return stripped
+
+
+class ProviderTrack(BaseModel):
+    """Track metadata enriched with optional candidates."""
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    id: Optional[ID] = None
+    name: str
+    provider: str
+    uri: Optional[URI] = None
+    artists: List[ProviderArtist] = Field(default_factory=list)
+    album: Optional[ProviderAlbum] = None
+    duration_ms: Optional[int] = Field(default=None, ge=0)
+    isrc: Optional[str] = None
+    score: Optional[float] = Field(default=None, ge=0.0)
+    metadata: Dict[str, Any] = Field(default_factory=dict)
+
+    @field_validator("name", "provider")
+    @classmethod
+    def _ensure_text(cls, value: str) -> str:
+        stripped = value.strip()
+        if not stripped:
+            raise ValueError("value must not be empty")
+        return stripped
+
+
+__all__ = ["ProviderAlbum", "ProviderArtist", "ProviderTrack"]

--- a/app/schemas/search.py
+++ b/app/schemas/search.py
@@ -1,0 +1,126 @@
+"""Search specific schemas shared across routers and services."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Mapping, Optional, Sequence
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationInfo, field_validator
+
+from app.schemas.common import Paging, SourceEnum
+
+
+class SearchQuery(BaseModel):
+    """Payload accepted by the smart search endpoint."""
+
+    model_config = ConfigDict(use_enum_values=True)
+
+    query: str = Field(..., description="Free-text search query")
+    type: str = Field(default="mixed", description="Result type filter")
+    sources: List[SourceEnum] = Field(
+        default_factory=lambda: [SourceEnum.SPOTIFY, SourceEnum.SOULSEEK]
+    )
+    genre: Optional[str] = None
+    year_from: Optional[int] = Field(default=None, ge=1900, le=2099)
+    year_to: Optional[int] = Field(default=None, ge=1900, le=2099)
+    min_bitrate: Optional[int] = Field(default=None, ge=0)
+    format_priority: Optional[List[str]] = None
+    limit: int = Field(default=25, ge=1)
+    offset: int = Field(default=0, ge=0)
+
+    @field_validator("query")
+    @classmethod
+    def _ensure_query(cls, value: str) -> str:
+        stripped = value.strip()
+        if not stripped:
+            raise ValueError("query must not be empty")
+        return stripped
+
+    @field_validator("sources", mode="before")
+    @classmethod
+    def _normalise_sources(cls, value: Optional[Sequence[str]]) -> List[SourceEnum]:
+        if value in (None, "", []):
+            return [SourceEnum.SPOTIFY, SourceEnum.SOULSEEK]
+        normalised: list[SourceEnum] = []
+        for item in value:
+            candidate = str(item).strip().lower()
+            if not candidate:
+                continue
+            try:
+                enum_value = SourceEnum(candidate)
+            except ValueError:
+                continue
+            if enum_value not in normalised:
+                normalised.append(enum_value)
+        return normalised or [SourceEnum.SPOTIFY, SourceEnum.SOULSEEK]
+
+    @field_validator("genre")
+    @classmethod
+    def _strip_optional(cls, value: Optional[str]) -> Optional[str]:
+        if value is None:
+            return None
+        stripped = value.strip()
+        return stripped or None
+
+    @field_validator("format_priority", mode="before")
+    @classmethod
+    def _normalise_formats(cls, value: Optional[Sequence[str]]) -> Optional[List[str]]:
+        if value in (None, ""):
+            return None
+        formatted: list[str] = []
+        for item in value:
+            if not item:
+                continue
+            candidate = str(item).strip().upper()
+            if candidate and candidate not in formatted:
+                formatted.append(candidate)
+        return formatted or None
+
+    @field_validator("year_to")
+    @classmethod
+    def _validate_year_range(
+        cls, value: Optional[int], info: ValidationInfo
+    ) -> Optional[int]:
+        year_from = info.data.get("year_from") if info.data else None
+        if year_from is not None and value is not None and year_from > value:
+            raise ValueError("year_from must be less than or equal to year_to")
+        return value
+
+
+class SearchItem(BaseModel):
+    """Normalised search result entry."""
+
+    model_config = ConfigDict(extra="allow", use_enum_values=True)
+
+    type: str
+    id: str
+    source: SourceEnum
+    title: str
+    artist: Optional[str] = None
+    album: Optional[str] = None
+    year: Optional[int] = None
+    genres: List[str] = Field(default_factory=list)
+    bitrate: Optional[int] = None
+    score: Optional[float] = Field(default=None, ge=0.0)
+    metadata: Dict[str, Any] = Field(default_factory=dict)
+
+    @field_validator("metadata", mode="before")
+    @classmethod
+    def _ensure_metadata(cls, value: Optional[Mapping[str, Any]]) -> Dict[str, Any]:
+        if value is None:
+            return {}
+        return dict(value)
+
+
+class SearchResponse(BaseModel):
+    """Envelope returned by the search endpoint."""
+
+    model_config = ConfigDict(use_enum_values=True)
+
+    items: List[SearchItem]
+    paging: Paging
+    sources: List[SourceEnum]
+    status: str = Field(default="ok")
+    failures: Dict[str, str] = Field(default_factory=dict)
+
+
+__all__ = ["SearchItem", "SearchQuery", "SearchResponse"]

--- a/app/schemas/spotify.py
+++ b/app/schemas/spotify.py
@@ -1,0 +1,88 @@
+"""Spotify-specific schema definitions preserved for compatibility."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Dict, List
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class SpotifySearchResponse(BaseModel):
+    items: List[Dict[str, Any]]
+
+
+class FollowedArtistsResponse(BaseModel):
+    artists: List[Dict[str, Any]]
+
+
+class ArtistReleasesResponse(BaseModel):
+    artist_id: str
+    releases: List[Dict[str, Any]]
+
+
+class DiscographyAlbum(BaseModel):
+    album: Dict[str, Any]
+    tracks: List[Dict[str, Any]] = Field(default_factory=list)
+
+
+class DiscographyResponse(BaseModel):
+    artist_id: str
+    albums: List[DiscographyAlbum] = Field(default_factory=list)
+
+
+class PlaylistEntry(BaseModel):
+    id: str
+    name: str
+    track_count: int
+    updated_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class PlaylistResponse(BaseModel):
+    playlists: List[PlaylistEntry]
+
+
+class TrackDetailResponse(BaseModel):
+    track: Dict[str, Any]
+
+
+class AudioFeaturesResponse(BaseModel):
+    audio_features: Dict[str, Any] | List[Dict[str, Any]]
+
+
+class PlaylistItemsResponse(BaseModel):
+    items: List[Dict[str, Any]]
+    total: int
+
+
+class SavedTracksResponse(BaseModel):
+    items: List[Dict[str, Any]]
+    total: int
+
+
+class UserProfileResponse(BaseModel):
+    profile: Dict[str, Any]
+
+
+class RecommendationsResponse(BaseModel):
+    tracks: List[Dict[str, Any]]
+    seeds: List[Dict[str, Any]]
+
+
+__all__ = [
+    "ArtistReleasesResponse",
+    "AudioFeaturesResponse",
+    "DiscographyAlbum",
+    "DiscographyResponse",
+    "FollowedArtistsResponse",
+    "PlaylistEntry",
+    "PlaylistItemsResponse",
+    "PlaylistResponse",
+    "RecommendationsResponse",
+    "SavedTracksResponse",
+    "SpotifySearchResponse",
+    "TrackDetailResponse",
+    "UserProfileResponse",
+]

--- a/app/schemas/system.py
+++ b/app/schemas/system.py
@@ -1,0 +1,60 @@
+"""System-level schema definitions (health, status, ping)."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from app.schemas.common import ISODateTime
+
+
+class StatusResponse(BaseModel):
+    status: str
+    artist_count: Optional[int] = None
+    album_count: Optional[int] = None
+    track_count: Optional[int] = None
+    last_scan: Optional[datetime] = None
+    connections: Optional[Dict[str, str]] = None
+
+
+class ServiceHealthResponse(BaseModel):
+    service: str
+    status: str
+    missing: List[str] = Field(default_factory=list)
+    optional_missing: List[str] = Field(default_factory=list)
+
+
+class HealthStatus(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    status: str
+    version: Optional[str] = None
+    uptime_s: Optional[float] = Field(default=None, ge=0)
+
+
+class VersionInfo(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    version: str
+    build: Optional[str] = None
+    commit: Optional[str] = None
+    generated_at: ISODateTime
+
+
+class Ping(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    ok: bool = True
+    at: ISODateTime
+    meta: Dict[str, Any] = Field(default_factory=dict)
+
+
+__all__ = [
+    "HealthStatus",
+    "Ping",
+    "ServiceHealthResponse",
+    "StatusResponse",
+    "VersionInfo",
+]


### PR DESCRIPTION
## Summary
- add foundational schema modules under `app/schemas/` to hold canonical DTOs
- provide common primitives (IDs, URIs, paging, problem detail) and provider/search/system/spotify models for future adoption

## Testing
- not run (schema scaffolding only)


------
https://chatgpt.com/codex/tasks/task_e_68de7e428cbc8321b8a9c67b1e04f095