### PR TITLE
feat: add soulseek and matching routes

### DIFF
--- a/ToDo.md
+++ b/ToDo.md
@@ -17,3 +17,25 @@ Verweise: PR TBD
 Subtasks:
 - Normalisierung der Service-Namen implementieren.
 - Regressionstests für gemischt geschriebene Service-Namen ergänzen.
+
+ID: TD-20251012-001
+Titel: Soulseek- und Matching-Ansichten mit Live-Daten versorgen
+Status: todo
+Priorität: P2
+Scope: frontend
+Owner: codex
+Created_at: 2025-10-12T09:00:00Z
+Updated_at: 2025-10-12T09:00:00Z
+Tags: navigation, integrations, soulseek, matching
+Beschreibung: Die neuen Navigationspunkte für Soulseek und Matching zeigen aktuell nur Platzhaltertexte. Für ein vollständiges Nutzererlebnis müssen die Komponenten API-Aufrufe der Downloader- und Matching-Services integrieren. Zusätzlich soll die Navigation den aktuellen Integrationsstatus widerspiegeln und Rückmeldungen bei Fehlern geben. Dokumentation und Monitoring-Hooks müssen mit den neuen Ansichten abgeglichen werden.
+Akzeptanzkriterien:
+- SoulseekPage lädt Status- und Konfigurationsdaten aus dem Backend und visualisiert aktive Freigaben.
+- MatchingPage zeigt laufende und ausstehende Zuordnungen inklusive Fehlerzuständen an.
+- Navigation spiegelt den Integrationsstatus (z. B. Warnhinweise) wider und wird in der Doku beschrieben.
+Risiko/Impact: Mittel; unvollständige Daten-Anbindung könnte zu verwirrenden Statusanzeigen führen.
+Dependencies: Backend-Endpunkte für Soulseek- und Matching-Status.
+Verweise: TASK TBD
+Subtasks:
+- API-Clients für Soulseek- und Matching-Status implementieren.
+- UI-Komponenten zur Visualisierung der Statusdaten ergänzen.
+- Monitoring- und Doku-Updates erstellen.

--- a/frontend/layout/Sidebar.tsx
+++ b/frontend/layout/Sidebar.tsx
@@ -1,22 +1,9 @@
 import { Fragment, useEffect } from 'react';
 import { createPortal } from 'react-dom';
 import { NavLink } from 'react-router-dom';
-import {
-  LayoutDashboard,
-  Music,
-  Radio,
-  Sparkles,
-  Settings,
-  X
-} from 'lucide-react';
+import { X } from 'lucide-react';
 
