### PR TITLE
feat: add spotify navbar search helpers

### DIFF
--- a/frontend/jest.config.cjs
+++ b/frontend/jest.config.cjs
@@ -12,12 +12,7 @@ const config = {
   moduleNameMapper: {
     '\\.(css|less|scss|sass)$': 'identity-obj-proxy'
   },
-  testMatch: [
-    '**/__tests__/**/*.smoke.test.tsx',
-    '**/__tests__/auth-header.test.ts',
-    '**/__tests__/downloads-failed-inline.test.tsx',
-    '**/__tests__/downloads.service.test.ts'
-  ],
+  testMatch: ['**/__tests__/**/*.test.ts?(x)'],
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
   testPathIgnorePatterns: ['/node_modules/', '/dist/']
 };

--- a/frontend/layout/Navbar.tsx
+++ b/frontend/layout/Navbar.tsx
@@ -1,7 +1,11 @@
-import { FormEvent, useState } from 'react';
+import { FormEvent, useEffect, useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { Bell, Menu, Moon, Search, Sun } from 'lucide-react';
 
+import { ApiError } from '../src/api/client';
+import { searchSpotify } from '../src/api/services/spotify';
+import type { SpotifySearchResults } from '../src/api/services/spotify';
+import SearchResultsOverlay from '../src/components/SearchResultsOverlay';
 import { useTheme } from '../src/hooks/useTheme';
 import { Input } from '../src/components/ui/input';
 import { cn } from '../src/lib/utils';
@@ -13,19 +17,76 @@ export interface NavbarProps {
 const Navbar = ({ onMenuClick }: NavbarProps) => {
   const { theme, setTheme } = useTheme();
   const [searchTerm, setSearchTerm] = useState('');
+  const [inputError, setInputError] = useState<string | null>(null);
+  const [searchError, setSearchError] = useState<string | null>(null);
+  const [isSearching, setIsSearching] = useState(false);
+  const [results, setResults] = useState<SpotifySearchResults | null>(null);
+  const [isOverlayOpen, setIsOverlayOpen] = useState(false);
+  const [activeQuery, setActiveQuery] = useState('');
+  const requestIdRef = useRef(0);
   const isDark = theme === 'dark';
 
   const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
+    const trimmed = searchTerm.trim();
+    if (!trimmed) {
+      setInputError('Please enter a search term.');
+      setSearchError(null);
+      setResults(null);
+      setIsOverlayOpen(false);
+      setActiveQuery('');
+      return;
+    }
+
+    const requestId = requestIdRef.current + 1;
+    requestIdRef.current = requestId;
+    setIsSearching(true);
+    setInputError(null);
+    setSearchError(null);
+    setIsOverlayOpen(true);
+    setActiveQuery(trimmed);
+
+    searchSpotify(trimmed)
+      .then((data) => {
+        if (requestIdRef.current !== requestId) {
+          return;
+        }
+        setResults(data);
+        setSearchError(null);
+      })
+      .catch((error) => {
+        if (requestIdRef.current !== requestId) {
+          return;
+        }
+        const message = error instanceof ApiError ? error.message || 'Unable to load search results.' : null;
+        setSearchError(message ?? 'Unable to load search results.');
+        setResults(null);
+      })
+      .finally(() => {
+        if (requestIdRef.current === requestId) {
+          setIsSearching(false);
+        }
+      });
   };
+
+  useEffect(() => {
+    if (searchTerm.trim().length === 0) {
+      setResults(null);
+      setSearchError(null);
+      setIsOverlayOpen(false);
+      setActiveQuery('');
+    }
+  }, [searchTerm]);
 
   const toggleTheme = () => {
     setTheme(isDark ? 'light' : 'dark');
   };
 
+  const inputErrorId = inputError ? 'navbar-search-error' : undefined;
+
   return (
     <header className="sticky top-0 z-40 border-b border-slate-200/80 bg-white/90 backdrop-blur-md dark:border-slate-800/70 dark:bg-slate-950/80">
-      <div className="flex h-16 items-center gap-4 px-4 sm:px-6">
+      <div className="relative flex h-16 items-center gap-4 px-4 sm:px-6">
         <button
           type="button"
           onClick={onMenuClick}
@@ -45,20 +106,48 @@ const Navbar = ({ onMenuClick }: NavbarProps) => {
           Harmony
         </Link>
 
-        <form
-          onSubmit={handleSubmit}
-          className="relative hidden flex-1 items-center md:flex"
-          role="search"
-        >
+        <form onSubmit={handleSubmit} className="relative hidden flex-1 items-center md:flex" role="search">
           <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-400" />
           <Input
+            type="search"
             value={searchTerm}
-            onChange={(event) => setSearchTerm(event.target.value)}
+            onChange={(event) => {
+              setSearchTerm(event.target.value);
+              if (inputError) {
+                setInputError(null);
+              }
+            }}
             placeholder="Search services, libraries, media..."
             className="h-10 rounded-lg border border-slate-200 bg-white pl-10 pr-4 text-sm text-slate-700 shadow-sm transition focus:border-indigo-500 focus:ring-2 focus:ring-indigo-400 dark:border-slate-700 dark:bg-slate-900/80 dark:text-slate-200 dark:placeholder:text-slate-500"
             aria-label="Search"
+            aria-invalid={inputError ? 'true' : undefined}
+            aria-describedby={inputErrorId}
+          />
+          <SearchResultsOverlay
+            query={activeQuery}
+            isOpen={isOverlayOpen}
+            isLoading={isSearching}
+            error={searchError}
+            results={results}
+            onSelect={() => {
+              setIsOverlayOpen(false);
+              setResults(null);
+            }}
+            onClose={() => {
+              setIsOverlayOpen(false);
+            }}
           />
         </form>
+
+        {inputError ? (
+          <p
+            id={inputErrorId}
+            className="absolute left-1/2 top-16 hidden w-full -translate-x-1/2 text-xs text-red-600 md:block"
+            role="alert"
+          >
+            {inputError}
+          </p>
+        ) : null}
 
         <div className="ml-auto flex items-center gap-2 sm:gap-3">
           <button

--- a/frontend/src/__tests__/NavbarSearch.test.tsx
+++ b/frontend/src/__tests__/NavbarSearch.test.tsx
@@ -1,0 +1,94 @@
+import { act, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+
+import Navbar from '../../layout/Navbar';
+import { ThemeProvider } from '../components/theme-provider';
+import type { SpotifySearchResults } from '../../layout/../src/api/services/spotify';
+import { searchSpotify } from '../../layout/../src/api/services/spotify';
+
+jest.mock('../../layout/../src/api/services/spotify', () => ({
+  searchSpotify: jest.fn()
+}));
+
+const mockedSearchSpotify = searchSpotify as jest.MockedFunction<typeof searchSpotify>;
+
+const renderNavbar = () =>
+  render(
+    <MemoryRouter>
+      <ThemeProvider>
+        <Navbar />
+      </ThemeProvider>
+    </MemoryRouter>
+  );
+
+beforeEach(() => {
+  mockedSearchSpotify.mockReset();
+});
+
+describe('Navbar search', () => {
+  it('submits a query and displays grouped results', async () => {
+    const mockResults: SpotifySearchResults = {
+      tracks: [
+        {
+          type: 'track',
+          id: 'track-1',
+          name: 'Hysteria',
+          artists: ['Muse'],
+          album: 'Absolution',
+          durationMs: 214000
+        }
+      ],
+      artists: [
+        {
+          type: 'artist',
+          id: 'artist-1',
+          name: 'Muse',
+          imageUrl: null,
+          followers: 1532000,
+          genres: ['Alternative Rock', 'Space Rock']
+        }
+      ],
+      albums: [
+        {
+          type: 'album',
+          id: 'album-1',
+          name: 'Black Holes & Revelations',
+          imageUrl: null,
+          releaseDate: '2006-07-03',
+          artists: ['Muse']
+        }
+      ]
+    };
+    mockedSearchSpotify.mockResolvedValue(mockResults);
+
+    const user = userEvent.setup();
+    renderNavbar();
+
+    const input = screen.getByRole('searchbox', { name: /search/i });
+    await act(async () => {
+      await user.type(input, 'Muse');
+      await user.keyboard('{Enter}');
+    });
+
+    expect(mockedSearchSpotify).toHaveBeenCalledWith('Muse');
+    expect(await screen.findByRole('heading', { name: /tracks/i })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: /hysteria/i })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: /black holes & revelations/i })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: /^muse/i })).toBeInTheDocument();
+  });
+
+  it('does not call the API when the query is empty', async () => {
+    const user = userEvent.setup();
+    renderNavbar();
+
+    const input = screen.getByRole('searchbox', { name: /search/i });
+    await act(async () => {
+      await user.click(input);
+      await user.keyboard('{Enter}');
+    });
+
+    expect(mockedSearchSpotify).not.toHaveBeenCalled();
+    expect(await screen.findByRole('alert')).toHaveTextContent(/please enter a search term/i);
+  });
+});

