### PR TITLE
fix: normalize download mutation responses

### DIFF
--- a/frontend/src/__tests__/downloads.service.test.ts
+++ b/frontend/src/__tests__/downloads.service.test.ts
@@ -58,6 +58,46 @@ describe('downloads service normalization', () => {
     });
   });
 
+  it('merges download_id responses with nested download details', async () => {
+    mockedRequest.mockResolvedValueOnce({
+      ok: true,
+      data: {
+        status: 'queued',
+        download_id: 'abc-123',
+        downloads: [
+          {
+            id: 777,
+            filename: 'nested.mp3',
+            status: 'running',
+            progress: 12,
+            priority: 4,
+            username: 'NestedUser'
+          }
+        ]
+      }
+    });
+
+    const payload: StartDownloadPayload = {
+      username: 'NestedUser',
+      files: [
+        {
+          filename: 'nested.mp3'
+        }
+      ]
+    };
+
+    const entry = await startDownload(payload);
+
+    expect(entry).toMatchObject({
+      id: 'abc-123',
+      filename: 'nested.mp3',
+      status: 'queued',
+      progress: 12,
+      priority: 4,
+      username: 'NestedUser'
+    });
+  });
+
   it('extracts entries from downloads arrays when retrying', async () => {
     mockedRequest.mockResolvedValueOnce({
       downloads: [


### PR DESCRIPTION
## Summary
- merge download_id responses with nested download metadata when normalizing downloads
- simplify start/retry download mutations to return consistent DownloadEntry values and extend service tests

## Testing
- npm test -- --runInBand
- npm run typecheck
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e0e1d28ca08321a77762d7060a7cb2