### PR TITLE
fix: normalize slskd validation request [NO-TASK]

### DIFF
--- a/tests/test_secret_validation.py
+++ b/tests/test_secret_validation.py
@@ -66,6 +66,24 @@ async def test_slskd_live_validates_successfully() -> None:
 
 
 @pytest.mark.asyncio
+async def test_slskd_live_with_prefixed_store_url() -> None:
+    captured_path: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured_path.append(request.url.path)
+        return httpx.Response(200)
+
+    service = _service_with_transport(httpx.MockTransport(handler))
+    store = SecretStore.from_values(
+        {"SLSKD_API_KEY": "abcdef123456", "SLSKD_URL": "http://slskd:5030/api"}
+    )
+
+    await service.validate("slskd_api_key", store=store)
+
+    assert captured_path == ["/api/v2/me"]
+
+
+@pytest.mark.asyncio
 async def test_slskd_live_reports_invalid_credentials() -> None:
     def handler(request: httpx.Request) -> httpx.Response:
         return httpx.Response(401)


### PR DESCRIPTION
## Summary
- Normalize the SLSKD base URL before issuing the `/api/v2/me` probe so duplicate path segments are avoided for prefixed installations.
- Extend the secret validation tests with coverage for a stored SLSKD URL that already contains an `/api` suffix.

## Changes
- Modified `app/services/secret_validation.py`
- Modified `tests/test_secret_validation.py`

## Migrations
- N/A

## Risks / Limitations
- Low risk; affects only the SLSKD validation request path.

## AGENTS.md Compliance
- Reviewed and followed repository guidelines.

## ToDo Updates
- Not applicable.

## Testing
- pytest tests/test_secret_validation.py


------
https://chatgpt.com/codex/tasks/task_e_68e01d5b6de4832182b4cad94f64e08e