### PR TITLE
feat: introduce download service abstraction

### DIFF
--- a/app/dependencies.py
+++ b/app/dependencies.py
@@ -20,6 +20,7 @@ from app.integrations.provider_gateway import ProviderGateway
 from app.integrations.registry import ProviderRegistry
 from app.errors import AppError, ErrorCode
 from app.logging import get_logger
+from app.services.download_service import DownloadService
 from app.services.integration_service import IntegrationService
 from app.services.watchlist_service import WatchlistService
 
@@ -91,6 +92,13 @@ def get_db() -> Generator[Session, None, None]:
 
 def get_watchlist_service(session: Session = Depends(get_db)) -> WatchlistService:
     return WatchlistService(session=session)
+
+
+def get_download_service(
+    session: Session = Depends(get_db),
+    transfers: TransfersApi = Depends(get_transfers_api),
+) -> DownloadService:
+    return DownloadService(session=session, transfers=transfers)
 
 
 def _is_allowlisted(path: str, allowlist: tuple[str, ...]) -> bool:

--- a/app/routers/download_router.py
+++ b/app/routers/download_router.py
@@ -4,37 +4,21 @@ from __future__ import annotations
 
 import json
 from datetime import datetime, timezone
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Optional
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
+from fastapi import APIRouter, Depends, Query, Request, status
 from fastapi.responses import Response
-from sqlalchemy.orm import Session
 
-from app.core.transfers_api import TransfersApi, TransfersApiError
-from app.dependencies import get_db, get_transfers_api
+from app.dependencies import get_download_service
 from app.logging import get_logger
-from app.models import Download
 from app.schemas import (
     DownloadEntryResponse,
     DownloadListResponse,
     DownloadPriorityUpdate,
     SoulseekDownloadRequest,
 )
-from app.utils.activity import record_activity
-from app.utils.downloads import (
-    ACTIVE_STATES,
-    coerce_priority,
-    determine_priority,
-    render_downloads_csv,
-    resolve_status_filter,
-    serialise_download,
-)
-from app.utils.events import (
-    DOWNLOAD_BLOCKED,
-)
-from app.utils.service_health import collect_missing_credentials
-from app.workers.persistence import update_priority
-from app.errors import AppError, ValidationAppError
+from app.services.download_service import DownloadService
+from app.errors import ValidationAppError
 
 router = APIRouter(tags=["Download"])
 logger = get_logger(__name__)
@@ -53,36 +37,13 @@ def _parse_iso8601(value: str) -> datetime:
     return parsed
 
 
-def _build_download_query(
-    session: Session,
-    *,
-    include_all: bool,
-    status_filter: Optional[str] = None,
-    created_from: Optional[datetime] = None,
-    created_to: Optional[datetime] = None,
-) -> Any:
-    query = session.query(Download)
-    if status_filter:
-        states = resolve_status_filter(status_filter)
-        query = query.filter(Download.state.in_(tuple(states)))
-    elif not include_all:
-        query = query.filter(Download.state.in_(tuple(ACTIVE_STATES)))
-
-    if created_from:
-        query = query.filter(Download.created_at >= created_from)
-    if created_to:
-        query = query.filter(Download.created_at <= created_to)
-
-    return query.order_by(Download.priority.desc(), Download.created_at.desc())
-
-
 @router.get("/downloads", response_model=DownloadListResponse)
 def list_downloads(
     limit: int = Query(20, ge=1, le=100),
     offset: int = Query(0, ge=0),
     all: bool = False,  # noqa: A002 - query parameter name mandated by API contract
     status_filter: Optional[str] = Query(None, alias="status"),
-    session: Session = Depends(get_db),
+    service: DownloadService = Depends(get_download_service),
 ) -> DownloadListResponse:
     """Return downloads with optional status filtering."""
 
@@ -94,48 +55,24 @@ def list_downloads(
         limit,
         offset,
     )
-    try:
-        query = _build_download_query(
-            session,
-            include_all=all,
-            status_filter=status_label,
-        )
-        downloads = query.offset(offset).limit(limit).all()
-    except (HTTPException, AppError):
-        raise
-    except Exception as exc:  # pragma: no cover - defensive database failure handling
-        logger.exception("Failed to list downloads: %s", exc)
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Failed to fetch downloads",
-        ) from exc
-
+    downloads = service.list_downloads(
+        include_all=all,
+        status_filter=status_label,
+        limit=limit,
+        offset=offset,
+    )
     return DownloadListResponse(downloads=downloads)
 
 
 @router.get("/download/{download_id}", response_model=DownloadEntryResponse)
 def get_download(
     download_id: int,
-    session: Session = Depends(get_db),
+    service: DownloadService = Depends(get_download_service),
 ) -> DownloadEntryResponse:
     """Return the persisted state of a single download."""
 
     logger.info("Download detail requested for id=%s", download_id)
