### PR TITLE
refactor(api): align watchlist router with service layer [CODX-P1-APP-501]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - feat(orchestrator): configurable priorities, pools, visibility, heartbeat, timer [CODX-ORCH-084]
   - Dokumentiert den Orchestrator im README, ergänzt Runtime-Guides (Prioritäten, Pools, Heartbeats) und verweist im PR-Template auf Migrations-/ENV-Hinweise.
 - refactor(api): domain router registry, unified middleware chain & error handlers; remove `/metrics` wiring [CODX-API-REF-312]
+- refactor(api): watchlist router delegates to `WatchlistService`, ensures structured logging & conflict handling [CODX-P1-APP-501]
 - refactor(spotify): consolidate domain service and routers via `SpotifyDomainService` + unified router [CODX-P1-SPOT-303]
 - feat(spotify): move Spotify domain service + routes into unified module, delegate legacy routers and extend tests/docs [CODX-P1-SPOT-203]
 - chore(config): centralize orchestrator/provider env parsing, add tests & docs [CODX-CONF-301]

--- a/README.md
+++ b/README.md
@@ -627,6 +627,7 @@ Das vollständige Schema steht über `${API_BASE_PATH}/openapi.json` bereit und 
 
 
 - Domänenrouter liegen in `app/api/<domain>.py` (z. B. `spotify`, `search`, `system`, `watchlist` als optionales Modul) und kapseln die öffentlich erreichbaren Endpunkte. Legacy-Module in `app/routers/` dienen ausschließlich als Thin-Reexports.
+- Der Watchlist-Endpunkt nutzt `app/services/watchlist_service.py`, um Datenbankzugriffe zu kapseln und strukturierte `service.call`-Events zu emittieren. Router arbeiten damit ausschließlich gegen Services statt rohe Sessions zu verwenden.
 - `app/api/router_registry.py` registriert sämtliche Domain-Router und vergibt konsistente Prefixes sowie OpenAPI-Tags – Tests können die Liste zentral prüfen.
 - `app/middleware/__init__.py` bündelt die komplette HTTP-Pipeline (Request-ID, Logging, optionale Auth/Rate-Limits, Cache, CORS/GZip, Error-Mapper).
 

--- a/app/api/routers/watchlist.py
+++ b/app/api/routers/watchlist.py
@@ -2,37 +2,23 @@
 
 from __future__ import annotations
 
-from datetime import datetime
+from fastapi import APIRouter, Depends, Response, status
 
-from fastapi import APIRouter, Depends, HTTPException, Response, status
-from sqlalchemy import select
-from sqlalchemy.orm import Session
+from app.dependencies import get_watchlist_service
+from app.schemas import WatchlistArtistCreate, WatchlistArtistEntry, WatchlistListResponse
+from app.services.watchlist_service import WatchlistService
 
-from app.dependencies import get_db
-from app.logging import get_logger
-from app.models import WatchlistArtist
-from app.schemas import (
-    WatchlistArtistCreate,
-    WatchlistArtistEntry,
-    WatchlistListResponse,
-)
 
 router = APIRouter(prefix="/watchlist", tags=["Watchlist"])
-logger = get_logger(__name__)
 
 
 @router.get("", response_model=WatchlistListResponse)
-def list_watchlist(session: Session = Depends(get_db)) -> WatchlistListResponse:
+def list_watchlist(
+    service: WatchlistService = Depends(get_watchlist_service),
+) -> WatchlistListResponse:
     """Return all registered watchlist artists."""
 
-    records = (
-        session.execute(select(WatchlistArtist).order_by(WatchlistArtist.created_at.asc()))
-        .scalars()
-        .all()
-    )
-    logger.debug("Fetched %d watchlist artist(s)", len(records))
-    items = [WatchlistArtistEntry.model_validate(record) for record in records]
-    return WatchlistListResponse(items=items)
+    return service.list_artists()
 
 
 @router.post(
@@ -42,57 +28,19 @@ def list_watchlist(session: Session = Depends(get_db)) -> WatchlistListResponse:
 )
 def add_watchlist_artist(
     payload: WatchlistArtistCreate,
-    session: Session = Depends(get_db),
+    service: WatchlistService = Depends(get_watchlist_service),
 ) -> WatchlistArtistEntry:
     """Add a new artist to the automated release watchlist."""
 
