### PR TITLE
refactor: drop legacy spotify router [NO-TASK]

### DIFF
--- a/app/api/router_registry.py
+++ b/app/api/router_registry.py
@@ -64,6 +64,8 @@ def compose_prefix(base: str, *parts: str) -> str:
 def _register(entry: RouterConfig) -> RouterConfig:
     if entry.key in _registry:
         raise ValueError(f"Router '{entry.key}' is already registered")
+    if not entry.router.routes:
+        raise ValueError(f"Router '{entry.key}' does not expose any routes")
     _registry[entry.key] = entry
     return entry
 

--- a/app/api/routers/spotify.py
+++ b/app/api/routers/spotify.py
@@ -5,7 +5,6 @@ from app.api.spotify import (
     core_router,
     free_ingest_router,
     free_router,
-    legacy_router,
     router,
 )
 
@@ -15,5 +14,4 @@ __all__ = [
     "backfill_router",
     "free_router",
     "free_ingest_router",
-    "legacy_router",
 ]

--- a/app/api/spotify.py
+++ b/app/api/spotify.py
@@ -15,7 +15,7 @@ from pydantic import BaseModel, Field, field_validator
 from sqlalchemy.orm import Session
 
 from app.api.cache_policy import CACHEABLE_RESPONSES
-from app.config import AppConfig, load_config
+from app.config import AppConfig
 from app.core.soulseek_client import SoulseekClient
 from app.core.spotify_client import SpotifyClient
 from app.db import session_scope
@@ -1221,25 +1221,10 @@ router.include_router(backfill_router)
 router.include_router(free_ingest_router)
 router.include_router(free_router)
 
-
-_config = load_config()
-_legacy_router: APIRouter | None = None
-if _config.features.enable_legacy_routes:
-    alias = APIRouter()
-    alias.include_router(core_router)
-    alias.include_router(backfill_router)
-    alias.include_router(free_ingest_router)
-    alias.include_router(free_router)
-    _legacy_router = alias
-
-legacy_router = _legacy_router
-
-
 __all__ = [
     "router",
     "core_router",
     "backfill_router",
     "free_router",
     "free_ingest_router",
-    "legacy_router",
 ]

--- a/app/routers/spotify.py
+++ b/app/routers/spotify.py
@@ -1,5 +1,5 @@
 """Backward-compatible re-export for the unified Spotify router."""
 
-from app.api.spotify import legacy_router, router
+from app.api.spotify import router
 
-__all__ = ["router", "legacy_router"]
+__all__ = ["router"]

--- a/reports/analysis/consolidation_map.md
+++ b/reports/analysis/consolidation_map.md
@@ -11,6 +11,6 @@
 | Config-Landschaft (ENV) | Viele `os.getenv` ohne Profile, Defaults verstreut | Profile + Dokumentation (siehe Config-Matrix) | Entkoppeln | `app/config.py`【F:app/config.py†L120-L299】<br>`app/main.py`【F:app/main.py†L239-L323】 | 1) Profile definieren; 2) Loader anpassen; 3) Docs/Deployment-Skripte updaten |
 
 ## Entfernen / Abschalten
-- **Legacy-Routen-Logging (`LegacyLoggingRoute`)** – Prüfen, ob `feature.enable_legacy_routes` dauerhaft benötigt wird; falls nicht, Feature-Flag abschalten und Route entfernen.【F:app/main.py†L157-L205】
+- **Legacy-Routen-Logging (`LegacyLoggingRoute`)** – Entfernt; Legacy-Router wird nicht mehr registriert, das Feature-Flag beeinflusst die API-Pfade nicht länger.【F:app/main.py†L520-L571】
 - **Free Import In-Memory File Store** – Ersatz durch persistente Storage (z. B. S3/DB) evaluieren; aktuell nur in API-State gehalten.【F:app/routers/spotify_free_router.py†L63-L120】
 

--- a/tests/routers/test_spotify_module.py
+++ b/tests/routers/test_spotify_module.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter
 from fastapi.routing import APIRoute
 
-from app.routers.spotify import legacy_router, router
+from app.routers import spotify as spotify_module
 
 
 def _route_paths(target: APIRouter) -> set[str]:
@@ -9,15 +9,12 @@ def _route_paths(target: APIRouter) -> set[str]:
 
 
 def test_spotify_router_includes_expected_paths() -> None:
-    paths = _route_paths(router)
+    paths = _route_paths(spotify_module.router)
     assert "/spotify/mode" in paths
     assert "/spotify/backfill/run" in paths
     assert "/spotify/import/free" in paths
     assert "/spotify/free/upload" in paths
 
 
-def test_legacy_router_is_optional_alias() -> None:
-    if legacy_router is None:
-        assert legacy_router is None
-    else:
-        assert isinstance(legacy_router, APIRouter)
+def test_legacy_router_alias_removed() -> None:
+    assert not hasattr(spotify_module, "legacy_router")


### PR DESCRIPTION
## Summary
- remove the optional legacy Spotify router alias and stop registering legacy API prefixes
- harden the router registry to reject router registrations that expose no routes
- document the removal of the legacy router logging shim and update router tests accordingly

## Testing
- pytest tests/routers/test_spotify_module.py tests/test_api_versioning.py

------
https://chatgpt.com/codex/tasks/task_e_68dfd8814b4c8321ae5f8f6408675140