-    try:
-        download = session.get(Download, download_id)
-    except (HTTPException, AppError):
-        raise
-    except Exception as exc:  # pragma: no cover - defensive database failure handling
-        logger.exception("Failed to load download %s: %s", download_id, exc)
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Failed to fetch download",
-        ) from exc
-
-    if download is None:
-        logger.warning("Download %s not found", download_id)
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Download not found")
-
+    download = service.get_download(download_id)
     return DownloadEntryResponse.model_validate(download)
 
 
@@ -143,48 +80,12 @@ def get_download(
 def update_download_priority(
     download_id: int,
     payload: DownloadPriorityUpdate,
-    session: Session = Depends(get_db),
+    service: DownloadService = Depends(get_download_service),
 ) -> DownloadEntryResponse:
     """Update the priority of a persisted download."""
 
     logger.info("Priority update requested for download %s", download_id)
-    try:
-        download = session.get(Download, download_id)
-    except (HTTPException, AppError):
-        raise
-    except Exception as exc:  # pragma: no cover - defensive database failure handling
-        logger.exception("Failed to load download %s for priority update: %s", download_id, exc)
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Failed to update download priority",
-        ) from exc
-
-    if download is None:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Download not found")
-
-    new_priority = int(payload.priority)
-    download.priority = new_priority
-    download.updated_at = datetime.utcnow()
-    payload_copy = dict(download.request_payload or {})
-    payload_copy["priority"] = new_priority
-    download.request_payload = payload_copy
-    session.add(download)
-    session.commit()
-
-    logger.info(
-        "Updated priority for download %s to %s",
-        download_id,
-        new_priority,
-    )
-
-    job_id = download.job_id
-    if job_id and not update_priority(job_id, new_priority, job_type="sync"):
-        logger.error(
-            "Failed to update worker job priority for download %s (job %s)",
-            download_id,
-            job_id,
-        )
-
+    download = service.update_priority(download_id, payload)
     return DownloadEntryResponse.model_validate(download)
 
 
@@ -192,186 +93,23 @@ def update_download_priority(
 async def start_download(
     payload: SoulseekDownloadRequest,
     request: Request,
-    session: Session = Depends(get_db),
+    service: DownloadService = Depends(get_download_service),
 ) -> Dict[str, Any]:
     """Persist requested downloads and enqueue them for the SyncWorker."""
 
-    if not payload.files:
-        logger.warning("Download request without files rejected")
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="No files supplied")
-
-    missing_credentials = collect_missing_credentials(session, ("soulseek",))
-    if missing_credentials:
-        missing_payload = {service: list(values) for service, values in missing_credentials.items()}
-        logger.warning("Download blocked due to missing credentials: %s", missing_payload)
-        record_activity(
-            "download",
-            DOWNLOAD_BLOCKED,
-            details={"missing": missing_payload, "username": payload.username},
-        )
-        raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail={"message": "Download blocked", "missing": missing_payload},
-        )
-
     worker = getattr(request.app.state, "sync_worker", None)
