### PR TITLE
test: add async deadline coverage for imports and sync

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,15 @@
+# Test Suite Notes
+
+## Async API deadline checks
+
+The tests in `tests/routers/test_request_deadlines.py` exercise the asynchronous request
+path for `/imports/free` and `/sync`. They rely on the shared
+`async_client_with_deadline` fixture to ensure database interactions stay off the event
+loop and complete within the configured deadline. Include them in your regular workflow
+by running:
+
+```bash
+pytest tests/routers/test_request_deadlines.py
+```
+
+They also run automatically when executing the full test suite.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 # ruff: noqa: E402
 
+pytest_plugins = ["tests.fixtures.async_client"]
+
 import asyncio
 from datetime import datetime
 from pathlib import Path

--- a/tests/fixtures/async_client.py
+++ b/tests/fixtures/async_client.py
@@ -1,0 +1,80 @@
+"""Shared HTTPX AsyncClient fixture with configurable deadline helpers."""
+
+from __future__ import annotations
+
+import time
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+from typing import AsyncIterator, Callable, Iterator
+
+import anyio
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from tests.simple_client import SimpleTestClient
+
+DEFAULT_ASYNC_DEADLINE_S = 0.75
+
+
+class DeadlineHelper:
+    """Provide helper utilities for tracking async execution deadlines."""
+
+    def __init__(
+        self,
+        *,
+        default: float = DEFAULT_ASYNC_DEADLINE_S,
+        clock: Callable[[], float] = time.perf_counter,
+    ) -> None:
+        self._default = default
+        self._clock = clock
+
+    @property
+    def default(self) -> float:
+        return self._default
+
+    @asynccontextmanager
+    async def limit(self, seconds: float | None = None) -> Iterator[Callable[[], float]]:
+        """Enforce that async operations finish within ``seconds``."""
+
+        budget = self._default if seconds is None else seconds
+        start = self._clock()
+        with anyio.fail_after(budget):
+            yield lambda: self._clock() - start
+
+
+@dataclass
+class AsyncDeadlineClient:
+    """Container bundling an AsyncClient with deadline helpers."""
+
+    client: AsyncClient
+    deadline: DeadlineHelper
+
+    @asynccontextmanager
+    async def within(
+        self, seconds: float | None = None
+    ) -> AsyncIterator[tuple[AsyncClient, Callable[[], float]]]:
+        async with self.deadline.limit(seconds) as elapsed:
+            yield self.client, elapsed
+
+
+@pytest.fixture
+async def async_client_with_deadline(
+    client: SimpleTestClient,
+) -> AsyncIterator[AsyncDeadlineClient]:
+    """Yield an AsyncClient ready for API tests with a shared deadline helper."""
+
+    deadline = DeadlineHelper()
+    transport = ASGITransport(app=client.app)
+    async with AsyncClient(
+        transport=transport,
+        base_url="http://test",
+        headers={"X-API-Key": "test-key"},
+    ) as http_client:
+        yield AsyncDeadlineClient(client=http_client, deadline=deadline)
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    """Force async tests to run against the asyncio backend."""
+
+    return "asyncio"

--- a/tests/routers/test_request_deadlines.py
+++ b/tests/routers/test_request_deadlines.py
@@ -1,0 +1,83 @@
+"""Async tests asserting API endpoints respect request deadlines."""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from app import db
+from app import dependencies as deps
+from app.workers.playlist_sync_worker import PlaylistSyncWorker
+from tests.fixtures.async_client import AsyncDeadlineClient
+from tests.helpers import api_path
+
+
+def _install_slow_session_runner(
+    monkeypatch: pytest.MonkeyPatch, delay: float
+) -> None:
+    original_db_run_session = db.run_session
+
+    async def slow_run_session(func, *, factory=None):
+        def _with_delay(session):
+            time.sleep(delay)
+            return func(session)
+
+        return await original_db_run_session(_with_delay, factory=factory)
+
+    monkeypatch.setattr(db, "run_session", slow_run_session)
+    monkeypatch.setattr(deps, "run_session", slow_run_session)
+
+
+@pytest.mark.anyio("asyncio")
+async def test_free_import_request_completes_within_deadline(
+    async_client_with_deadline: AsyncDeadlineClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    deadline = async_client_with_deadline.deadline.default
+    delay = deadline * 0.6
+    _install_slow_session_runner(monkeypatch, delay)
+
+    async with async_client_with_deadline.within() as (client, elapsed):
+        response = await client.post(
+            api_path("/imports/free"),
+            json={
+                "links": [
+                    "https://open.spotify.com/playlist/37i9dQZF1DX4JAvHpjipBk",
+                ]
+            },
+        )
+
+    elapsed_seconds = elapsed()
+    assert response.status_code == 200
+    assert response.json()["ok"] is True
+    assert elapsed_seconds >= delay
+    assert elapsed_seconds < deadline
+
+
+@pytest.mark.anyio("asyncio")
+async def test_manual_sync_request_completes_within_deadline(
+    async_client_with_deadline: AsyncDeadlineClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    deadline = async_client_with_deadline.deadline.default
+    delay = deadline * 0.6
+    _install_slow_session_runner(monkeypatch, delay)
+
+    playlist_calls = {"count": 0}
+
+    async def fake_sync_once(self) -> None:  # type: ignore[override]
+        playlist_calls["count"] += 1
+
+    monkeypatch.setattr(PlaylistSyncWorker, "sync_once", fake_sync_once, raising=False)
+
+    async with async_client_with_deadline.within() as (client, elapsed):
+        response = await client.post(api_path("/sync"))
+
+    elapsed_seconds = elapsed()
+    assert response.status_code == 202
+    body = response.json()
+    assert body["results"]["playlists"] == "completed"
+    assert playlist_calls == {"count": 1}
+    assert elapsed_seconds >= delay
+    assert elapsed_seconds < deadline


### PR DESCRIPTION
## Summary
- add a shared httpx.AsyncClient fixture with an anyio deadline helper for async API tests
- add router tests for /imports/free and /sync that monkeypatch slow DB runners and assert requests stay within their budgets
- document the new tests in tests/README.md for contributors

## Testing
- pytest tests/routers/test_request_deadlines.py

------
https://chatgpt.com/codex/tasks/task_e_68dedb9d7bc48321b1af3602d53be929