### PR TITLE
fix: remove unsupported blocked download status filter

### DIFF
--- a/frontend/src/api/services/downloads.ts
+++ b/frontend/src/api/services/downloads.ts
@@ -7,7 +7,7 @@ import type {
   StartDownloadPayload,
   DownloadFilePayload
 } from '../types';
-import { useMutation, useQuery } from '../../lib/query';
+import { useMutation } from '../../lib/query';
 import { ApiError } from '../client';
 import { LIBRARY_POLL_INTERVAL_MS } from '../config';
 

--- a/frontend/src/pages/Library/LibraryDownloads.tsx
+++ b/frontend/src/pages/Library/LibraryDownloads.tsx
@@ -33,8 +33,7 @@ const statusOptions = [
   { value: 'queued', label: 'Warteschlange' },
   { value: 'completed', label: 'Abgeschlossen' },
   { value: 'failed', label: 'Fehlgeschlagen' },
-  { value: 'cancelled', label: 'Abgebrochen' },
-  { value: 'blocked', label: 'Blockiert' }
+  { value: 'cancelled', label: 'Abgebrochen' }
 ];
 
 const DOWNLOAD_SOURCE = 'library_manual';


### PR DESCRIPTION
## Summary
- remove the unsupported "blocked" entry from the library downloads status filter
- drop an unused `useQuery` import from the downloads service to keep lint clean

## Testing
- npm test -- --watch=false
- npm run typecheck
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e0d96a07008321aa161e65ab0abece