-    enqueue = getattr(worker, "enqueue", None)
-    if enqueue is None:
-        logger.error("Download worker unavailable for request from %s", payload.username)
-        record_activity("download", "failed", details={"reason": "worker_unavailable"})
-        raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail="Download worker unavailable",
-        )
-
-    download_records: List[Download] = []
-    job_files: List[Dict[str, Any]] = []
-    try:
-        job_priorities: List[int] = []
-        for file_info in payload.files:
-            filename = str(file_info.get("filename") or file_info.get("name") or "unknown")
-            priority = determine_priority(file_info)
-            download = Download(
-                filename=filename,
-                state="queued",
-                progress=0.0,
-                username=payload.username,
-                priority=priority,
-            )
-            session.add(download)
-            session.flush()
-
-            payload_copy = dict(file_info)
-            payload_copy.setdefault("filename", filename)
-            payload_copy["download_id"] = download.id
-            payload_copy["priority"] = priority
-            download.request_payload = payload_copy
-            job_files.append(payload_copy)
-
-            download_records.append(download)
-            job_priorities.append(priority)
-        session.commit()
-    except Exception as exc:  # pragma: no cover - defensive persistence handling
-        session.rollback()
-        logger.exception("Failed to persist download request: %s", exc)
-        record_activity("download", "failed", details={"reason": "persistence_error"})
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to queue download"
-        ) from exc
-
-    job_priority = max(job_priorities or [0])
-    job = {"username": payload.username, "files": job_files, "priority": job_priority}
-    try:
-        await enqueue(job)
-    except Exception as exc:  # pragma: no cover - defensive worker error
-        logger.exception("Failed to enqueue download job: %s", exc)
-        now = datetime.utcnow()
-        for download in download_records:
-            download.state = "failed"
-            download.updated_at = now
-        session.commit()
-        record_activity("download", "failed", details={"reason": "enqueue_error"})
-        raise HTTPException(
-            status_code=status.HTTP_502_BAD_GATEWAY, detail="Failed to enqueue download"
-        ) from exc
-
-    download_payload = [
-        {
-            "id": download.id,
-            "filename": download.filename,
-            "state": download.state,
-            "progress": download.progress,
-            "priority": download.priority,
-            "username": download.username,
-        }
-        for download in download_records
-    ]
-
-    record_activity(
-        "download",
-        "queued",
-        details={
-            "download_ids": [download.id for download in download_records],
-            "username": payload.username,
-        },
-    )
-
-    logger.info("Queued %d download(s) for %s", len(download_records), payload.username)
-
-    primary_id = download_records[0].id if download_records else None
-    response: Dict[str, Any] = {
-        "status": "queued",
-        "downloads": download_payload,
-    }
-    if primary_id is not None:
-        response["download_id"] = primary_id
-    return response
+    return await service.queue_downloads(payload, worker=worker)
 
 
 @router.delete("/download/{download_id}")
 async def cancel_download(
     download_id: int,
-    session: Session = Depends(get_db),
-    transfers: TransfersApi = Depends(get_transfers_api),
+    service: DownloadService = Depends(get_download_service),
 ) -> Dict[str, Any]:
     """Cancel a queued or running download."""
 
     logger.info("Cancellation requested for download id=%s", download_id)
-    try:
-        download = session.get(Download, download_id)
-    except (HTTPException, AppError):
-        raise
-    except Exception as exc:  # pragma: no cover - defensive database failure handling
-        logger.exception("Failed to load download %s for cancellation: %s", download_id, exc)
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Failed to cancel download",
-        ) from exc
-
-    if download is None:
-        logger.warning("Cancellation failed: download %s not found", download_id)
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Download not found")
-
-    if download.state not in {"queued", "running", "downloading"}:
-        logger.warning(
-            "Cancellation rejected for download %s due to invalid state %s",
-            download_id,
-            download.state,
-        )
-        raise HTTPException(
-            status_code=status.HTTP_409_CONFLICT,
-            detail="Download cannot be cancelled in its current state",
-        )
-
-    try:
-        await transfers.cancel_download(download_id)
-    except TransfersApiError as exc:
-        logger.error("slskd cancellation failed for %s: %s", download_id, exc)
-        raise HTTPException(
-            status_code=status.HTTP_502_BAD_GATEWAY,
-            detail="Failed to cancel download via slskd",
-        ) from exc
-
-    download.state = "cancelled"
-    download.updated_at = datetime.utcnow()
-
-    try:
-        session.commit()
-    except Exception as exc:  # pragma: no cover - defensive persistence handling
-        session.rollback()
-        logger.exception("Failed to persist cancellation for download %s: %s", download_id, exc)
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Failed to cancel download",
-        ) from exc
-
-    record_activity(
-        "download",
-        "download_cancelled",
-        details={"download_id": download_id, "filename": download.filename},
-    )
-
-    return {"status": "cancelled", "download_id": download_id}
+    return await service.cancel_download(download_id)
 
 
 @router.get("/downloads/export")
@@ -380,7 +118,7 @@ def export_downloads(
     status_filter: Optional[str] = Query(None, alias="status"),
     from_time: Optional[str] = Query(None, alias="from"),
     to_time: Optional[str] = Query(None, alias="to"),
-    session: Session = Depends(get_db),
+    service: DownloadService = Depends(get_download_service),
 ) -> Response:
     """Export downloads as JSON or CSV without paging limits."""
 
