### PR TITLE
docs: align architecture overview with api router paths

### DIFF
--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -3,6 +3,7 @@
 Diese Übersicht definiert den gemeinsamen Bezugsrahmen für Router, Services, Core-Domain und Orchestrator. Sie stellt Prinzipien, Flows und Verträge bereit, die bei jeder Änderung geprüft werden müssen. Ergänzende Details finden sich in `docs/architecture/contracts.md`, `docs/architecture/diagrams.md` sowie den ADRs unter `docs/architecture/adr/`.
 
 ## Zweck & Leitprinzipien
+
 - **Simplicity First:** Kleine, klar abgegrenzte Komponenten, die ohne versteckte Kopplungen funktionieren.
 - **Idempotenz als Standard:** Jede Anfrage und jeder Job darf gefahrlos erneut laufen (Queue-Redelivery, API-Retries, Deployments).
 - **DRY & KISS:** Fachlogik liegt im Core bzw. dedizierten Services; Router und Integrationen bleiben dünne Adapter.
@@ -11,27 +12,30 @@ Diese Übersicht definiert den gemeinsamen Bezugsrahmen für Router, Services, C
 
 ## Schichtenmodell
 
-| Schicht | Verantwortung | Beispielmodule | Anti-Patterns |
-| --- | --- | --- | --- |
-| **API (Router)** | HTTP-/CLI-Oberfläche, Request-Validierung, Fehler-Envelope, Auth. | `app/routers/*`, FastAPI Dependencies | Business-Logik, Direktzugriff auf Datenbank oder Provider |
-| **Application (Services)** | Orchestriert Use-Cases, kapselt Transaktionen, orchestriert mehrere Integrationen. | `app/services/*`, `app/workers/*` | Zustandsbehaftete globale Variablen, direkte Response-Objekte |
-| **Domain (Core)** | Reine Fachlogik, Matching, Normalisierung, Fehlerklassen. | `app/core/*`, `app/errors.py` | Provider-spezifische DTOs, Side-Effects |
-| **Infrastructure** | Integrationen, Persistence, Messaging, Konfiguration. | `app/integrations/*`, `app/db.py`, `app/models.py` | Domain-Logik in Adapter verschieben |
-| **Orchestrator/Workers** | Zeit-/Event-gesteuerte Jobs, Dispatch, Visibility-Handling, Heartbeats. | `app/workers/*`, `app/services/dlq_service.py` | API-Calls ohne Idempotenz, ungeplante Retries |
+| Schicht                    | Verantwortung                                                                      | Beispielmodule                                         | Anti-Patterns                                                 |
+| -------------------------- | ---------------------------------------------------------------------------------- | ------------------------------------------------------ | ------------------------------------------------------------- |
+| **API (Router)**           | HTTP-/CLI-Oberfläche, Request-Validierung, Fehler-Envelope, Auth.                  | `app/api/*`, `app/api/routers/*`, FastAPI Dependencies | Business-Logik, Direktzugriff auf Datenbank oder Provider     |
+| **Application (Services)** | Orchestriert Use-Cases, kapselt Transaktionen, orchestriert mehrere Integrationen. | `app/services/*`, `app/workers/*`                      | Zustandsbehaftete globale Variablen, direkte Response-Objekte |
+| **Domain (Core)**          | Reine Fachlogik, Matching, Normalisierung, Fehlerklassen.                          | `app/core/*`, `app/errors.py`                          | Provider-spezifische DTOs, Side-Effects                       |
+| **Infrastructure**         | Integrationen, Persistence, Messaging, Konfiguration.                              | `app/integrations/*`, `app/db.py`, `app/models.py`     | Domain-Logik in Adapter verschieben                           |
+| **Orchestrator/Workers**   | Zeit-/Event-gesteuerte Jobs, Dispatch, Visibility-Handling, Heartbeats.            | `app/workers/*`, `app/services/dlq_service.py`         | API-Calls ohne Idempotenz, ungeplante Retries                 |
 
 ## Modulverantwortungen
 