--- a/frontend/src/api/services/spotify.ts
+++ b/frontend/src/api/services/spotify.ts
@@ -5,7 +5,9 @@ import type {
   ArtistReleasesResponse,
   FollowedArtistsResponse,
   NormalizedTrack,
+  SpotifyAlbumSearchResult,
   SpotifyArtist,
+  SpotifyArtistSearchResult,
   SpotifyArtistRelease,
   SpotifyFreeEnqueuePayload,
   SpotifyFreeEnqueueResponse,
@@ -13,9 +15,152 @@ import type {
   SpotifyFreeParseResponse,
   SpotifyFreeUploadPayload,
   SpotifyFreeUploadResponse,
+  SpotifyImage,
   SpotifyMode,
-  SpotifyModeResponse
+  SpotifyModeResponse,
+  SpotifyRawAlbum,
+  SpotifyRawArtist,
+  SpotifyRawTrack,
+  SpotifySearchResponse,
+  SpotifySearchResults,
+  SpotifyTrackSearchResult
 } from '../types';
+
+const notEmpty = <T>(value: T | null | undefined): value is T => value !== null && value !== undefined;
+
+const getFirstImageUrl = (images?: SpotifyImage[] | null): string | null => {
+  if (!Array.isArray(images)) {
+    return null;
+  }
+  for (const image of images) {
+    if (image && typeof image.url === 'string' && image.url.trim().length > 0) {
+      return image.url;
+    }
+  }
+  return null;
+};
+
+const toStringArray = (input: unknown): string[] => {
+  if (!Array.isArray(input)) {
+    return [];
+  }
+  return input
+    .map((value) => (typeof value === 'string' ? value : null))
+    .filter((value): value is string => Boolean(value && value.trim().length > 0));
+};
+
+const normalizeTrackSearchItem = (item: SpotifyRawTrack | null | undefined): SpotifyTrackSearchResult | null => {
+  if (!item || typeof item !== 'object') {
+    return null;
+  }
+  const name = typeof item.name === 'string' ? item.name.trim() : '';
+  if (!name) {
+    return null;
+  }
+  const id = typeof item.id === 'string' && item.id.trim().length > 0 ? item.id : null;
+  const rawArtists = Array.isArray(item.artists) ? item.artists : [];
+  const artists = rawArtists
+    .map((artist) => (artist && typeof artist.name === 'string' ? artist.name.trim() : null))
+    .filter((artist): artist is string => Boolean(artist));
+  const albumName = item.album && typeof item.album.name === 'string' ? item.album.name.trim() : null;
+  const durationMs = typeof item.duration_ms === 'number' && Number.isFinite(item.duration_ms)
+    ? item.duration_ms
+    : null;
+
+  return {
+    type: 'track',
+    id,
+    name,
+    artists,
+    album: albumName && albumName.length > 0 ? albumName : null,
+    durationMs
+  };
+};
+
+const normalizeArtistSearchItem = (
+  item: SpotifyRawArtist | null | undefined
+): SpotifyArtistSearchResult | null => {
+  if (!item || typeof item !== 'object') {
+    return null;
+  }
+  const name = typeof item.name === 'string' ? item.name.trim() : '';
+  if (!name) {
+    return null;
+  }
+  const id = typeof item.id === 'string' && item.id.trim().length > 0 ? item.id : null;
+  const followersPayload = item.followers;
+  const followers =
+    followersPayload && typeof followersPayload.total === 'number' && Number.isFinite(followersPayload.total)
+      ? followersPayload.total
+      : null;
+  return {
+    type: 'artist',
+    id,
+    name,
+    imageUrl: getFirstImageUrl(item.images ?? null),
+    followers,
+    genres: toStringArray(item.genres)
+  };
+};
+
+const normalizeAlbumSearchItem = (item: SpotifyRawAlbum | null | undefined): SpotifyAlbumSearchResult | null => {
+  if (!item || typeof item !== 'object') {
+    return null;
+  }
+  const name = typeof item.name === 'string' ? item.name.trim() : '';
+  if (!name) {
+    return null;
+  }
+  const id = typeof item.id === 'string' && item.id.trim().length > 0 ? item.id : null;
+  const artistsPayload = Array.isArray(item.artists) ? item.artists : [];
+  const artists = artistsPayload
+    .map((artist) => (artist && typeof artist.name === 'string' ? artist.name.trim() : null))
+    .filter((artist): artist is string => Boolean(artist));
+  const releaseDate = typeof item.release_date === 'string' && item.release_date.trim().length > 0
+    ? item.release_date
+    : null;
+  return {
+    type: 'album',
+    id,
+    name,
+    imageUrl: getFirstImageUrl(item.images ?? null),
+    releaseDate,
+    artists
+  };
+};
+
+const fetchSearchItems = async <T>(endpoint: string, query: string): Promise<T[]> => {
+  const response = await request<SpotifySearchResponse<T>>({
+    method: 'GET',
+    url: apiUrl(endpoint),
+    params: { query }
+  });
+  return Array.isArray(response.items) ? response.items : [];
+};
+
+export const searchSpotifyTracks = async (query: string): Promise<SpotifyTrackSearchResult[]> => {
+  const rawItems = await fetchSearchItems<SpotifyRawTrack>('/spotify/search/tracks', query);
+  return rawItems.map(normalizeTrackSearchItem).filter(notEmpty);
+};
+
+export const searchSpotifyArtists = async (query: string): Promise<SpotifyArtistSearchResult[]> => {
+  const rawItems = await fetchSearchItems<SpotifyRawArtist>('/spotify/search/artists', query);
+  return rawItems.map(normalizeArtistSearchItem).filter(notEmpty);
+};
+
+export const searchSpotifyAlbums = async (query: string): Promise<SpotifyAlbumSearchResult[]> => {
+  const rawItems = await fetchSearchItems<SpotifyRawAlbum>('/spotify/search/albums', query);
+  return rawItems.map(normalizeAlbumSearchItem).filter(notEmpty);
+};
+
+export const searchSpotify = async (query: string): Promise<SpotifySearchResults> => {
+  const [tracks, artists, albums] = await Promise.all([
+    searchSpotifyTracks(query),
+    searchSpotifyArtists(query),
+    searchSpotifyAlbums(query)
+  ]);
+  return { tracks, artists, albums };
+};
 
 export const getFollowedArtists = async (): Promise<SpotifyArtist[]> =>
   request<FollowedArtistsResponse>({ method: 'GET', url: apiUrl('/spotify/artists/followed') }).then(
@@ -63,7 +208,9 @@ export const uploadSpotifyFreeFile = async (
 export type {
   ArtistPreferenceEntry,
   NormalizedTrack,
+  SpotifyAlbumSearchResult,
   SpotifyArtist,
+  SpotifyArtistSearchResult,
   SpotifyArtistRelease,
   SpotifyFreeEnqueuePayload,
   SpotifyFreeEnqueueResponse,
@@ -71,6 +218,8 @@ export type {
   SpotifyFreeParseResponse,
   SpotifyFreeUploadPayload,
   SpotifyFreeUploadResponse,
+  SpotifySearchResults,
   SpotifyMode,
-  SpotifyModeResponse
+  SpotifyModeResponse,
+  SpotifyTrackSearchResult
 };

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -163,6 +163,83 @@ export interface SpotifyFreeEnqueueResponse {
   skipped: number;
 }
 
+export interface SpotifySearchResponse<T = Record<string, unknown>> {
+  items: T[];
+}
+
+export interface SpotifyRawArtist {
+  id?: string | null;
+  name?: string | null;
+  images?: SpotifyImage[] | null;
+  genres?: string[] | null;
+  followers?: { total?: number | null } | null;
+  popularity?: number | null;
+  uri?: string | null;
+  metadata?: Record<string, unknown> | null;
+}
+
+export interface SpotifyRawAlbum {
+  id?: string | null;
+  name?: string | null;
+  release_date?: string | null;
+  images?: SpotifyImage[] | null;
+  artists?: SpotifyRawArtist[] | null;
+  total_tracks?: number | null;
+  uri?: string | null;
+  metadata?: Record<string, unknown> | null;
+}
+
+export interface SpotifyRawTrackArtist {
+  id?: string | null;
+  name?: string | null;
+  metadata?: Record<string, unknown> | null;
+}
+
+export interface SpotifyRawTrack {
+  id?: string | null;
+  name?: string | null;
+  provider?: string | null;
+  artists?: SpotifyRawTrackArtist[] | null;
+  album?: SpotifyRawAlbum | null;
+  duration_ms?: number | null;
+  isrc?: string | null;
+  score?: number | null;
+  metadata?: Record<string, unknown> | null;
+}
+
+export interface SpotifyTrackSearchResult {
+  type: 'track';
+  id: string | null;
+  name: string;
+  artists: string[];
+  album: string | null;
+  durationMs: number | null;
+}
+
+export interface SpotifyArtistSearchResult {
+  type: 'artist';
+  id: string | null;
+  name: string;
+  imageUrl: string | null;
+  followers: number | null;
+  genres: string[];
+}
+
+export interface SpotifyAlbumSearchResult {
+  type: 'album';
+  id: string | null;
+  name: string;
+  imageUrl: string | null;
+  releaseDate: string | null;
+  artists: string[];
+}
+
+export interface SpotifySearchResults {
+  tracks: SpotifyTrackSearchResult[];
+  artists: SpotifyArtistSearchResult[];
+  albums: SpotifyAlbumSearchResult[];
+}
+
 export interface WatchlistArtistEntry {
   id: number | string;
   spotify_artist_id: string;

--- a/frontend/src/components/SearchResultsOverlay.tsx
+++ b/frontend/src/components/SearchResultsOverlay.tsx
@@ -1,0 +1,189 @@
+import type {
+  SpotifyAlbumSearchResult,
+  SpotifyArtistSearchResult,
+  SpotifySearchResults,
+  SpotifyTrackSearchResult
+} from '../api/services/spotify';
+import { cn } from '../lib/utils';
+
+const formatDuration = (value: number | null): string | null => {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) {
+    return null;
+  }
+  const totalSeconds = Math.round(value / 1000);
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${minutes}:${seconds.toString().padStart(2, '0')}`;
+};
+
+const formatFollowers = (value: number | null): string | null => {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value < 0) {
+    return null;
+  }
+  return new Intl.NumberFormat().format(value);
+};
+
+const trackSubtitle = (track: SpotifyTrackSearchResult): string | null => {
+  const parts: string[] = [];
+  if (track.artists.length > 0) {
+    parts.push(track.artists.join(', '));
+  }
+  if (track.album) {
+    parts.push(track.album);
+  }
+  const duration = formatDuration(track.durationMs);
+  if (duration) {
+    parts.push(duration);
+  }
+  return parts.length > 0 ? parts.join(' • ') : null;
+};
+
+const artistSubtitle = (artist: SpotifyArtistSearchResult): string | null => {
+  const parts: string[] = [];
+  const followers = formatFollowers(artist.followers);
+  if (followers) {
+    parts.push(`${followers} followers`);
+  }
+  if (artist.genres.length > 0) {
+    parts.push(artist.genres.slice(0, 3).join(', '));
+  }
+  return parts.length > 0 ? parts.join(' • ') : null;
+};
+
+const albumSubtitle = (album: SpotifyAlbumSearchResult): string | null => {
+  const parts: string[] = [];
+  if (album.artists.length > 0) {
+    parts.push(album.artists.join(', '));
+  }
+  if (album.releaseDate) {
+    parts.push(album.releaseDate);
+  }
+  return parts.length > 0 ? parts.join(' • ') : null;
+};
+
+type SearchResultSelection =
+  | { type: 'track'; item: SpotifyTrackSearchResult }
+  | { type: 'artist'; item: SpotifyArtistSearchResult }
+  | { type: 'album'; item: SpotifyAlbumSearchResult };
+
+export interface SearchResultsOverlayProps {
+  query: string;
+  isOpen: boolean;
+  isLoading: boolean;
+  error?: string | null;
+  results: SpotifySearchResults | null;
+  onSelect?: (selection: SearchResultSelection) => void;
+  onClose?: () => void;
+}
+
+export const SearchResultsOverlay = ({
+  query,
+  isOpen,
+  isLoading,
+  error,
+  results,
+  onSelect,
+  onClose
+}: SearchResultsOverlayProps) => {
+  const shouldRender = isOpen || isLoading || Boolean(error);
+  if (!shouldRender) {
+    return null;
+  }
+
+  const groups: Array<{
+    key: 'tracks' | 'artists' | 'albums';
+    label: string;
+    items: SpotifyTrackSearchResult[] | SpotifyArtistSearchResult[] | SpotifyAlbumSearchResult[];
+  }> = [
+    { key: 'tracks', label: 'Tracks', items: results?.tracks ?? [] },
+    { key: 'artists', label: 'Artists', items: results?.artists ?? [] },
+    { key: 'albums', label: 'Albums', items: results?.albums ?? [] }
+  ];
+
+  const hasResults = groups.some((group) => group.items.length > 0);
+
+  return (
+    <div
+      className={cn(
+        'absolute left-0 right-0 top-full z-50 mt-2 w-full rounded-lg border border-slate-200 bg-white shadow-xl',
+        'focus:outline-none dark:border-slate-700 dark:bg-slate-900'
+      )}
+      role="region"
+      aria-label={query ? `Search results for “${query}”` : 'Search results'}
+      tabIndex={-1}
+      onKeyDown={(event) => {
+        if (event.key === 'Escape') {
+          event.preventDefault();
+          onClose?.();
+        }
+      }}
+    >
+      {isLoading ? (
+        <p className="px-4 py-3 text-sm text-slate-500 dark:text-slate-400" role="status" aria-live="polite">
+          Searching…
+        </p>
+      ) : error ? (
+        <p className="px-4 py-3 text-sm text-red-600 dark:text-red-400" role="alert">
+          {error}
+        </p>
+      ) : hasResults ? (
+        <div className="max-h-80 overflow-y-auto py-2">
+          {groups.map((group) => {
+            if (group.items.length === 0) {
+              return null;
+            }
+            return (
+              <section key={group.key} aria-label={`${group.label} results`} className="py-1">
+                <h3 className="px-4 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                  {group.label}
+                </h3>
+                <ul className="mt-1 space-y-1 px-2" role="listbox">
+                  {group.items.map((item) => {
+                    const selection = { type: group.key, item } as SearchResultSelection;
+                    const title = item.name;
+                    const subtitle =
+                      group.key === 'tracks'
+                        ? trackSubtitle(item as SpotifyTrackSearchResult)
+                        : group.key === 'artists'
+                          ? artistSubtitle(item as SpotifyArtistSearchResult)
+                          : albumSubtitle(item as SpotifyAlbumSearchResult);
+                    return (
+                      <li key={`${group.key}-${item.id ?? title}`} className="list-none">
+                        <button
+                          type="button"
+                          role="option"
+                          onClick={() => {
+                            onSelect?.(selection);
+                            onClose?.();
+                          }}
+                          className={cn(
+                            'w-full rounded-md px-3 py-2 text-left text-sm transition-colors',
+                            'hover:bg-indigo-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500',
+                            'dark:hover:bg-slate-800'
+                          )}
+                        >
+                          <span className="block font-medium text-slate-900 dark:text-slate-100">{title}</span>
+                          {subtitle ? (
+                            <span className="mt-0.5 block text-xs text-slate-500 dark:text-slate-400">{subtitle}</span>
+                          ) : null}
+                        </button>
+                      </li>
+                    );
+                  })}
+                </ul>
+              </section>
+            );
+          })}
+        </div>
+      ) : (
+        <p className="px-4 py-3 text-sm text-slate-500 dark:text-slate-400" role="status" aria-live="polite">
+          No results found{query ? ` for “${query}”` : ''}.
+        </p>
+      )}
+    </div>
+  );
+};
+
+export type { SearchResultSelection };
+
+export default SearchResultsOverlay;


### PR DESCRIPTION
## Summary
- add typed Spotify search helpers that normalize artist, album, and track results
- refresh the navbar search UX with validation, async state, and a reusable results overlay component
- expand Jest configuration and add coverage for the navbar search flow

## Testing
- npm test -- --runTestsByPath src/__tests__/NavbarSearch.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68e1329d01208321b83b264780485e20