### PR TITLE
fix: normalize download responses for API variations

### DIFF
--- a/frontend/jest.config.cjs
+++ b/frontend/jest.config.cjs
@@ -15,7 +15,8 @@ const config = {
   testMatch: [
     '**/__tests__/**/*.smoke.test.tsx',
     '**/__tests__/auth-header.test.ts',
-    '**/__tests__/downloads-failed-inline.test.tsx'
+    '**/__tests__/downloads-failed-inline.test.tsx',
+    '**/__tests__/downloads.service.test.ts'
   ],
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
   testPathIgnorePatterns: ['/node_modules/', '/dist/']

--- a/frontend/src/__tests__/downloads.service.test.ts
+++ b/frontend/src/__tests__/downloads.service.test.ts
@@ -1,0 +1,97 @@
+import { startDownload, retryDownload } from '../api/services/downloads';
+import type { StartDownloadPayload } from '../api/types';
+import { apiUrl, request } from '../api/client';
+
+jest.mock('../api/client', () => {
+  const actual = jest.requireActual('../api/client');
+  return {
+    ...actual,
+    apiUrl: jest.fn((path: string) => path),
+    request: jest.fn()
+  };
+});
+
+describe('downloads service normalization', () => {
+  const mockedRequest = request as jest.MockedFunction<typeof request>;
+  const mockedApiUrl = apiUrl as jest.MockedFunction<typeof apiUrl>;
+
+  beforeEach(() => {
+    mockedRequest.mockReset();
+    mockedApiUrl.mockReset();
+    mockedApiUrl.mockImplementation((path: string) => path);
+  });
+
+  it('normalizes responses with download_id envelopes into DownloadEntry', async () => {
+    mockedRequest.mockResolvedValueOnce({ ok: true, data: { download_id: 321 } });
+
+    const payload: StartDownloadPayload = {
+      username: ' User ',
+      files: [
+        {
+          filename: 'song.mp3'
+        }
+      ]
+    };
+
+    const entry = await startDownload(payload);
+
+    expect(mockedRequest).toHaveBeenCalledWith({
+      method: 'POST',
+      url: '/download',
+      data: {
+        username: 'User',
+        files: [
+          {
+            filename: 'song.mp3',
+            name: 'song.mp3'
+          }
+        ]
+      }
+    });
+
+    expect(entry).toMatchObject({
+      id: 321,
+      status: 'queued',
+      progress: 0,
+      priority: 0,
+      filename: ''
+    });
+  });
+
+  it('extracts entries from downloads arrays when retrying', async () => {
+    mockedRequest.mockResolvedValueOnce({
+      downloads: [
+        {
+          id: 77,
+          filename: 'retry.mp3',
+          status: 'running',
+          progress: 25,
+          priority: 2
+        }
+      ]
+    });
+
+    const entry = await retryDownload(12);
+
+    expect(mockedRequest).toHaveBeenCalledWith({ method: 'POST', url: '/download/12/retry' });
+    expect(entry).toEqual(
+      expect.objectContaining({
+        id: 77,
+        filename: 'retry.mp3',
+        status: 'running',
+        progress: 25,
+        priority: 2
+      })
+    );
+  });
+
+  it('prefers returned download_id values over retry arguments', async () => {
+    mockedRequest.mockResolvedValueOnce({ download_id: 'new-id' });
+
+    const entry = await retryDownload(55);
+
+    expect(entry.id).toBe('new-id');
+    expect(entry.status).toBe('queued');
+    expect(entry.progress).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- normalize download service responses to handle `download_id` fields and nested download arrays
- reuse backend-provided identifiers when starting or retrying downloads and keep sensible fallbacks
- extend Jest coverage for the download service and include the new suite in the test configuration

## Testing
- npm test
- npm run typecheck
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e0df23a3588321a5eb6f1043eb9b00