-| Modul/Komponente | Rolle | Owners | Qualitätskriterien |
-| --- | --- | --- | --- |
-| Router (`app/routers/*`) | Übersetzt HTTP-Requests in Service-Aufrufe, validiert Input und mappt Fehlercodes. | API-Team | FastAPI-Schemata gepflegt, kein Datenbankzugriff, Logging `event=request`. |
-| Services (`app/services/*`) | Enthält Anwendungs-Use-Cases, koordiniert Integrationen und Domain-Komponenten. | Core-Team | Idempotente Methoden, Transaktionsgrenzen dokumentiert, Retry-fähig. |
-| Core (`app/core/*`) | Domain-Modelle, Matching, Normalisierung, Fehler. | Domain-Team | Reine Funktionen, deterministische Tests, keine Provider-Aufrufe. |
-| Integrationen (`app/integrations/*`) | Provider-spezifische Adapters, Mapping von DTOs, Timeout/Retries. | Integrations-Team | Logging `event=integration_call`, Fehler auf Taxonomie gemappt. |
-| Orchestrator (`app/workers/*`, `app/services/dlq_service.py`) | Job-Planung, Dispatch, Visibility, Dead-Letter-Handling. | Platform-Team | Lease-Verträge eingehalten, Heartbeat-Events, DLQ gepflegt. |
+| Modul/Komponente                                              | Rolle                                                                              | Owners            | Qualitätskriterien                                                         |
+| ------------------------------------------------------------- | ---------------------------------------------------------------------------------- | ----------------- | -------------------------------------------------------------------------- |
+| Router (`app/api/routers/*`)                                  | Übersetzt HTTP-Requests in Service-Aufrufe, validiert Input und mappt Fehlercodes. | API-Team          | FastAPI-Schemata gepflegt, kein Datenbankzugriff, Logging `event=request`. |
+| Services (`app/services/*`)                                   | Enthält Anwendungs-Use-Cases, koordiniert Integrationen und Domain-Komponenten.    | Core-Team         | Idempotente Methoden, Transaktionsgrenzen dokumentiert, Retry-fähig.       |
+| Core (`app/core/*`)                                           | Domain-Modelle, Matching, Normalisierung, Fehler.                                  | Domain-Team       | Reine Funktionen, deterministische Tests, keine Provider-Aufrufe.          |
+| Integrationen (`app/integrations/*`)                          | Provider-spezifische Adapters, Mapping von DTOs, Timeout/Retries.                  | Integrations-Team | Logging `event=integration_call`, Fehler auf Taxonomie gemappt.            |
+| Orchestrator (`app/workers/*`, `app/services/dlq_service.py`) | Job-Planung, Dispatch, Visibility, Dead-Letter-Handling.                           | Platform-Team     | Lease-Verträge eingehalten, Heartbeat-Events, DLQ gepflegt.                |
+
+Der frühere Pfad `app/routers/*` stellt nur noch Legacy-Reexports bereit und darf nicht mehr als Quelle für neue Endpunkte verwendet werden.
 
 ## Kern-Flows
 
 ### Request → Response
+
 1. Router validiert Payload, prüft Authentifizierung und erzeugt `event=request` mit `status=received`.
 2. Router ruft den passenden Service auf und übergibt normalisierte DTOs (siehe Contracts).
 3. Services orchestrieren Core-Logik und Integrationen, loggen `event=service.call` und `event=integration_call` mit Dauer.
@@ -39,6 +43,7 @@ Diese Übersicht definiert den gemeinsamen Bezugsrahmen für Router, Services, C
 5. Router wandelt Domain- oder Service-Resultate in Response-DTOs um und emittiert `event=request` mit `status=completed`.
 
 ### Job Lifecycle (Queue)
