### PR TITLE
TASK_ID: CODX-NA - Normalize service health name casing

### DIFF
--- a/ToDo.md
+++ b/ToDo.md
@@ -1,0 +1,19 @@
+ID: TD-20251004-002
+Titel: Service Health akzeptiert gemischte Groß-/Kleinschreibung
+Status: done
+Priorität: P2
+Scope: backend
+Owner: codex
+Created_at: 2025-10-04T13:46:28Z
+Updated_at: 2025-10-04T13:46:28Z
+Tags: service-health, configuration
+Beschreibung: Mixed-Case-Service-Namen führten bei den Health-Hilfsfunktionen zu KeyError-Ausnahmen. Die neue Normalisierung sorgt dafür, dass sowohl evaluate_service_health als auch collect_missing_credentials unabhängig von der Schreibweise funktionieren. Tests decken die Regression ab und verhindern erneute Einführungen des Fehlers.
+Akzeptanzkriterien:
+- evaluate_service_health akzeptiert Service-Namen mit beliebiger Groß-/Kleinschreibung und liefert den kanonischen Namen zurück.
+- collect_missing_credentials verarbeitet gemischt geschriebene Service-Namen ohne Ausnahme und meldet fehlende Credentials mit kanonischem Schlüssel.
+Risiko/Impact: Niedrig; reine Normalisierung ohne Auswirkungen auf bestehende Aufrufer.
+Dependencies: Keine
+Verweise: PR TBD
+Subtasks:
+- Normalisierung der Service-Namen implementieren.
+- Regressionstests für gemischt geschriebene Service-Namen ergänzen.

--- a/app/utils/service_health.py
+++ b/app/utils/service_health.py
@@ -12,6 +12,15 @@ from sqlalchemy.orm import Session
 from app.models import Setting
 
 
+def _normalize_service_name(service: str) -> str:
+    """Return the canonical representation for a service name."""
+
+    normalized = service.strip().lower()
+    if not normalized:
+        raise KeyError("Unknown service ''")
+    return normalized
+
+
 @dataclass(frozen=True)
 class ServiceDefinition:
     """Describe the required configuration for a service."""
@@ -49,8 +58,9 @@ _SERVICE_DEFINITIONS: tuple[ServiceDefinition, ...] = (
 
 
 def _definition_for(service: str) -> ServiceDefinition:
+    normalized = _normalize_service_name(service)
     for definition in _SERVICE_DEFINITIONS:
-        if definition.name == service:
+        if definition.name == normalized:
             return definition
     raise KeyError(f"Unknown service '{service}'")
 
@@ -108,7 +118,7 @@ def collect_missing_credentials(
     for service in services:
         health = evaluate_service_health(session, service)
         if health.missing:
-            missing[service] = tuple(health.missing)
+            missing[health.service] = tuple(health.missing)
     return missing
 
 

--- a/tests/utils/test_service_health.py
+++ b/tests/utils/test_service_health.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from app.db import session_scope
+from app.utils.service_health import collect_missing_credentials, evaluate_service_health
+
+
+def test_evaluate_service_health_handles_mixed_case_service_names() -> None:
+    with session_scope() as session:
+        result = evaluate_service_health(session, "SpOtIfY")
+
+    assert result.service == "spotify"
+
+
+def test_collect_missing_credentials_handles_mixed_case_names() -> None:
+    with session_scope() as session:
+        missing = collect_missing_credentials(session, ("Spotify",))
+
+    assert missing == {} or "spotify" in missing


### PR DESCRIPTION
## Summary
- normalise service identifiers in the service health utilities before resolving definitions
- report missing credentials using canonical service names to avoid duplicates from mixed casing inputs
- add regression tests covering mixed-case service names in service health helpers

## Testing
- pytest tests/utils/test_service_health.py -q
- mypy app

## ToDo-Update
- TD-20251004-002 (done) – Service Health akzeptiert gemischte Groß-/Kleinschreibung

------
https://chatgpt.com/codex/tasks/task_e_68e123cbdff08321b4578a438d983ac0