-    spotify_id = payload.spotify_artist_id.strip()
-    name = payload.name.strip()
-
-    existing = (
-        session.execute(
-            select(WatchlistArtist).where(WatchlistArtist.spotify_artist_id == spotify_id)
-        )
-        .scalars()
-        .first()
-    )
-    if existing is not None:
-        logger.info("Watchlist artist %s already registered", spotify_id)
-        raise HTTPException(
-            status_code=status.HTTP_409_CONFLICT,
-            detail="Artist already registered",
-        )
-
-    now = datetime.utcnow()
-    record = WatchlistArtist(
-        spotify_artist_id=spotify_id,
-        name=name,
-        last_checked=now,
-    )
-    session.add(record)
-    session.commit()
-    session.refresh(record)
-
-    logger.info("Added %s (%s) to watchlist", name, spotify_id)
-    return WatchlistArtistEntry.model_validate(record)
+    return service.add_artist(payload)
 
 
 @router.delete("/{artist_id}", status_code=status.HTTP_204_NO_CONTENT)
 def remove_watchlist_artist(
     artist_id: int,
-    session: Session = Depends(get_db),
+    service: WatchlistService = Depends(get_watchlist_service),
 ) -> Response:
     """Remove an artist from the release watchlist."""
 
-    record = session.get(WatchlistArtist, int(artist_id))
-    if record is None:
-        logger.info("Watchlist artist %s not found for deletion", artist_id)
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="Watchlist artist not found",
-        )
-
-    session.delete(record)
-    session.commit()
-    logger.info("Removed %s (%s) from watchlist", record.name, record.spotify_artist_id)
+    service.remove_artist(int(artist_id))
     return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/app/dependencies.py
+++ b/app/dependencies.py
@@ -6,7 +6,7 @@ from functools import lru_cache
 import hmac
 from typing import Generator
 
-from fastapi import Request, status
+from fastapi import Depends, Request, status
 
 from sqlalchemy.orm import Session
 
@@ -21,6 +21,7 @@ from app.integrations.registry import ProviderRegistry
 from app.errors import AppError, ErrorCode
 from app.logging import get_logger
 from app.services.integration_service import IntegrationService
+from app.services.watchlist_service import WatchlistService
 
 
 _integration_service_override: IntegrationService | None = None
@@ -86,6 +87,10 @@ def get_db() -> Generator[Session, None, None]:
         yield session
     finally:
         session.close()
+
+
+def get_watchlist_service(session: Session = Depends(get_db)) -> WatchlistService:
+    return WatchlistService(session=session)
 
 
 def _is_allowlisted(path: str, allowlist: tuple[str, ...]) -> bool:

