### PR TITLE
fix: parse spotify user playlist links

### DIFF
--- a/tests/utils/test_spotify_free.py
+++ b/tests/utils/test_spotify_free.py
@@ -1,0 +1,55 @@
+"""Regression tests for Spotify FREE playlist link parsing."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.utils.spotify_free import _normalise_playlist_link
+
+
+@pytest.mark.parametrize(
+    "link",
+    [
+        "https://open.spotify.com/playlist/37i9dQZF1DXcBWIGoYBM5M",
+        "spotify:playlist:37i9dQZF1DXcBWIGoYBM5M",
+    ],
+)
+def test_normalise_playlist_link_accepts_direct_playlist_links(link: str) -> None:
+    playlist_id, reason = _normalise_playlist_link(link, allow_user_urls=False)
+
+    assert playlist_id == "37i9dQZF1DXcBWIGoYBM5M"
+    assert reason is None
+
+
+def test_normalise_playlist_link_accepts_user_playlist_url_when_allowed() -> None:
+    playlist_id, reason = _normalise_playlist_link(
+        "https://open.spotify.com/user/spotify/playlist/37i9dQZF1DXcBWIGoYBM5M",
+        allow_user_urls=True,
+    )
+
+    assert playlist_id == "37i9dQZF1DXcBWIGoYBM5M"
+    assert reason is None
+
+
+def test_normalise_playlist_link_accepts_user_playlist_uri_when_allowed() -> None:
+    playlist_id, reason = _normalise_playlist_link(
+        "spotify:user:spotify:playlist:37i9dQZF1DXcBWIGoYBM5M",
+        allow_user_urls=True,
+    )
+
+    assert playlist_id == "37i9dQZF1DXcBWIGoYBM5M"
+    assert reason is None
+
+
+@pytest.mark.parametrize(
+    "link",
+    [
+        "https://open.spotify.com/user/spotify/playlist/37i9dQZF1DXcBWIGoYBM5M",
+        "spotify:user:spotify:playlist:37i9dQZF1DXcBWIGoYBM5M",
+    ],
+)
+def test_normalise_playlist_link_rejects_user_links_when_disallowed(link: str) -> None:
+    playlist_id, reason = _normalise_playlist_link(link, allow_user_urls=False)
+
+    assert playlist_id is None
+    assert reason == "NOT_A_PLAYLIST_URL"


### PR DESCRIPTION
## Summary
- allow `_normalise_playlist_link` to extract playlist IDs from Spotify user playlist URLs/URIs when enabled
- add regression coverage for direct and user playlist links in `tests/utils/test_spotify_free.py`

## Testing
- `pytest`
- `ruff check`
- `black --check .`
- `mypy`


------
https://chatgpt.com/codex/tasks/task_e_68deba65a27083218bf5d6874e96d4c2