### PR TITLE
refactor: run download DB mutations through session runner

### DIFF
--- a/app/dependencies.py
+++ b/app/dependencies.py
@@ -106,9 +106,14 @@ def get_watchlist_service(session: Session = Depends(get_db)) -> WatchlistServic
 
 def get_download_service(
     session: Session = Depends(get_db),
+    session_runner: SessionRunner = Depends(get_session_runner),
     transfers: TransfersApi = Depends(get_transfers_api),
 ) -> DownloadService:
-    return DownloadService(session=session, transfers=transfers)
+    return DownloadService(
+        session=session,
+        session_runner=session_runner,
+        transfers=transfers,
+    )
 
 
 def _is_allowlisted(path: str, allowlist: tuple[str, ...]) -> bool:

--- a/tests/services/test_download_service.py
+++ b/tests/services/test_download_service.py
@@ -31,7 +31,14 @@ class StubWorker:
 
 
 def _service(db_session, transfers: StubTransfersApi | None = None) -> DownloadService:
-    return DownloadService(session=db_session, transfers=transfers or StubTransfersApi())
+    async def runner(func):
+        return func(db_session)
+
+    return DownloadService(
+        session=db_session,
+        session_runner=runner,
+        transfers=transfers or StubTransfersApi(),
+    )
 
 
 def test_list_downloads_filters_active_states(db_session) -> None:


### PR DESCRIPTION
## Summary
- refactor `DownloadService` to accept an async session runner and move blocking ORM work into helper DTOs
- update the FastAPI dependency wiring plus unit and router tests for the new runner-aware service
- extend async responsiveness tests to cover download queue, cancel, and retry flows

## Testing
- pytest tests/services/test_download_service.py tests/test_download.py tests/routers/test_download_errors.py tests/routers/test_async_db_responsiveness.py

------
https://chatgpt.com/codex/tasks/task_e_68dff838719c8321bfa7abeb6d6b19af