### PR TITLE
feat(download): standardize error handling [TASK-000]

### DIFF
--- a/tests/routers/test_download_errors.py
+++ b/tests/routers/test_download_errors.py
@@ -1,0 +1,96 @@
+"""Regression tests for the download router error envelope."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from app.core.transfers_api import TransfersDependencyError
+from app.db import session_scope
+from app.models import Download
+from tests.helpers import api_path
+from tests.simple_client import SimpleTestClient
+
+
+def _create_download(*, state: str = "queued", **overrides: Any) -> int:
+    with session_scope() as session:
+        record = Download(
+            filename=overrides.get("filename", "sample.mp3"),
+            state=state,
+            progress=overrides.get("progress", 0.0),
+            username=overrides.get("username", "tester"),
+            priority=overrides.get("priority", 1),
+        )
+        request_payload = overrides.get("request_payload")
+        if request_payload is not None:
+            record.request_payload = dict(request_payload)
+        session.add(record)
+        session.flush()
+        download_id = record.id
+    return download_id
+
+
+def test_start_download_without_files_returns_validation_error(
+    client: SimpleTestClient,
+) -> None:
+    payload = {"username": "tester", "files": []}
+
+    response = client.post(api_path("/download"), json=payload)
+
+    assert response.status_code == 400
+    body = response.json()
+    assert body["ok"] is False
+    assert body["error"]["code"] == "VALIDATION_ERROR"
+    assert body["error"]["message"] == "No files supplied"
+
+
+def test_get_download_not_found_returns_standard_error(client: SimpleTestClient) -> None:
+    response = client.get(api_path("/download/999999"))
+
+    assert response.status_code == 404
+    body = response.json()
+    assert body["ok"] is False
+    assert body["error"]["code"] == "NOT_FOUND"
+    assert body["error"]["message"] == "Download not found"
+
+
+def test_cancel_download_dependency_failure_maps_to_error_envelope(
+    client: SimpleTestClient,
+) -> None:
+    download_id = _create_download(state="queued")
+    stub = client.app.state.transfers_stub
+    stub.raise_cancel = TransfersDependencyError(
+        "slskd unavailable", status_code=503, details={"hint": "retry"}
+    )
+
+    try:
+        response = client.delete(api_path(f"/download/{download_id}"))
+    finally:
+        stub.raise_cancel = None
+
+    assert response.status_code == 503
+    body = response.json()
+    assert body["ok"] is False
+    assert body["error"]["code"] == "DEPENDENCY_ERROR"
+    assert body["error"]["message"] == "slskd unavailable"
+    assert body["error"].get("meta") == {
+        "provider": "slskd",
+        "hint": "retry",
+        "status_code": 503,
+    }
+
+
+def test_retry_download_invalid_state_returns_validation_error(
+    client: SimpleTestClient,
+) -> None:
+    download_id = _create_download(state="queued", request_payload={"filename": "song.mp3"})
+
+    response = client.post(api_path(f"/download/{download_id}/retry"))
+
+    assert response.status_code == 409
+    body = response.json()
+    assert body["ok"] is False
+    assert body["error"]["code"] == "VALIDATION_ERROR"
+    assert (
+        body["error"]["message"]
+        == "Download cannot be retried in its current state"
+    )

--- a/tests/services/test_errors_mapping.py
+++ b/tests/services/test_errors_mapping.py
@@ -6,6 +6,7 @@ from app.integrations.provider_gateway import (
     ProviderGatewayRateLimitedError,
     ProviderGatewayTimeoutError,
 )
+from app.core.transfers_api import TransfersDependencyError
 from app.services.errors import ServiceError, to_api_error
 
 
@@ -59,3 +60,16 @@ def test_to_api_error_from_value_error() -> None:
     mapped = to_api_error(ValueError("invalid"), provider="spotify")
     assert mapped.error.code == "VALIDATION_ERROR"
     assert mapped.error.details == {"provider": "spotify"}
+
+
+def test_to_api_error_from_transfers_error() -> None:
+    exc = TransfersDependencyError(
+        "slskd unavailable", status_code=502, details={"hint": "retry"}
+    )
+    mapped = to_api_error(exc, provider="slskd")
+    assert mapped.error.code == "DEPENDENCY_ERROR"
+    assert mapped.error.details == {
+        "provider": "slskd",
+        "hint": "retry",
+        "status_code": 502,
+    }

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -230,7 +230,9 @@ def test_cancel_download_returns_502_when_transfers_unavailable(client) -> None:
     transfers_stub.raise_cancel = TransfersApiError("offline")
 
     response = client.delete(f"/download/{original_id}")
-    assert response.status_code == 502
+    assert response.status_code == 503
+    body = response.json()
+    assert body["error"]["code"] == "DEPENDENCY_ERROR"
 
     with session_scope() as session:
         download = session.get(Download, original_id)
@@ -304,7 +306,9 @@ def test_retry_download_returns_502_when_enqueue_fails(client) -> None:
     transfers_stub.raise_enqueue = TransfersApiError("offline")
 
     response = client.post(f"/download/{original_id}/retry")
-    assert response.status_code == 502
+    assert response.status_code == 503
+    body = response.json()
+    assert body["error"]["code"] == "DEPENDENCY_ERROR"
 
     with session_scope() as session:
         downloads = session.query(Download).all()
@@ -341,7 +345,9 @@ def test_retry_download_returns_502_when_cancel_fails(client) -> None:
     transfers_stub.raise_cancel = TransfersApiError("offline")
 
     response = client.post(f"/download/{original_id}/retry")
-    assert response.status_code == 502
+    assert response.status_code == 503
+    body = response.json()
+    assert body["error"]["code"] == "DEPENDENCY_ERROR"
 
     with session_scope() as session:
         downloads = session.query(Download).all()


### PR DESCRIPTION
## Summary
- replace download service HTTPException usage with AppError variants and consistent status mapping
- extend `to_api_error` to translate transfers API failures into canonical `ApiError` payloads
- add regression tests for download router errors and update existing service and integration tests

## Testing
- pytest tests/services/test_download_service.py tests/services/test_errors_mapping.py
- pytest tests/test_download.py tests/test_download_credentials.py tests/routers/test_download_errors.py

------
https://chatgpt.com/codex/tasks/task_e_68df8c5f4f388321af804b039a35c157