### PR TITLE
feat: standardise router logging events

### DIFF
--- a/app/routers/imports_router.py
+++ b/app/routers/imports_router.py
@@ -15,6 +15,7 @@ from app.config import AppConfig
 from app.dependencies import SessionRunner, get_app_config, get_session_runner
 from app.errors import ValidationAppError
 from app.logging import get_logger
+from app.logging_events import log_event
 from app.models import ImportBatch, ImportSession
 from app.utils.spotify_free import (
     InvalidPayloadError,
@@ -111,15 +112,16 @@ async def create_free_import(
 
     await run_in_session(_persist_records)
 
-    logger.info(
-        "processed FREE ingest request",
-        extra={
-            "event": "free_ingest",
-            "session_id": session_id,
-            "accepted": len(parse_result.accepted),
-            "rejected": len(parse_result.rejected),
-            "skipped": len(parse_result.skipped),
-        },
+    log_event(
+        logger,
+        "api.import.free",
+        component="router.imports",
+        status="ok",
+        entity_id=session_id,
+        accepted=len(parse_result.accepted),
+        rejected=len(parse_result.rejected),
+        skipped=len(parse_result.skipped),
+        provided=parse_result.total_links,
     )
 
     response_payload = {

--- a/app/routers/metadata_router.py
+++ b/app/routers/metadata_router.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from fastapi import APIRouter, HTTPException, Request, status
 
 from app.logging import get_logger
+from app.logging_events import log_event
 
 router = APIRouter(prefix="/metadata", tags=["Metadata"])
 logger = get_logger(__name__)
@@ -14,7 +15,14 @@ logger = get_logger(__name__)
 async def start_metadata_update(request: Request) -> dict[str, object]:
     """Kick off a metadata update job."""
 
-    logger.info("Metadata update requested but legacy integration is disabled")
+    log_event(
+        logger,
+        "api.metadata.request",
+        component="router.metadata",
+        status="blocked",
+        entity_id=None,
+        action="update",
+    )
     raise HTTPException(
         status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
         detail="Metadata update disabled while legacy integration is archived",
@@ -25,7 +33,14 @@ async def start_metadata_update(request: Request) -> dict[str, object]:
 async def get_metadata_status(request: Request) -> dict[str, object]:
     """Return the current metadata job status."""
 
-    logger.info("Metadata status requested but legacy integration is disabled")
+    log_event(
+        logger,
+        "api.metadata.request",
+        component="router.metadata",
+        status="blocked",
+        entity_id=None,
+        action="status",
+    )
     raise HTTPException(
         status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
         detail="Metadata update disabled while legacy integration is archived",
@@ -36,7 +51,14 @@ async def get_metadata_status(request: Request) -> dict[str, object]:
 async def stop_metadata_update(request: Request) -> dict[str, object]:
     """Request to stop the running metadata job."""
 
-    logger.info("Metadata stop requested but legacy integration is disabled")
+    log_event(
+        logger,
+        "api.metadata.request",
+        component="router.metadata",
+        status="blocked",
+        entity_id=None,
+        action="stop",
+    )
     raise HTTPException(
         status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
         detail="Metadata update disabled while legacy integration is archived",

--- a/app/routers/soulseek_router.py
+++ b/app/routers/soulseek_router.py
@@ -17,6 +17,7 @@ from app.db import session_scope
 from app.dependencies import get_db, get_soulseek_client
 from app.errors import DependencyError
 from app.logging import get_logger
+from app.logging_events import log_event
 from app.models import DiscographyJob, Download
 from app.schemas import (
     DiscographyDownloadRequest,
@@ -74,7 +75,14 @@ async def soulseek_status(
     try:
         await client.get_download_status()
     except Exception as exc:  # pragma: no cover - defensive
-        logger.warning("Soulseek status check failed: %s", exc)
+        log_event(
+            logger,
+            "api.soulseek.status",
+            component="router.soulseek",
+            status="error",
+            entity_id=None,
+            error=str(exc),
+        )
         return StatusResponse(status="disconnected")
     return StatusResponse(status="connected")
 

--- a/tests/logging/test_router_events.py
+++ b/tests/logging/test_router_events.py
@@ -1,0 +1,139 @@
+"""Snapshot tests for router logging events."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from typing import Any, cast
+
+import pytest
+from fastapi import HTTPException
+
+from app import logging_events
+from app.middleware import request_logging
+
+
+def _load_module(name: str):
+    module = sys.modules.get(name)
+    if module is None:
+        module = importlib.import_module(name)
+    return module
+
+
+download_router_module = _load_module("app.routers.download_router")
+metadata_router_module = _load_module("app.routers.metadata_router")
+soulseek_router_module = _load_module("app.routers.soulseek_router")
+sync_router_module = _load_module("app.routers.sync_router")
+
+
+class _StubDownloadService:
+    def list_downloads(
+        self,
+        *,
+        include_all: bool,
+        status_filter: str | None,
+        limit: int,
+        offset: int,
+    ) -> list[dict[str, Any]]:
+        assert include_all is True
+        assert status_filter == "queued"
+        assert limit == 5
+        assert offset == 2
+        return []
+
+
+def _first_record(caplog, event: str):
+    for record in caplog.records:
+        if record.message == event:
+            return record
+    raise AssertionError(f"event {event!r} not found in logs")
+
+
+def test_download_router_list_emits_structured_event(caplog, monkeypatch) -> None:
+    monkeypatch.setattr(download_router_module.logger, "disabled", False)
+    service = _StubDownloadService()
+
+    with caplog.at_level("INFO", logger="app.routers.download_router"):
+        response = download_router_module.list_downloads(
+            limit=5,
+            offset=2,
+            all=True,
+            status_filter="queued",
+            service=service,
+        )
+
+    assert response.downloads == []
+
+    record = _first_record(caplog, "api.download.list")
+    assert record.event == "api.download.list"
+    assert record.component == "router.download"
+    assert record.status == "requested"
+    assert record.entity_id is None
+    assert record.include_all is True
+    assert record.status_filter == "queued"
+    assert record.limit == 5
+    assert record.offset == 2
+
+
+@pytest.mark.asyncio
+async def test_metadata_router_logs_blocked_event(caplog, monkeypatch) -> None:
+    monkeypatch.setattr(metadata_router_module.logger, "disabled", False)
+    with caplog.at_level("INFO", logger="app.routers.metadata_router"):
+        with pytest.raises(HTTPException):
+            await metadata_router_module.start_metadata_update(cast(Any, object()))
+
+    record = _first_record(caplog, "api.metadata.request")
+    assert record.component == "router.metadata"
+    assert record.status == "blocked"
+    assert record.action == "update"
+
+
+class _FailingSoulseekClient:
+    async def get_download_status(self) -> None:  # pragma: no cover - behaviour mocked
+        raise RuntimeError("daemon unavailable")
+
+
+@pytest.mark.asyncio
+async def test_soulseek_status_failure_logs_error_event(caplog, monkeypatch) -> None:
+    monkeypatch.setattr(soulseek_router_module.logger, "disabled", False)
+    with caplog.at_level("INFO", logger="app.routers.soulseek_router"):
+        response = await soulseek_router_module.soulseek_status(client=_FailingSoulseekClient())
+
+    assert response.status == "disconnected"
+
+    record = _first_record(caplog, "api.soulseek.status")
+    assert record.component == "router.soulseek"
+    assert record.status == "error"
+    assert record.error == "daemon unavailable"
+
+
+@pytest.mark.asyncio
+async def test_sync_router_missing_credentials_logs_blocked_event(
+    caplog, monkeypatch
+) -> None:
+    monkeypatch.setattr(sync_router_module.logger, "disabled", False)
+    async def fake_missing_credentials(session_runner):  # pragma: no cover - simple stub
+        return {"spotify": ("token",)}
+
+    monkeypatch.setattr(
+        sync_router_module, "_missing_credentials", fake_missing_credentials
+    )
+    monkeypatch.setattr(
+        sync_router_module, "record_activity", lambda *args, **kwargs: None
+    )
+
+    with caplog.at_level("INFO", logger="app.routers.sync_router"):
+        with pytest.raises(HTTPException):
+            await sync_router_module.trigger_manual_sync(
+                request=object(), session_runner=None
+            )
+
+    record = _first_record(caplog, "api.sync.trigger")
+    assert record.component == "router.sync"
+    assert record.status == "blocked"
+    assert record.entity_id is None
+    assert record.meta == {"missing": {"spotify": ["token"]}}
+
+
+def test_request_logging_shim_uses_single_log_event_instance() -> None:
+    assert request_logging.log_event is logging_events.log_event


### PR DESCRIPTION
## Summary
- switch router logging to `app.logging_events.log_event` with structured payloads for download, import, metadata, soulseek and sync routes
- add logging contract coverage capturing emitted fields for router events and middleware shim aliases

## Testing
- pytest tests/logging/test_router_events.py

------
https://chatgpt.com/codex/tasks/task_e_68df9211d9c88321939ff7ddb7b78bb0