+
 1. Service oder Timer enqueued einen Job mit Idempotency-Key (`<job-type>:<entity-id>:<timestamp-epoch>`).
 2. Orchestrator-Scheduler reserviert Jobs nach Priorität, setzt Visibility Timeout und vergibt eine Lease.
 3. Dispatcher übergibt den Job an einen Worker-Pool; Handler bestätigt Heartbeats innerhalb des Visibility-Fensters.
@@ -46,12 +51,14 @@ Diese Übersicht definiert den gemeinsamen Bezugsrahmen für Router, Services, C
 5. Bei Fehlern: Retry mit exponentiellem Backoff (Budget aus Config), Überschreitung landet im DLQ (`event=worker_job`, `status=failed`).
 
 ### Watchlist Timer → Enqueue → Handler
+
 1. Timer löst gemäß `WATCHLIST_INTERVAL` aus, liest Artists mit fälligem `last_checked`.
 2. Service erstellt pro Artist einen Job (`watchlist.sync`) und setzt Idempotency-Key `watchlist:<artist-id>:<tick-start>`.
 3. Worker lädt Spotify-Releases, mappt auf Downloads und triggert Soulseek-Enqueue über den ProviderGateway.
 4. Erfolgreiche Läufe löschen Retry-Cooldowns (`event=watchlist.cooldown.clear`), Fehler loggen `event=watchlist.cooldown.skip` und respektieren Budget/Backoff.
 
 ## Fehler-, Retry- und Idempotenzverträge
+
 - **Logging-Contract:** Jedes Event enthält `event`, `component`, `status`, `duration_ms`, `entity_id` (siehe `contracts.md`).
 - **Fehlertaxonomie:** Konsistent zu FastAPI/Error-Envelope (`code`, `message`, optional `meta`).
 - **Retries:** Services definieren maximale Versuche, Backoff-Strategien und DLQ-Hand-Off; Werte dokumentiert in `docs/architecture/contracts.md`.
@@ -59,11 +66,13 @@ Diese Übersicht definiert den gemeinsamen Bezugsrahmen für Router, Services, C
 - **Visibility & Heartbeat:** Jede Lease setzt `visibility_timeout` und fordert Heartbeats (`event=worker.heartbeat`) innerhalb 2/3 der Lease-Dauer.
 
 ## Konfiguration & Feature-Flags
+
 - **Konfigurationsmatrix:** `docs/ops/runtime-config.md` listet relevante ENV-Variablen (Ingest, Watchlist, Provider, Orchestrator). Neue Parameter dort und in dieser Übersicht verlinken.
 - **Feature-Flags:** `ENABLE_LYRICS`, `ENABLE_ARTWORK`, `INGEST_MAX_PENDING_JOBS`, `WATCHLIST_MAX_CONCURRENCY` u. a. werden in Services geprüft und müssen hier dokumentiert bleiben.
 - **Observability:** Structured Logs sind primär, Metriken entfallen. Externe Systeme abonnieren `event=request`, `event=worker_job`, `event=integration_call`.
 
 ## Erweiterungspunkte
+
 - **Neue Provider:** Implementiere `MusicProvider`-Adapter, ergänze Mapping in `ProviderGateway`, schreibe ADR bei signifikanten Schnittstellenänderungen.
 - **Neue Job-Typen:** Definiere Worker-Handler inkl. Visibility-, Retry- und DLQ-Strategie, erweitere Orchestrator-Konfiguration und dokumentiere den Flow.
 - **Neue APIs:** Router delegieren strikt an bestehende Services oder neue Use-Case-Services; Fehler und Logging folgen dem Contract.


### PR DESCRIPTION
## Summary
- update the API layer description to reference app/api modules and clarify the legacy app/routers path
- refresh the module responsibility table with the current router location and add a note about legacy re-exports

## Testing
- npx --yes prettier --check docs/architecture/overview.md

------
https://chatgpt.com/codex/tasks/task_e_68e0cb9a2b108321a5f2ac19c236920c