### PR TITLE
feat: add async session runner for routers

### DIFF
--- a/app/db.py
+++ b/app/db.py
@@ -187,4 +187,4 @@ async def run_session(
 ) -> T:
     """Execute ``func`` with a database session in a worker thread."""
 
-    return await asyncio.to_thread(_call_with_session, func, factory)
+    return await asyncio.to_thread(_call_with_session, func, factory=factory)

--- a/tests/routers/test_async_db_responsiveness.py
+++ b/tests/routers/test_async_db_responsiveness.py
@@ -1,0 +1,116 @@
+"""Async integration tests verifying DB helpers avoid blocking the event loop."""
+
+from __future__ import annotations
+
+import time
+from contextlib import asynccontextmanager
+
+import anyio
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.db import SessionCallable
+from app.dependencies import SessionRunner, get_session_runner
+from app.workers.playlist_sync_worker import PlaylistSyncWorker
+from tests.helpers import api_path
+from tests.simple_client import SimpleTestClient
+
+
+class TimeBudget:
+    """Helper providing an async context manager enforcing a time limit."""
+
+    @asynccontextmanager
+    async def limit(self, seconds: float):
+        start = time.perf_counter()
+        with anyio.fail_after(seconds):
+            yield lambda: time.perf_counter() - start
+
+
+@pytest.fixture
+def time_budget() -> TimeBudget:
+    return TimeBudget()
+
+
+@pytest.fixture
+async def async_client(client: SimpleTestClient) -> AsyncClient:
+    transport = ASGITransport(app=client.app)
+    async with AsyncClient(
+        transport=transport,
+        base_url="http://test",
+        headers={"X-API-Key": "test-key"},
+    ) as http_client:
+        yield http_client
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+def _slow_runner(delay: float, runner: SessionRunner) -> SessionRunner:
+    async def _wrapper(func: SessionCallable[object]) -> object:
+        def _delayed(session):
+            time.sleep(delay)
+            return func(session)
+
+        return await runner(_delayed)
+
+    return _wrapper
+
+
+@pytest.mark.anyio("asyncio")
+async def test_free_import_uses_async_session(
+    client: SimpleTestClient,
+    async_client: AsyncClient,
+    time_budget: TimeBudget,
+) -> None:
+    delay = 0.2
+    original_runner = get_session_runner()
+    client.app.dependency_overrides[get_session_runner] = lambda: _slow_runner(delay, original_runner)
+
+    try:
+        async with time_budget.limit(0.75) as elapsed:
+            response = await async_client.post(
+                api_path("/imports/free"),
+                json={
+                    "links": [
+                        "https://open.spotify.com/playlist/37i9dQZF1DX4JAvHpjipBk",
+                    ]
+                },
+            )
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload["ok"] is True
+        assert elapsed() >= delay
+    finally:
+        client.app.dependency_overrides.pop(get_session_runner, None)
+
+
+@pytest.mark.anyio("asyncio")
+async def test_manual_sync_checks_credentials_off_thread(
+    client: SimpleTestClient,
+    async_client: AsyncClient,
+    time_budget: TimeBudget,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    delay = 0.2
+    original_runner = get_session_runner()
+    client.app.dependency_overrides[get_session_runner] = lambda: _slow_runner(delay, original_runner)
+
+    playlist_calls = {"count": 0}
+
+    async def fake_sync_once(self) -> None:  # type: ignore[override]
+        playlist_calls["count"] += 1
+
+    monkeypatch.setattr(PlaylistSyncWorker, "sync_once", fake_sync_once, raising=False)
+
+    try:
+        async with time_budget.limit(0.75) as elapsed:
+            response = await async_client.post(api_path("/sync"))
+        assert response.status_code == 202
+        body = response.json()
+        assert body["results"]["playlists"] == "completed"
+        assert playlist_calls == {"count": 1}
+        assert elapsed() >= delay
+    finally:
+        client.app.dependency_overrides.pop(get_session_runner, None)


### PR DESCRIPTION
## Summary
- add a reusable async database session runner dependency for routers and fix the run_session helper
- refactor the free import and manual sync routes to persist and query via the async runner instead of direct session_scope usage
- add anyio-based router tests that slow mocked DB work to ensure the endpoints stay responsive

## Testing
- pytest tests/test_imports_free.py tests/test_sync.py tests/routers/test_async_db_responsiveness.py


------
https://chatgpt.com/codex/tasks/task_e_68ded300ec7c83218dc2426ed0c821b7