--- a/app/services/watchlist_service.py
+++ b/app/services/watchlist_service.py
@@ -1,0 +1,145 @@
+"""Service layer for managing watchlist artists via the public API."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from time import perf_counter
+from logging import Logger
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.errors import AppError, ErrorCode, NotFoundError
+from app.logging import get_logger
+from app.logging_events import log_event
+from app.models import WatchlistArtist
+from app.schemas import (
+    WatchlistArtistCreate,
+    WatchlistArtistEntry,
+    WatchlistListResponse,
+)
+
+
+@dataclass(slots=True)
+class WatchlistService:
+    """Expose CRUD operations for watchlist artists."""
+
+    session: Session
+    _logger: Logger = field(init=False, repr=False)
+
+    def __post_init__(self) -> None:  # pragma: no cover - simple assignment
+        object.__setattr__(self, "_logger", get_logger(__name__))
+
+    def list_artists(self) -> WatchlistListResponse:
+        """Return all artists ordered by creation timestamp."""
+
+        start = perf_counter()
+        statement = select(WatchlistArtist).order_by(WatchlistArtist.created_at.asc())
+        artists = self.session.execute(statement).scalars().all()
+        duration_ms = (perf_counter() - start) * 1_000
+        items = [WatchlistArtistEntry.model_validate(record) for record in artists]
+        log_event(
+            self._logger,
+            "service.call",
+            component="service.watchlist",
+            operation="list",
+            status="ok",
+            duration_ms=round(duration_ms, 3),
+            result_count=len(items),
+        )
+        return WatchlistListResponse(items=items)
+
+    def add_artist(self, payload: WatchlistArtistCreate) -> WatchlistArtistEntry:
+        """Persist a new watchlist artist if it does not already exist."""
+
+        spotify_id = payload.spotify_artist_id.strip()
+        name = payload.name.strip()
+        start = perf_counter()
+
+        existing = (
+            self.session.execute(
+                select(WatchlistArtist).where(WatchlistArtist.spotify_artist_id == spotify_id)
+            )
+            .scalars()
+            .first()
+        )
+        if existing is not None:
+            duration_ms = (perf_counter() - start) * 1_000
+            log_event(
+                self._logger,
+                "service.call",
+                component="service.watchlist",
+                operation="add",
+                status="error",
+                duration_ms=round(duration_ms, 3),
+                entity_id=str(existing.id),
+                spotify_artist_id=spotify_id,
+                error="artist_exists",
+            )
+            raise AppError(
+                "Artist already registered.",
+                code=ErrorCode.VALIDATION_ERROR,
+                http_status=409,
+                meta={"spotify_artist_id": spotify_id},
+            )
+
+        now = datetime.utcnow()
+        record = WatchlistArtist(
+            spotify_artist_id=spotify_id,
+            name=name,
+            last_checked=now,
+        )
+        self.session.add(record)
+        self.session.commit()
+        self.session.refresh(record)
+
+        duration_ms = (perf_counter() - start) * 1_000
+        log_event(
+            self._logger,
+            "service.call",
+            component="service.watchlist",
+            operation="add",
+            status="ok",
+            duration_ms=round(duration_ms, 3),
+            entity_id=str(record.id),
+            spotify_artist_id=spotify_id,
+        )
+        return WatchlistArtistEntry.model_validate(record)
+
+    def remove_artist(self, artist_id: int) -> None:
+        """Remove an artist from the watchlist or raise if missing."""
+
+        start = perf_counter()
+        record = self.session.get(WatchlistArtist, int(artist_id))
+        if record is None:
+            duration_ms = (perf_counter() - start) * 1_000
+            log_event(
+                self._logger,
+                "service.call",
+                component="service.watchlist",
+                operation="remove",
+                status="error",
+                duration_ms=round(duration_ms, 3),
+                entity_id=str(artist_id),
+                error="not_found",
+            )
+            raise NotFoundError("Watchlist artist not found.")
+
+        self.session.delete(record)
+        self.session.commit()
+
+        duration_ms = (perf_counter() - start) * 1_000
+        log_event(
+            self._logger,
+            "service.call",
+            component="service.watchlist",
+            operation="remove",
+            status="ok",
+            duration_ms=round(duration_ms, 3),
+            entity_id=str(artist_id),
+            spotify_artist_id=record.spotify_artist_id,
+        )
+
+
+__all__ = ["WatchlistService"]


### PR DESCRIPTION
## Kurzfassung
**Was/Warum:** Watchlist-Routen delegieren jetzt an einen dedizierten Service, der Logging-Contract und Konfliktbehandlung vereinheitlicht.
**TASK_ID:** CODX-P1-APP-501

## Änderungen (Dateien)
- Neu/Geändert/Gelöscht:
  - Neu: `app/services/watchlist_service.py`
  - Geändert: `app/api/routers/watchlist.py`, `app/dependencies.py`, `README.md`, `CHANGELOG.md`

## Tests & Nachweise
- Befehle/Logs/Screens:
  - `ruff check app/services/watchlist_service.py app/api/routers/watchlist.py app/dependencies.py`
  - `black --check .`
  - `mypy app`
  - `pytest -q`
- Coverage (geänderte Module): Bestehende Tests, keine Abweichung von Vorgaben

## Verträge
- Public-API: unverändert (OpenAPI nicht angepasst)
- DB/Migration: nein (keine Migration notwendig)

## Migration & Deployment
- Migration ausgeführt (`alembic upgrade head`): nein
- ENV-Defaults geprüft/kommuniziert: nicht erforderlich (keine Änderungen)

## Doku & ToDo
- README/CHANGELOG/ADR aktualisiert: ja
- ToDo.md aktualisiert (Nachweis-Link): nicht erforderlich

## Checkliste
- [x] AGENTS.md gelesen & Scope-Guard geprüft
- [x] Keine Secrets/`BACKUP`/Lizenzdateien verändert
- [x] `pytest -q`, `mypy app`, `ruff`, `black --check` grün oder Ausnahme dokumentiert

------
https://chatgpt.com/codex/tasks/task_e_68de9b460ba8832185a1329852d5f4a7