### PR TITLE
feat: asyncify free ingest persistence

### DIFF
--- a/app/api/spotify.py
+++ b/app/api/spotify.py
@@ -20,8 +20,10 @@ from app.core.soulseek_client import SoulseekClient
 from app.core.spotify_client import SpotifyClient
 from app.db import session_scope
 from app.dependencies import (
+    SessionRunner,
     get_app_config,
     get_db,
+    get_session_runner,
     get_soulseek_client,
     get_spotify_client,
 )
@@ -90,12 +92,14 @@ def _get_spotify_service(
     config=Depends(get_app_config),
     spotify_client: SpotifyClient = Depends(get_spotify_client),
     soulseek_client: SoulseekClient = Depends(get_soulseek_client),
+    session_runner: SessionRunner = Depends(get_session_runner),
 ) -> SpotifyDomainService:
     return SpotifyDomainService(
         config=config,
         spotify_client=spotify_client,
         soulseek_client=soulseek_client,
         app_state=request.app.state,
+        session_runner=session_runner,
     )
 
 

--- a/tests/api/test_spotify_free_ingest.py
+++ b/tests/api/test_spotify_free_ingest.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import time
+from typing import Any
+
+import anyio
+import pytest
+from httpx import ASGITransport, AsyncClient, Response
+
+from app.db import SessionCallable, session_scope
+from app.dependencies import SessionRunner, get_session_runner
+from app.models import IngestItem, IngestItemState, IngestJob, IngestJobState
+from tests.helpers import api_path
+from tests.simple_client import SimpleTestClient
+
+
+pytestmark = pytest.mark.anyio("asyncio")
+
+
+@pytest.fixture
+async def async_client(client: SimpleTestClient) -> AsyncClient:
+    transport = ASGITransport(app=client.app)
+    async with AsyncClient(
+        transport=transport,
+        base_url="http://test",
+        headers={"X-API-Key": "test-key"},
+    ) as http_client:
+        yield http_client
+
+
+def _slow_runner(delay: float, runner: SessionRunner) -> SessionRunner:
+    async def _wrapper(func: SessionCallable[Any]) -> Any:
+        def _delayed(session):
+            time.sleep(delay)
+            return func(session)
+
+        return await runner(_delayed)
+
+    return _wrapper
+
+
+async def test_free_ingest_pipeline_uses_async_db_executor(
+    client: SimpleTestClient, async_client: AsyncClient
+) -> None:
+    delay = 0.25
+    original_runner = get_session_runner()
+    client.app.dependency_overrides[get_session_runner] = lambda: _slow_runner(delay, original_runner)
+
+    ticker_count = 0
+
+    async def ticker() -> None:
+        nonlocal ticker_count
+        try:
+            while True:
+                await asyncio.sleep(0.05)
+                ticker_count += 1
+        except asyncio.CancelledError:
+            pass
+
+    ticker_task = asyncio.create_task(ticker())
+    response: Response | None = None
+    elapsed = 0.0
+    try:
+        start = time.perf_counter()
+        with anyio.fail_after(3.0):
+            response = await async_client.post(
+                api_path("/spotify/import/free"),
+                json={"tracks": ["Soulseek Artist - Test Song"]},
+            )
+        elapsed = time.perf_counter() - start
+    finally:
+        ticker_task.cancel()
+        with contextlib.suppress(BaseException):
+            await ticker_task
+        client.app.dependency_overrides.pop(get_session_runner, None)
+
+    assert response is not None
+    assert response.status_code == 202
+    assert elapsed >= delay
+    assert ticker_count > 0
+
+    payload = response.json()
+    job_id = payload["job_id"]
+    assert isinstance(job_id, str) and job_id
+
+    with session_scope() as session:
+        job = session.get(IngestJob, job_id)
+        assert job is not None
+        assert job.state == IngestJobState.COMPLETED.value
+        items = (
+            session.query(IngestItem)
+            .filter(IngestItem.job_id == job_id, IngestItem.source_type != "LINK")
+            .all()
+        )
+        assert items, "expected at least one track item"
+        assert all(item.state == IngestItemState.QUEUED.value for item in items)