@@ -392,162 +130,28 @@ def export_downloads(
     created_from = _parse_iso8601(from_time) if from_time else None
     created_to = _parse_iso8601(to_time) if to_time else None
 
-    try:
-        query = _build_download_query(
-            session,
-            include_all=True,
-            status_filter=status_label,
-            created_from=created_from,
-            created_to=created_to,
-        )
-        downloads = query.all()
-    except (HTTPException, AppError):
-        raise
-    except Exception as exc:  # pragma: no cover - defensive database failure handling
-        logger.exception("Failed to export downloads: %s", exc)
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Failed to export downloads",
-        ) from exc
-
-    payload = [serialise_download(item) for item in downloads]
+    export = service.export_downloads(
+        status_filter=status_label,
+        created_from=created_from,
+        created_to=created_to,
+        format=fmt,
+    )
 
     if fmt == "json":
         return Response(
-            content=json.dumps(payload, ensure_ascii=False),
-            media_type="application/json",
+            content=json.dumps(export["content"], ensure_ascii=False),
+            media_type=export["media_type"],
         )
 
-    csv_content = render_downloads_csv(payload)
-    return Response(content=csv_content, media_type="text/csv")
+    return Response(content=export["content"], media_type=export["media_type"])
 
 
 @router.post("/download/{download_id}/retry", status_code=status.HTTP_202_ACCEPTED)
 async def retry_download(
     download_id: int,
-    session: Session = Depends(get_db),
-    transfers: TransfersApi = Depends(get_transfers_api),
+    service: DownloadService = Depends(get_download_service),
 ) -> Dict[str, Any]:
     """Retry a failed or cancelled download by creating a new entry."""
 
     logger.info("Retry requested for download id=%s", download_id)
-    try:
-        original = session.get(Download, download_id)
-    except (HTTPException, AppError):
-        raise
-    except Exception as exc:  # pragma: no cover - defensive database failure handling
-        logger.exception("Failed to load download %s for retry: %s", download_id, exc)
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Failed to retry download",
-        ) from exc
-
-    if original is None:
-        logger.warning("Retry failed: download %s not found", download_id)
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Download not found")
-
-    if original.state not in {"failed", "cancelled"}:
-        logger.warning(
-            "Retry rejected for download %s due to invalid state %s",
-            download_id,
-            original.state,
-        )
-        raise HTTPException(
-            status_code=status.HTTP_409_CONFLICT,
-            detail="Download cannot be retried in its current state",
-        )
-
-    if not original.username or not original.request_payload:
-        logger.error("Retry rejected for download %s due to missing payload", download_id)
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Download cannot be retried because original request data is missing",
-        )
-
-    payload_copy = dict(original.request_payload or {})
-    filename = payload_copy.get("filename") or original.filename
-    if not filename:
-        logger.error("Retry rejected for download %s due to missing filename", download_id)
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Download cannot be retried because filename is unknown",
-        )
-
-    filesize = (
-        payload_copy.get("filesize") or payload_copy.get("size") or payload_copy.get("file_size")
-    )
-    if filesize is not None:
-        payload_copy.setdefault("filesize", filesize)
-
-    priority = coerce_priority(payload_copy.get("priority"))
-    if priority is None:
-        priority = original.priority
-
-    new_download = Download(
-        filename=filename,
-        state="queued",
-        progress=0.0,
-        username=original.username,
-        priority=priority,
-    )
-    session.add(new_download)
-    session.flush()
-
-    payload_copy["download_id"] = new_download.id
-    payload_copy.setdefault("filename", filename)
-    payload_copy["priority"] = priority
-    new_download.request_payload = payload_copy
-
-    try:
-        await transfers.cancel_download(download_id)
-    except TransfersApiError as exc:
-        session.rollback()
-        logger.error("slskd cancellation before retry failed for %s: %s", download_id, exc)
-        raise HTTPException(
-            status_code=status.HTTP_502_BAD_GATEWAY,
-            detail="Failed to cancel existing download via slskd",
-        ) from exc
-
-    try:
-        await transfers.enqueue(username=original.username, files=[payload_copy])
-    except TransfersApiError as exc:
-        session.rollback()
-        logger.error("Failed to enqueue retry for download %s: %s", download_id, exc)
-        raise HTTPException(
-            status_code=status.HTTP_502_BAD_GATEWAY,
-            detail="Failed to enqueue download via slskd",
-        ) from exc
-    except Exception as exc:  # pragma: no cover - defensive unexpected failure
-        session.rollback()
-        logger.exception("Unexpected error while retrying download %s: %s", download_id, exc)
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Failed to retry download",
-        ) from exc
-
-    try:
-        session.commit()
-    except Exception as exc:  # pragma: no cover - defensive persistence handling
-        session.rollback()
-        logger.exception("Failed to persist retry download for %s: %s", download_id, exc)
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Failed to retry download",
-        ) from exc
-
-    record_activity(
-        "download",
-        "download_retried",
-        details={
-            "original_download_id": download_id,
-            "retry_download_id": new_download.id,
-            "username": original.username,
-            "filename": filename,
-        },
-    )
-
-    response: Dict[str, Any] = {
-        "status": "queued",
-        "download_id": new_download.id,
-    }
-    return response
+    return await service.retry_download(download_id)

