### PR TITLE
fix: warn when orchestrator metrics fail to increment [NO-TASK]

### DIFF
--- a/tests/orchestrator/test_events.py
+++ b/tests/orchestrator/test_events.py
@@ -1,0 +1,36 @@
+"""Tests for orchestrator event helpers."""
+
+from __future__ import annotations
+
+import logging
+
+from app.orchestrator import events
+
+
+def test_increment_metric_logs_warning(monkeypatch, caplog):
+    """Ensure metric increments that fail emit a structured warning."""
+
+    def _raise_error(key: str) -> int:  # pragma: no cover - helper
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(events, "increment_counter", _raise_error)
+
+    with caplog.at_level(logging.WARNING, logger="app.orchestrator.metrics"):
+        events._increment_metric("orchestrator.commit", "failed")
+
+    expected_key = "metrics.orchestrator.commit.failed"
+
+    warning_record = next(
+        (
+            record
+            for record in caplog.records
+            if record.levelno == logging.WARNING
+            and getattr(record, "event", "") == "orchestrator.metrics.increment_failed"
+        ),
+        None,
+    )
+
+    assert warning_record is not None
+    assert warning_record.metric_key == expected_key
+    assert warning_record.status == "error"
+    assert warning_record.metric_status == "failed"


### PR DESCRIPTION
## Summary
- log a structured warning when orchestrator metrics increments fail so alerting can be triggered with the metric key context
- add coverage for the warning path by simulating a counter failure in the orchestrator events helper

## Testing
- ruff check .
- black --check .
- mypy
- pytest
- pytest tests/orchestrator/test_events.py


------
https://chatgpt.com/codex/tasks/task_e_68deb3d8d7608321a863e59c772ba662