### PR TITLE
fix: align downloads include-all query flag

### DIFF
--- a/frontend/src/api/services/downloads.ts
+++ b/frontend/src/api/services/downloads.ts
@@ -124,7 +124,7 @@ const withDefaultDownload = (entry: DownloadEntry | undefined, fallback: Partial
 export const getDownloads = async (options: FetchDownloadsOptions = {}): Promise<DownloadEntry[]> => {
   const params: Record<string, string> = {};
   if (options.includeAll) {
-    params.scope = 'all';
+    params.all = 'true';
   }
   if (typeof options.status === 'string' && options.status.length > 0 && options.status !== 'all') {
     params.status = options.status;


### PR DESCRIPTION
## Summary
- update the downloads service to send the `all` query flag when requesting all downloads

## Testing
- npm test
- npm run typecheck
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e0d5e66ccc8321b35ccea2da65f6ee