### PR TITLE
feat: extend cache middleware configuration [NO-TASK]

### DIFF
--- a/app/middleware/__init__.py
+++ b/app/middleware/__init__.py
@@ -26,6 +26,7 @@ def install_middleware(app: FastAPI, config: AppConfig) -> None:
     response_cache = ResponseCache(
         max_items=middleware_cfg.cache.max_items,
         default_ttl=float(middleware_cfg.cache.default_ttl),
+        fail_open=middleware_cfg.cache.fail_open,
     )
     app.state.response_cache = response_cache
 

--- a/tests/middleware/test_cache_middleware.py
+++ b/tests/middleware/test_cache_middleware.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.config import load_config
+from app.middleware.cache import CacheMiddleware
+from app.services.cache import ResponseCache
+
+
+def _create_app(
+    env: dict[str, str],
+    routes: dict[str, Callable[[], dict[str, object]]],
+    monkeypatch: pytest.MonkeyPatch,
+) -> tuple[TestClient, dict[str, int], ResponseCache]:
+    relevant_keys = {
+        "CACHE_DEFAULT_TTL_S",
+        "CACHE_STALE_WHILE_REVALIDATE_S",
+        "CACHE_FAIL_OPEN",
+        "CACHE_ENABLED",
+        "CACHE_MAX_ITEMS",
+        "CACHE_STRATEGY_ETAG",
+        "CACHEABLE_PATHS",
+        "DATABASE_URL",
+    }
+    for key in relevant_keys:
+        monkeypatch.delenv(key, raising=False)
+    for key, value in env.items():
+        monkeypatch.setenv(key, value)
+
+    config = load_config()
+    cache_config = config.middleware.cache
+    app = FastAPI()
+    app.state.api_base_path = config.api_base_path
+
+    call_counts: dict[str, int] = {path: 0 for path in routes}
+
+    for path, handler in routes.items():
+
+        async def _endpoint(
+            handler: Callable[[], dict[str, object]] = handler,
+            path: str = path,
+        ) -> dict[str, object]:
+            call_counts[path] += 1
+            return handler()
+
+        app.get(path)(_endpoint)  # type: ignore[misc]
+
+    response_cache = ResponseCache(
+        max_items=cache_config.max_items,
+        default_ttl=float(cache_config.default_ttl),
+        fail_open=cache_config.fail_open,
+    )
+    app.state.response_cache = response_cache
+    app.add_middleware(CacheMiddleware, cache=response_cache, config=cache_config)
+
+    return TestClient(app), call_counts, response_cache
+
+
+def test_cache_control_uses_path_specific_rules(monkeypatch: pytest.MonkeyPatch) -> None:
+    env = {
+        "DATABASE_URL": "sqlite:///:memory:",
+        "CACHE_DEFAULT_TTL_S": "45",
+        "CACHE_STALE_WHILE_REVALIDATE_S": "90",
+        "CACHEABLE_PATHS": "^/cache/me$|120|30, ^/cache/default$||",
+    }
+
+    routes = {
+        "/cache/me": lambda: {"path": "me"},
+        "/cache/default": lambda: {"path": "default"},
+    }
+
+    client, calls, _ = _create_app(env, routes, monkeypatch)
+
+    me_response = client.get("/cache/me")
+    assert me_response.status_code == 200
+    assert me_response.headers["Cache-Control"] == "public, max-age=120, stale-while-revalidate=30"
+    assert calls["/cache/me"] == 1
+
+    cached_me = client.get("/cache/me")
+    assert cached_me.status_code == 200
+    assert cached_me.headers["Cache-Control"] == "public, max-age=120, stale-while-revalidate=30"
+    assert calls["/cache/me"] == 1
+
+    default_response = client.get("/cache/default")
+    assert default_response.status_code == 200
+    assert (
+        default_response.headers["Cache-Control"] == "public, max-age=45, stale-while-revalidate=90"
+    )
+    assert calls["/cache/default"] == 1
+
+    cached_default = client.get("/cache/default")
+    assert cached_default.status_code == 200
+    assert (
+        cached_default.headers["Cache-Control"] == "public, max-age=45, stale-while-revalidate=90"
+    )
+    assert calls["/cache/default"] == 1
+
+
+def test_cache_fail_closed_propagates_errors(monkeypatch: pytest.MonkeyPatch) -> None:
+    env = {
+        "DATABASE_URL": "sqlite:///:memory:",
+        "CACHE_FAIL_OPEN": "false",
+        "CACHEABLE_PATHS": "^/boom$|10|",
+    }
+
+    client, _, cache = _create_app(env, {"/boom": lambda: {"ok": True}}, monkeypatch)
+
+    class ExplodingDict(dict):
+        def get(self, key):  # type: ignore[override]
+            raise RuntimeError("boom")
+
+    cache._cache = ExplodingDict()  # type: ignore[attr-defined]
+
+    with pytest.raises(RuntimeError):
+        client.get("/boom")

--- a/tests/observability/test_logging_cache.py
+++ b/tests/observability/test_logging_cache.py
@@ -35,6 +35,9 @@ async def test_cache_logs_use_contract(monkeypatch) -> None:
         vary=(),
         created_at=0.0,
         expires_at=None,
+        ttl=0.0,
+        stale_while_revalidate=None,
+        stale_expires_at=None,
     )
 
     await cache.set("demo", entry)

--- a/tests/services/test_cache_logging_and_ttl.py
+++ b/tests/services/test_cache_logging_and_ttl.py
@@ -31,6 +31,9 @@ def _entry() -> CacheEntry:
         vary=tuple(),
         created_at=0.0,
         expires_at=None,
+        ttl=0.0,
+        stale_while_revalidate=None,
+        stale_expires_at=None,
     )
 
 

--- a/tests/test_cache_store.py
+++ b/tests/test_cache_store.py
@@ -39,6 +39,9 @@ def _make_entry(path: str, body: bytes, *, last_modified: datetime | None = None
         vary=("Authorization",),
         created_at=0.0,
         expires_at=None,
+        ttl=1.0,
+        stale_while_revalidate=None,
+        stale_expires_at=None,
     )
 
 


### PR DESCRIPTION
## Summary
- add fail_open and stale cache settings to the middleware configuration, including structured cache rules
- update the response cache and middleware to honor per-route TTL/stale values and propagate failures when fail_open is disabled
- add regression tests covering cache-control overrides and fail_closed behaviour

## Testing
- pytest
- ruff check
- black --check .
- mypy

------
https://chatgpt.com/codex/tasks/task_e_68debd7e21748321a56a9963c20e5251