--- a/app/services/download_service.py
+++ b/app/services/download_service.py
@@ -1,0 +1,428 @@
+"""Service layer for download-related database and worker interactions."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+from fastapi import HTTPException, status
+from sqlalchemy.orm import Session
+
+from app.core.transfers_api import TransfersApi, TransfersApiError
+from app.errors import AppError
+from app.logging import get_logger
+from app.models import Download
+from app.schemas import DownloadPriorityUpdate, SoulseekDownloadRequest
+from app.utils.activity import record_activity
+from app.utils.downloads import (
+    ACTIVE_STATES,
+    coerce_priority,
+    determine_priority,
+    render_downloads_csv,
+    resolve_status_filter,
+    serialise_download,
+)
+from app.utils.events import DOWNLOAD_BLOCKED
+from app.utils.service_health import collect_missing_credentials
+from app.workers.persistence import update_priority as update_worker_priority
+
+
+logger = get_logger(__name__)
+
+
+class DownloadService:
+    """Encapsulates persistence and worker coordination for downloads."""
+
+    def __init__(self, *, session: Session, transfers: TransfersApi) -> None:
+        self._session = session
+        self._transfers = transfers
+
+    # ------------------------------------------------------------------
+    # Query helpers
+    # ------------------------------------------------------------------
+    def _build_download_query(
+        self,
+        *,
+        include_all: bool,
+        status_filter: Optional[str] = None,
+        created_from: Optional[datetime] = None,
+        created_to: Optional[datetime] = None,
+    ) -> Any:
+        query = self._session.query(Download)
+        if status_filter:
+            states = resolve_status_filter(status_filter)
+            query = query.filter(Download.state.in_(tuple(states)))
+        elif not include_all:
+            query = query.filter(Download.state.in_(tuple(ACTIVE_STATES)))
+
+        if created_from:
+            query = query.filter(Download.created_at >= created_from)
+        if created_to:
+            query = query.filter(Download.created_at <= created_to)
+
+        return query.order_by(Download.priority.desc(), Download.created_at.desc())
+
+    def list_downloads(
+        self,
+        *,
+        include_all: bool,
+        status_filter: Optional[str],
+        limit: int,
+        offset: int,
+    ) -> List[Download]:
+        try:
+            query = self._build_download_query(
+                include_all=include_all, status_filter=status_filter
+            )
+            return query.offset(offset).limit(limit).all()
+        except (HTTPException, AppError):
+            raise
+        except Exception as exc:  # pragma: no cover - defensive database failure handling
+            logger.exception("Failed to list downloads: %s", exc)
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Failed to fetch downloads",
+            ) from exc
+
+    def get_download(self, download_id: int) -> Download:
+        try:
+            download = self._session.get(Download, download_id)
+        except (HTTPException, AppError):
+            raise
+        except Exception as exc:  # pragma: no cover - defensive database failure handling
+            logger.exception("Failed to load download %s: %s", download_id, exc)
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Failed to fetch download",
+            ) from exc
+
+        if download is None:
+            logger.warning("Download %s not found", download_id)
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Download not found")
+        return download
+
+    def update_priority(self, download_id: int, payload: DownloadPriorityUpdate) -> Download:
+        download = self.get_download(download_id)
+
+        new_priority = int(payload.priority)
+        download.priority = new_priority
+        download.updated_at = datetime.utcnow()
+        payload_copy = dict(download.request_payload or {})
+        payload_copy["priority"] = new_priority
+        download.request_payload = payload_copy
+
+        self._session.add(download)
+        self._session.commit()
+
+        logger.info("Updated priority for download %s to %s", download_id, new_priority)
+
+        job_id = download.job_id
+        if job_id and not update_worker_priority(job_id, new_priority, job_type="sync"):
+            logger.error(
+                "Failed to update worker job priority for download %s (job %s)",
+                download_id,
+                job_id,
+            )
+
+        return download
+
+    async def queue_downloads(
+        self,
+        payload: SoulseekDownloadRequest,
+        *,
+        worker: Any,
+    ) -> Dict[str, Any]:
+        if not payload.files:
+            logger.warning("Download request without files rejected")
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="No files supplied")
+
+        missing_credentials = collect_missing_credentials(self._session, ("soulseek",))
+        if missing_credentials:
+            missing_payload = {service: list(values) for service, values in missing_credentials.items()}
+            logger.warning("Download blocked due to missing credentials: %s", missing_payload)
+            record_activity(
+                "download",
+                DOWNLOAD_BLOCKED,
+                details={"missing": missing_payload, "username": payload.username},
+            )
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail={"message": "Download blocked", "missing": missing_payload},
+            )
+
+        enqueue = getattr(worker, "enqueue", None) if worker else None
+        if enqueue is None:
+            logger.error("Download worker unavailable for request from %s", payload.username)
+            record_activity("download", "failed", details={"reason": "worker_unavailable"})
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="Download worker unavailable",
+            )
+
+        download_records: List[Download] = []
+        job_files: List[Dict[str, Any]] = []
+        job_priorities: List[int] = []
+        try:
+            for file_info in payload.files:
+                filename = str(file_info.get("filename") or file_info.get("name") or "unknown")
+                priority = determine_priority(file_info)
+                download = Download(
+                    filename=filename,
+                    state="queued",
+                    progress=0.0,
+                    username=payload.username,
+                    priority=priority,
+                )
+                self._session.add(download)
+                self._session.flush()
+
+                payload_copy = dict(file_info)
+                payload_copy.setdefault("filename", filename)
+                payload_copy["download_id"] = download.id
+                payload_copy["priority"] = priority
+                download.request_payload = payload_copy
+                job_files.append(payload_copy)
+
+                download_records.append(download)
+                job_priorities.append(priority)
+            self._session.commit()
+        except Exception as exc:  # pragma: no cover - defensive persistence handling
+            self._session.rollback()
+            logger.exception("Failed to persist download request: %s", exc)
+            record_activity("download", "failed", details={"reason": "persistence_error"})
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Failed to queue download",
+            ) from exc
+
+        job_priority = max(job_priorities or [0])
+        job = {"username": payload.username, "files": job_files, "priority": job_priority}
+        try:
+            await enqueue(job)  # type: ignore[func-returns-value]
+        except Exception as exc:  # pragma: no cover - defensive worker error
+            logger.exception("Failed to enqueue download job: %s", exc)
+            now = datetime.utcnow()
+            for download in download_records:
+                download.state = "failed"
+                download.updated_at = now
+            self._session.commit()
+            record_activity("download", "failed", details={"reason": "enqueue_error"})
+            raise HTTPException(
+                status_code=status.HTTP_502_BAD_GATEWAY,
+                detail="Failed to enqueue download",
+            ) from exc
+
+        record_activity(
+            "download",
+            "queued",
+            details={
+                "download_ids": [download.id for download in download_records],
+                "username": payload.username,
+            },
+        )
+
+        logger.info("Queued %d download(s) for %s", len(download_records), payload.username)
+
+        download_payload = [
+            {
+                "id": download.id,
+                "filename": download.filename,
+                "state": download.state,
+                "progress": download.progress,
+                "priority": download.priority,
+                "username": download.username,
+            }
+            for download in download_records
+        ]
+
+        response: Dict[str, Any] = {"status": "queued", "downloads": download_payload}
+        if download_records:
+            response["download_id"] = download_records[0].id
+        return response
+
+    async def cancel_download(self, download_id: int) -> Dict[str, Any]:
+        download = self.get_download(download_id)
+
+        if download.state not in {"queued", "running", "downloading"}:
+            logger.warning(
+                "Cancellation rejected for download %s due to invalid state %s",
+                download_id,
+                download.state,
+            )
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="Download cannot be cancelled in its current state",
+            )
+
+        try:
+            await self._transfers.cancel_download(download_id)
+        except TransfersApiError as exc:
+            logger.error("slskd cancellation failed for %s: %s", download_id, exc)
+            raise HTTPException(
+                status_code=status.HTTP_502_BAD_GATEWAY,
+                detail="Failed to cancel download via slskd",
+            ) from exc
+
+        download.state = "cancelled"
+        download.updated_at = datetime.utcnow()
+
+        try:
+            self._session.commit()
+        except Exception as exc:  # pragma: no cover - defensive persistence handling
+            self._session.rollback()
+            logger.exception("Failed to persist cancellation for download %s: %s", download_id, exc)
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Failed to cancel download",
+            ) from exc
+
+        record_activity(
+            "download",
+            "download_cancelled",
+            details={"download_id": download_id, "filename": download.filename},
+        )
+
+        return {"status": "cancelled", "download_id": download_id}
+
+    def export_downloads(
+        self,
+        *,
+        status_filter: Optional[str],
+        created_from: Optional[datetime],
+        created_to: Optional[datetime],
+        format: str,
+    ) -> ResponsePayload:
+        try:
+            query = self._build_download_query(
+                include_all=True,
+                status_filter=status_filter,
+                created_from=created_from,
+                created_to=created_to,
+            )
+            downloads = query.all()
+        except (HTTPException, AppError):
+            raise
+        except Exception as exc:  # pragma: no cover - defensive database failure handling
+            logger.exception("Failed to export downloads: %s", exc)
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Failed to export downloads",
+            ) from exc
+
+        payload = [serialise_download(item) for item in downloads]
+        if format == "csv":
+            return {"content": render_downloads_csv(payload), "media_type": "text/csv"}
+        return {
+            "content": payload,
+            "media_type": "application/json",
+        }
+
+    async def retry_download(self, download_id: int) -> Dict[str, Any]:
+        original = self.get_download(download_id)
+
+        if original.state not in {"failed", "cancelled"}:
+            logger.warning(
+                "Retry rejected for download %s due to invalid state %s",
+                download_id,
+                original.state,
+            )
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="Download cannot be retried in its current state",
+            )
+
+        if not original.username or not original.request_payload:
+            logger.error("Retry rejected for download %s due to missing payload", download_id)
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Download cannot be retried because original request data is missing",
+            )
+
+        payload_copy = dict(original.request_payload or {})
+        filename = payload_copy.get("filename") or original.filename
+        if not filename:
+            logger.error("Retry rejected for download %s due to missing filename", download_id)
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Download cannot be retried because filename is unknown",
+            )
+
+        filesize = (
+            payload_copy.get("filesize")
+            or payload_copy.get("size")
+            or payload_copy.get("file_size")
+        )
+        if filesize is not None:
+            payload_copy.setdefault("filesize", filesize)
+
+        priority = coerce_priority(payload_copy.get("priority"))
+        if priority is None:
+            priority = original.priority
+
+        new_download = Download(
+            filename=filename,
+            state="queued",
+            progress=0.0,
+            username=original.username,
+            priority=priority,
+        )
+        self._session.add(new_download)
+        self._session.flush()
+
+        payload_copy["download_id"] = new_download.id
+        payload_copy.setdefault("filename", filename)
+        payload_copy["priority"] = priority
+        new_download.request_payload = payload_copy
+
+        try:
+            await self._transfers.cancel_download(download_id)
+        except TransfersApiError as exc:
+            self._session.rollback()
+            logger.error("slskd cancellation before retry failed for %s: %s", download_id, exc)
+            raise HTTPException(
+                status_code=status.HTTP_502_BAD_GATEWAY,
+                detail="Failed to cancel existing download via slskd",
+            ) from exc
+
+        try:
+            await self._transfers.enqueue(username=original.username, files=[payload_copy])
+        except TransfersApiError as exc:
+            self._session.rollback()
+            logger.error("Failed to enqueue retry for download %s: %s", download_id, exc)
+            raise HTTPException(
+                status_code=status.HTTP_502_BAD_GATEWAY,
+                detail="Failed to enqueue download via slskd",
+            ) from exc
+        except Exception as exc:  # pragma: no cover - defensive unexpected failure
+            self._session.rollback()
+            logger.exception("Unexpected error while retrying download %s: %s", download_id, exc)
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Failed to retry download",
+            ) from exc
+
+        try:
+            self._session.commit()
+        except Exception as exc:  # pragma: no cover - defensive persistence handling
+            self._session.rollback()
+            logger.exception("Failed to persist retry download for %s: %s", download_id, exc)
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Failed to retry download",
+            ) from exc
+
+        record_activity(
+            "download",
+            "download_retried",
+            details={
+                "original_download_id": download_id,
+                "retry_download_id": new_download.id,
+                "username": original.username,
+                "filename": filename,
+            },
+        )
+
+        return {"status": "queued", "download_id": new_download.id}
+
+
+ResponsePayload = Dict[str, Any]

--- a/tests/services/test_download_service.py
+++ b/tests/services/test_download_service.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+from fastapi import HTTPException
+
+from app.models import Download
+from app.schemas import DownloadPriorityUpdate, SoulseekDownloadRequest
+from app.services.download_service import DownloadService
+
+
+class StubTransfersApi:
+    def __init__(self) -> None:
+        self.cancelled: list[int] = []
+        self.enqueued: list[tuple[str, list[dict[str, Any]]]] = []
+
+    async def cancel_download(self, download_id: int) -> None:
+        self.cancelled.append(download_id)
+
+    async def enqueue(self, *, username: str, files: list[dict[str, Any]]) -> None:
+        self.enqueued.append((username, files))
+
+
+class StubWorker:
+    def __init__(self) -> None:
+        self.jobs: list[dict[str, Any]] = []
+
+    async def enqueue(self, job: dict[str, Any]) -> None:
+        await asyncio.sleep(0)
+        self.jobs.append(job)
+
+
+def _service(db_session, transfers: StubTransfersApi | None = None) -> DownloadService:
+    return DownloadService(session=db_session, transfers=transfers or StubTransfersApi())
+
+
+def test_list_downloads_filters_active_states(db_session) -> None:
+    active = Download(filename="queued.mp3", state="queued", progress=0.0, priority=10)
+    done = Download(filename="done.mp3", state="completed", progress=1.0, priority=5)
+    db_session.add_all([active, done])
+    db_session.commit()
+
+    service = _service(db_session)
+
+    downloads = service.list_downloads(include_all=False, status_filter=None, limit=10, offset=0)
+    assert [item.id for item in downloads] == [active.id]
+
+
+def test_get_download_missing_raises(db_session) -> None:
+    service = _service(db_session)
+
+    with pytest.raises(HTTPException) as excinfo:
+        service.get_download(999)
+
+    assert excinfo.value.status_code == 404
+
+
+def test_update_priority_persists_and_notifies_worker(monkeypatch, db_session) -> None:
+    download = Download(
+        filename="song.mp3",
+        state="queued",
+        progress=0.0,
+        priority=1,
+        request_payload={"filename": "song.mp3", "priority": 1},
+    )
+    db_session.add(download)
+    db_session.commit()
+
+    notified: dict[str, Any] = {}
+
+    def fake_update_priority(job_id: int, priority: int, *, job_type: str) -> bool:
+        notified.update({"job_id": job_id, "priority": priority, "job_type": job_type})
+        return True
+
+    monkeypatch.setattr("app.services.download_service.update_worker_priority", fake_update_priority)
+
+    download.job_id = 42
+    db_session.commit()
+
+    service = _service(db_session)
+    updated = service.update_priority(download.id, DownloadPriorityUpdate(priority=5))
+
+    assert updated.priority == 5
+    assert updated.request_payload["priority"] == 5
+    assert notified["priority"] == 5
+    assert notified["job_type"] == "sync"
+    assert notified["job_id"] == str(download.job_id)
+
+
+@pytest.mark.asyncio
+async def test_queue_downloads_persists_and_enqueues(db_session) -> None:
+    worker = StubWorker()
+    service = _service(db_session)
+
+    payload = SoulseekDownloadRequest(
+        username="tester",
+        files=[{"filename": "track.mp3", "priority": 4}],
+    )
+
+    response = await service.queue_downloads(payload, worker=worker)
+
+    assert response["status"] == "queued"
+    assert worker.jobs and worker.jobs[0]["username"] == "tester"
+
+
+@pytest.mark.asyncio
+async def test_queue_downloads_without_worker_raises(db_session) -> None:
+    service = _service(db_session)
+
+    payload = SoulseekDownloadRequest(username="tester", files=[{"filename": "track.mp3"}])
+
+    with pytest.raises(HTTPException) as excinfo:
+        await service.queue_downloads(payload, worker=None)
+
+    assert excinfo.value.status_code == 503


### PR DESCRIPTION
## Summary
- move download persistence and worker coordination into a dedicated service
- update the download router to depend on the new service via dependency injection
- cover the service behaviour with focused unit tests

## Testing
- pytest tests/services/test_download_service.py

------
https://chatgpt.com/codex/tasks/task_e_68dec7585d848321afdf998bf981c47b