-const navigationItems = [
-  { to: '/dashboard', label: 'Dashboard', icon: LayoutDashboard },
-  { to: '/spotify', label: 'Spotify', icon: Music },
-  { to: '/soulseek', label: 'Soulseek', icon: Radio },
-  { to: '/matching', label: 'Matching', icon: Sparkles },
-  { to: '/settings', label: 'Settings', icon: Settings }
-] as const;
+import { navigationItems } from '../src/config/navigation';
 
 export interface SidebarProps {
   open: boolean;

--- a/frontend/src/__tests__/AppRoutes.test.tsx
+++ b/frontend/src/__tests__/AppRoutes.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+import AppRoutes from '../routes';
+
+describe('AppRoutes', () => {
+  const renderWithRoute = (route: string) =>
+    render(
+      <MemoryRouter initialEntries={[route]}>
+        <AppRoutes />
+      </MemoryRouter>
+    );
+
+  it('renders the Soulseek page without redirecting', () => {
+    renderWithRoute('/soulseek');
+
+    expect(
+      screen.getByRole('heading', { name: /Soulseek/i, level: 1 })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Soulseek-Community, um neue Musikquellen zu entdecken/i)
+    ).toBeInTheDocument();
+  });
+
+  it('renders the Matching page without redirecting', () => {
+    renderWithRoute('/matching');
+
+    expect(
+      screen.getByRole('heading', { name: /Matching/i, level: 1 })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Abgleichsstatus, vorgeschlagene Zuordnungen/i)
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,19 +1,12 @@
 import { ReactNode, useMemo, useState } from 'react';
 import { Link, NavLink, useLocation } from 'react-router-dom';
-import { CircleDot, Download, Menu, Moon, Music, Settings, Sun, Users } from 'lucide-react';
+import { CircleDot, Menu, Moon, Sun } from 'lucide-react';
 import { cn } from '../lib/utils';
 import { Button } from './ui/shadcn';
 import { ScrollArea } from './ui/scroll-area';
 import { Switch } from './ui/switch';
 import { useTheme } from '../hooks/useTheme';
-
-const navItems = [
-  { to: '/dashboard', label: 'Dashboard', icon: CircleDot },
-  { to: '/downloads', label: 'Downloads', icon: Download },
-  { to: '/artists', label: 'Artists', icon: Users },
-  { to: '/spotify', label: 'Spotify', icon: Music },
-  { to: '/settings', label: 'Settings', icon: Settings }
-] as const;
+import { navigationItems } from '../config/navigation';
 
 interface LayoutProps {
   children: ReactNode;
@@ -25,7 +18,7 @@ const Layout = ({ children }: LayoutProps) => {
   const location = useLocation();
 
   const activeTitle = useMemo(() => {
-    const match = navItems.find((item) => location.pathname.startsWith(item.to));
+    const match = navigationItems.find((item) => location.pathname.startsWith(item.to));
     return match?.label ?? 'Harmony';
   }, [location.pathname]);
 
@@ -46,7 +39,7 @@ const Layout = ({ children }: LayoutProps) => {
         </div>
         <ScrollArea className="h-[calc(100vh-4rem)]">
           <nav className="flex flex-col gap-1 p-4">
-            {navItems.map((item) => {
+            {navigationItems.map((item) => {
               const Icon = item.icon;
               return (
                 <NavLink

--- a/frontend/src/config/navigation.ts
+++ b/frontend/src/config/navigation.ts
@@ -1,0 +1,26 @@
+import {
+  CircleDot,
+  Download,
+  LucideIcon,
+  Music,
+  Radio,
+  Settings,
+  Sparkles,
+  Users
+} from 'lucide-react';
+
+export interface NavigationItem {
+  to: string;
+  label: string;
+  icon: LucideIcon;
+}
+
+export const navigationItems: NavigationItem[] = [
+  { to: '/dashboard', label: 'Dashboard', icon: CircleDot },
+  { to: '/downloads', label: 'Downloads', icon: Download },
+  { to: '/artists', label: 'Artists', icon: Users },
+  { to: '/spotify', label: 'Spotify', icon: Music },
+  { to: '/soulseek', label: 'Soulseek', icon: Radio },
+  { to: '/matching', label: 'Matching', icon: Sparkles },
+  { to: '/settings', label: 'Settings', icon: Settings }
+];

--- a/frontend/src/pages/MatchingPage.tsx
+++ b/frontend/src/pages/MatchingPage.tsx
@@ -1,0 +1,17 @@
+const MatchingPage = () => (
+  <section className="space-y-6">
+    <header className="space-y-2">
+      <h1 className="text-2xl font-semibold text-slate-900 dark:text-slate-100">Matching</h1>
+      <p className="text-sm text-slate-600 dark:text-slate-400">
+        Gleiche neu importierte Titel automatisch mit deiner Bibliothek und externen Diensten ab, um Duplikate und
+        Metadaten-Konflikte zu vermeiden.
+      </p>
+    </header>
+    <div className="rounded-xl border border-dashed border-slate-300 bg-white/80 p-6 text-sm text-slate-500 shadow-sm dark:border-slate-700 dark:bg-slate-900/60 dark:text-slate-300">
+      Das Matching-Dashboard zeigt demnächst den Abgleichsstatus, vorgeschlagene Zuordnungen und Integrationen mit Spotify
+      oder lokalen Tags.
+    </div>
+  </section>
+);
+
+export default MatchingPage;

--- a/frontend/src/pages/SoulseekPage.tsx
+++ b/frontend/src/pages/SoulseekPage.tsx
@@ -1,0 +1,17 @@
+const SoulseekPage = () => (
+  <section className="space-y-6">
+    <header className="space-y-2">
+      <h1 className="text-2xl font-semibold text-slate-900 dark:text-slate-100">Soulseek</h1>
+      <p className="text-sm text-slate-600 dark:text-slate-400">
+        Verbinde deinen Harmony-Katalog mit der Soulseek-Community, um neue Musikquellen zu entdecken
+        und Downloads zu orchestrieren.
+      </p>
+    </header>
+    <div className="rounded-xl border border-dashed border-slate-300 bg-white/80 p-6 text-sm text-slate-500 shadow-sm dark:border-slate-700 dark:bg-slate-900/60 dark:text-slate-300">
+      Die Soulseek-Integration ist in Vorbereitung. Hier erscheinen demnächst Verbindungsdetails, Freigabe-Status
+      und eine Übersicht aktiver Suchanfragen.
+    </div>
+  </section>
+);
+
+export default SoulseekPage;

--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -2,7 +2,9 @@ import { Navigate, Route, Routes } from 'react-router-dom';
 
 import DashboardPage from '../pages/DashboardPage';
 import LibraryPage from '../pages/Library';
+import MatchingPage from '../pages/MatchingPage';
 import SettingsPage from '../pages/SettingsPage';
+import SoulseekPage from '../pages/SoulseekPage';
 import SpotifyPage from '../pages/SpotifyPage';
 
 const AppRoutes = () => (
@@ -14,6 +16,8 @@ const AppRoutes = () => (
     <Route path="/artists" element={<Navigate to="/library?tab=artists" replace />} />
     <Route path="/watchlist" element={<Navigate to="/library?tab=watchlist" replace />} />
     <Route path="/spotify" element={<SpotifyPage />} />
+    <Route path="/soulseek" element={<SoulseekPage />} />
+    <Route path="/matching" element={<MatchingPage />} />
     <Route path="/settings" element={<SettingsPage />} />
     <Route path="*" element={<Navigate to="/dashboard" replace />} />
   </Routes>


### PR DESCRIPTION
## Summary
- add Soulseek and Matching placeholder pages and hook them into the router
- share a single navigation config between the production layout and the storybook sidebar
- verify the new routes render via a dedicated AppRoutes test

## Testing
- `npm test -- AppRoutes`

## ToDo-Update
- Added TD-20251012-001 (Soulseek- und Matching-Ansichten mit Live-Daten versorgen)


------
https://chatgpt.com/codex/tasks/task_e_68e135cd648c832186455006e6261fb4