--- a/tests/services/test_spotify_domain_service.py
+++ b/tests/services/test_spotify_domain_service.py
@@ -151,9 +151,12 @@ async def test_submit_free_ingest_uses_custom_factory() -> None:
 
     created: dict[str, Any] = {}
 
-    def factory(config, soulseek, worker) -> StubFreeIngestService:  # type: ignore[override]
+    def factory(
+        config, soulseek, worker, session_runner
+    ) -> StubFreeIngestService:  # type: ignore[override]
         created["worker"] = worker
         created["config"] = config
+        created["session_runner"] = session_runner
         return StubFreeIngestService()
 
     service = _make_service(free_ingest_factory=factory)
@@ -162,6 +165,7 @@ async def test_submit_free_ingest_uses_custom_factory() -> None:
 
     assert result == "submission"
     assert created["worker"] is None
+    assert "session_runner" in created
     submit_mock.assert_awaited()
 
 

--- a/tests/test_free_ingest.py
+++ b/tests/test_free_ingest.py
@@ -66,7 +66,8 @@ def _add_items(job_id: str, state: IngestItemState, count: int) -> None:
             session.add(item)
 
 
-def test_partial_and_skip_preserves_partial_error(
+@pytest.mark.anyio("asyncio")
+async def test_partial_and_skip_preserves_partial_error(
     free_ingest_service: FreeIngestService,
 ) -> None:
     job_id = "job_partial_skip"
@@ -74,7 +75,7 @@ def test_partial_and_skip_preserves_partial_error(
     _add_items(job_id, IngestItemState.QUEUED, 3)
     _add_items(job_id, IngestItemState.FAILED, 2)
 
-    free_ingest_service._finalise_job_state(
+    await free_ingest_service._finalise_job_state(
         job_id,
         total_tracks=5,
         queued_tracks=3,
@@ -99,13 +100,14 @@ def test_partial_and_skip_preserves_partial_error(
         assert job.error == "partial queued=3 failed=2||skip_reason=limit"
 
 
-def test_only_skip_sets_error_to_reason_without_partial(
+@pytest.mark.anyio("asyncio")
+async def test_only_skip_sets_error_to_reason_without_partial(
     free_ingest_service: FreeIngestService,
 ) -> None:
     job_id = "job_only_skip"
     _create_job(job_id, skipped_tracks=10, error="duplicate")
 
-    free_ingest_service._finalise_job_state(
+    await free_ingest_service._finalise_job_state(
         job_id,
         total_tracks=0,
         queued_tracks=0,
@@ -130,14 +132,15 @@ def test_only_skip_sets_error_to_reason_without_partial(
         assert job.error == "duplicate"
 
 
-def test_only_fail_sets_state_failed(
+@pytest.mark.anyio("asyncio")
+async def test_only_fail_sets_state_failed(
     free_ingest_service: FreeIngestService,
 ) -> None:
     job_id = "job_only_fail"
     _create_job(job_id, skipped_tracks=0, error=None)
     _add_items(job_id, IngestItemState.FAILED, 5)
 
-    free_ingest_service._finalise_job_state(
+    await free_ingest_service._finalise_job_state(
         job_id,
         total_tracks=5,
         queued_tracks=0,


### PR DESCRIPTION
## Summary
- run FreeIngestService persistence helpers through an injected async SessionRunner instead of blocking session_scope calls
- wire SpotifyDomainService and the API dependency to provide the session runner when building the free ingest service
- update free-ingest tests for the async helpers and add an integration check to ensure the pipeline stays responsive when DB work is slow

## Testing
- `pytest tests/test_free_ingest.py tests/services/test_spotify_domain_service.py tests/test_free_ingest_router.py tests/api/test_spotify_free_ingest.py tests/routers/test_async_db_responsiveness.py::test_free_import_uses_async_session`


------
https://chatgpt.com/codex/tasks/task_e_68e002fb83b48321979e2d6ebb0785aa