### PR TITLE
feat(frontend): support soulseek download payload

### DIFF
--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -241,8 +241,17 @@ export interface RetryAllFailedResponse {
   skipped: number;
 }
 
+export interface DownloadFilePayload {
+  filename?: string;
+  name?: string;
+  source?: string;
+  priority?: number;
+  [key: string]: unknown;
+}
+
 export interface StartDownloadPayload {
-  track_id: string;
+  username: string;
+  files: DownloadFilePayload[];
 }
 
 export interface DownloadExportFilters {


### PR DESCRIPTION
## Summary
- extend the Soulseek start download payload to include usernames and file descriptors
- update the library downloads UI to capture or derive usernames and file metadata when queuing downloads
- align unit tests with the new payload structure and cover derived-username behaviour

## Testing
- npm test
- npm run typecheck
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e0d6d554748321836328134621afe8