### PR TITLE
feat: add plex health checks

### DIFF
--- a/app/routers/health_router.py
+++ b/app/routers/health_router.py
@@ -32,3 +32,14 @@ def soulseek_health(session: Session = Depends(get_db)) -> ServiceHealthResponse
         missing=list(result.missing),
         optional_missing=list(result.optional_missing),
     )
+
+
+@router.get("/plex", response_model=ServiceHealthResponse)
+def plex_health(session: Session = Depends(get_db)) -> ServiceHealthResponse:
+    result = evaluate_service_health(session, "plex")
+    return ServiceHealthResponse(
+        service=result.service,
+        status=result.status,
+        missing=list(result.missing),
+        optional_missing=list(result.optional_missing),
+    )

--- a/app/utils/service_health.py
+++ b/app/utils/service_health.py
@@ -37,6 +37,10 @@ _SERVICE_DEFINITIONS: tuple[ServiceDefinition, ...] = (
         required_keys=("SPOTIFY_CLIENT_ID", "SPOTIFY_CLIENT_SECRET", "SPOTIFY_REDIRECT_URI"),
     ),
     ServiceDefinition(
+        name="plex",
+        required_keys=("PLEX_BASE_URL", "PLEX_TOKEN", "PLEX_LIBRARY"),
+    ),
+    ServiceDefinition(
         name="soulseek",
         required_keys=("SLSKD_URL",),
         optional_keys=("SLSKD_API_KEY",),

--- a/tests/snapshots/openapi.json
+++ b/tests/snapshots/openapi.json
@@ -14909,6 +14909,164 @@
         }
       }
     },
+    "/api/v1/health/plex": {
+      "get": {
+        "tags": [
+          "Health"
+        ],
+        "summary": "Plex Health",
+        "operationId": "plex_health_api_v1_health_plex_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ServiceHealthResponse"
+                }
+              }
+            },
+            "headers": {
+              "ETag": {
+                "description": "Entity tag identifying the cached representation.",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "Last-Modified": {
+                "description": "Timestamp of the last modification in RFC 1123 format.",
+                "schema": {
+                  "type": "string",
+                  "format": "date-time"
+                }
+              },
+              "Cache-Control": {
+                "description": "Cache directives for clients and proxies.",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "Vary": {
+                "description": "Headers that affect the cached representation.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "304": {
+            "description": "Not Modified",
+            "headers": {
+              "ETag": {
+                "description": "Entity tag identifying the cached representation.",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "Last-Modified": {
+                "description": "Timestamp of the last modification in RFC 1123 format.",
+                "schema": {
+                  "type": "string",
+                  "format": "date-time"
+                }
+              },
+              "Cache-Control": {
+                "description": "Cache directives for clients and proxies.",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "Vary": {
+                "description": "Headers that affect the cached representation.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too many requests",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "424": {
+            "description": "Failed dependency",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "Bad gateway",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Service unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "504": {
+            "description": "Gateway timeout",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/watchlist": {
       "get": {
         "tags": [

--- a/tests/test_health_endpoints.py
+++ b/tests/test_health_endpoints.py
@@ -66,3 +66,32 @@ def test_soulseek_health_requires_base_url(client) -> None:
     payload = response.json()
     assert payload["status"] == "fail"
     assert payload["missing"] == ["SLSKD_URL"]
+
+
+def test_plex_health_reports_missing_credentials(client) -> None:
+    response = client.get("/health/plex")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["service"] == "plex"
+    assert payload["status"] == "fail"
+    assert payload["missing"] == ["PLEX_BASE_URL", "PLEX_TOKEN", "PLEX_LIBRARY"]
+    assert payload["optional_missing"] == []
+
+
+def test_plex_health_ok_when_all_values_present(client) -> None:
+    _insert_settings(
+        {
+            "PLEX_BASE_URL": "http://plex",
+            "PLEX_TOKEN": "token",
+            "PLEX_LIBRARY": "Music",
+        }
+    )
+
+    response = client.get("/health/plex")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["service"] == "plex"
+    assert payload["status"] == "ok"
+    assert payload["missing"] == []

--- a/tests/test_status_connections.py
+++ b/tests/test_status_connections.py
@@ -34,4 +34,5 @@ def test_status_connections_reports_health(client) -> None:
     assert "connections" in payload
     assert payload["connections"]["spotify"] == "fail"
     assert payload["connections"]["soulseek"] == "ok"
-    assert set(payload["connections"].keys()) == {"spotify", "soulseek"}
+    assert payload["connections"]["plex"] == "fail"
+    assert set(payload["connections"].keys()) == {"spotify", "plex", "soulseek"}


### PR DESCRIPTION
## Summary
- add the Plex credentials to the service health registry so they are evaluated like Spotify and Soulseek
- expose a `/health/plex` endpoint that returns the standard `ServiceHealthResponse`
- refresh the OpenAPI snapshot and extend health/status tests to cover the Plex service

## Testing
- `pytest tests/test_health_endpoints.py tests/test_status_connections.py`
- `pytest tests/snapshots/test_openapi_schema.py`
- `pytest` *(fails: numerous existing OperationalError/idempotency assertion failures unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68e0dd2412808321b1aded03c244df43