### PR TITLE
fix: offload playlist sync DB work

### DIFF
--- a/tests/workers/test_playlist_sync_worker.py
+++ b/tests/workers/test_playlist_sync_worker.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import asyncio
+import threading
 import time
+from contextlib import contextmanager
 
 import pytest
 
@@ -44,3 +46,56 @@ async def test_playlist_sync_worker_yields_control_during_fetch() -> None:
     await ticker_task
 
     assert client.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_playlist_sync_worker_offloads_db_work(monkeypatch: pytest.MonkeyPatch) -> None:
+    main_thread = threading.current_thread()
+    session_threads: list[threading.Thread] = []
+
+    class DummySession:
+        def __init__(self) -> None:
+            self.store: dict[str, object] = {}
+
+        def get(self, _model: object, key: str) -> object | None:
+            return self.store.get(key)
+
+        def add(self, playlist: object) -> None:
+            playlist_id = getattr(playlist, "id", None)
+            if playlist_id is not None:
+                self.store[str(playlist_id)] = playlist
+
+    @contextmanager
+    def fake_session_scope() -> DummySession:
+        session_threads.append(threading.current_thread())
+        yield DummySession()
+
+    monkeypatch.setattr(
+        "app.workers.playlist_sync_worker.session_scope",
+        fake_session_scope,
+    )
+
+    client_payload = [{"id": "abc123", "name": "Test Playlist", "tracks": {"total": 3}}]
+
+    class _Client:
+        def get_user_playlists(self) -> list[dict[str, object]]:
+            return client_payload
+
+    worker = PlaylistSyncWorker(_Client(), interval_seconds=0.1)
+
+    original_to_thread = asyncio.to_thread
+    to_thread_calls: list[tuple[object, tuple[object, ...], dict[str, object]]] = []
+
+    async def spy_to_thread(func: object, /, *args: object, **kwargs: object) -> object:
+        to_thread_calls.append((func, args, kwargs))
+        return await original_to_thread(func, *args, **kwargs)
+
+    monkeypatch.setattr(asyncio, "to_thread", spy_to_thread)
+
+    await worker.sync_once()
+
+    assert any(
+        getattr(call[0], "__name__", "") == "_persist_playlists" for call in to_thread_calls
+    ), "Database persistence should run via asyncio.to_thread"
+    assert session_threads, "session_scope should be invoked"
+    assert all(thread is not main_thread for thread in session_threads)


### PR DESCRIPTION
## Summary
- offload playlist persistence to a threaded helper so the worker coroutine stays responsive
- add regression coverage that spies on `asyncio.to_thread` to ensure database writes stay off the event loop

## Testing
- pytest
- pytest tests/workers/test_playlist_sync_worker.py
- ruff check tests/workers/test_playlist_sync_worker.py app/workers/playlist_sync_worker.py
- black --check tests/workers/test_playlist_sync_worker.py app/workers/playlist_sync_worker.py
- mypy app/workers/playlist_sync_worker.py

------
https://chatgpt.com/codex/tasks/task_e_68dec280951083218c2b6a4e49bb0222