### PR TITLE
feat: CODX-P1-SPOT-???

### DIFF
--- a/ToDo.md
+++ b/ToDo.md
@@ -61,3 +61,25 @@ Subtasks:
 - API-Clients für Soulseek- und Matching-Status implementieren.
 - UI-Komponenten zur Visualisierung der Statusdaten ergänzen.
 - Monitoring- und Doku-Updates erstellen.
+
+ID: TD-20251012-003
+Titel: Spotify PRO Buttons triggern OAuth-Fluss direkt
+Status: todo
+Priorität: P2
+Scope: frontend
+Owner: codex
+Created_at: 2025-10-12T16:30:00Z
+Updated_at: 2025-10-12T16:30:00Z
+Tags: spotify, ux, integrations
+Beschreibung: Die Spotify-Übersicht blendet jetzt PRO-spezifische Aktionen ein, doch die Buttons leiten lediglich auf allgemeine Seiten weiter. Für einen konsistenten Flow sollen Nutzer:innen den OAuth-Anmeldeprozess direkt aus der Oberfläche starten und den Status der Authentifizierung live sehen können. Zudem fehlt ein klarer Abschluss-Dialog nach erfolgreichem Login, der auf verfügbare PRO-Funktionen verweist. Ziel ist eine nahtlose UX ohne manuelle Kontextwechsel in Backend-Tools. Die Umsetzung sollte Telemetrie-Hooks berücksichtigen, um Fehlversuche zu analysieren und Retry-Hinweise zu geben.
+Akzeptanzkriterien:
+- PRO-Aktionsbuttons öffnen einen OAuth-Dialog inklusive Callback-Verarbeitung innerhalb des Frontends.
+- Nach erfolgreicher Authentifizierung aktualisiert sich der Status-Bereich automatisch ohne Reload.
+- Nutzer:innen erhalten einen Abschluss-Hinweis mit Links zu Watchlist, Künstlerbibliothek und Backfill-Aufträgen.
+Risiko/Impact: Mittel; Fehler im OAuth-Flow könnten den Zugriff auf PRO-Funktionen blockieren.
+Dependencies: Harmonys OAuth-Endpunkt und Redirect-Konfiguration.
+Verweise: TASK TBD
+Subtasks:
+- OAuth-Start-Endpoint aus dem Frontend ansteuern und Redirect-Handling implementieren.
+- Status-Polling nach Auth-Callback integrieren und UI-Feedback ergänzen.
+- Tracking für erfolgreiche und gescheiterte OAuth-Versuche hinzufügen.

--- a/frontend/src/__tests__/SettingsPage.test.tsx
+++ b/frontend/src/__tests__/SettingsPage.test.tsx
@@ -3,10 +3,12 @@ import userEvent from '@testing-library/user-event';
 import SettingsPage from '../pages/SettingsPage';
 import { renderWithProviders } from '../test-utils';
 import { getSettings, updateSettings, testServiceConnection } from '../api/services/system';
+import { getSpotifyStatus } from '../api/services/spotify';
 
 type GetSettingsMock = jest.MockedFunction<typeof getSettings>;
 type UpdateSettingsMock = jest.MockedFunction<typeof updateSettings>;
 type TestServiceConnectionMock = jest.MockedFunction<typeof testServiceConnection>;
+type GetSpotifyStatusMock = jest.MockedFunction<typeof getSpotifyStatus>;
 
 jest.mock('../api/services/system', () => ({
   ...jest.requireActual('../api/services/system'),
@@ -15,9 +17,15 @@ jest.mock('../api/services/system', () => ({
   testServiceConnection: jest.fn()
 }));
 
+jest.mock('../api/services/spotify', () => ({
+  ...jest.requireActual('../api/services/spotify'),
+  getSpotifyStatus: jest.fn()
+}));
+
 const mockedGetSettings = getSettings as GetSettingsMock;
 const mockedUpdateSettings = updateSettings as UpdateSettingsMock;
 const mockedTestServiceConnection = testServiceConnection as TestServiceConnectionMock;
+const mockedGetSpotifyStatus = getSpotifyStatus as GetSpotifyStatusMock;
 
 const toastMock = jest.fn();
 
@@ -32,6 +40,12 @@ describe('SettingsPage', () => {
       }
     });
     mockedUpdateSettings.mockResolvedValue();
+    mockedGetSpotifyStatus.mockResolvedValue({
+      status: 'unconfigured',
+      free_available: true,
+      pro_available: false,
+      authenticated: false
+    });
   });
 
   it('lädt und speichert Einstellungen', async () => {
@@ -51,7 +65,7 @@ describe('SettingsPage', () => {
         { key: 'SPOTIFY_CLIENT_ID', value: 'updated-id' }
       ])
     );
-    expect(toastMock).toHaveBeenCalledWith(expect.objectContaining({ title: '✅ Einstellungen gespeichert' }));
+    expect(toastMock).toHaveBeenCalledWith(expect.objectContaining({ title: 'Spotify settings saved' }));
   });
 
   it('prüft Dienst-Verbindung und zeigt Ergebnis an', async () => {

--- a/frontend/src/components/SpotifyFreeImport.tsx
+++ b/frontend/src/components/SpotifyFreeImport.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, useMemo, useRef, useState } from 'react';
+import { ChangeEvent, useRef, useState } from 'react';
 import { Loader2, Upload } from 'lucide-react';
 
 import {
@@ -26,10 +26,6 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '.
 import { Textarea } from './ui/textarea';
 import { useToast } from '../hooks/useToast';
 
-interface SpotifyFreeImportProps {
-  proAvailable: boolean;
-}
-
 const normaliseQuery = (track: NormalizedTrack): string => {
   const segments = [track.title.trim(), track.artist.trim()];
   if (track.album) {
@@ -41,7 +37,7 @@ const normaliseQuery = (track: NormalizedTrack): string => {
   return segments.filter(Boolean).join(' ');
 };
 
-const SpotifyFreeImport = ({ proAvailable }: SpotifyFreeImportProps) => {
+const SpotifyFreeImport = () => {
   const { toast } = useToast();
   const [input, setInput] = useState('');
   const [fileName, setFileName] = useState<string | null>(null);
@@ -53,12 +49,8 @@ const SpotifyFreeImport = ({ proAvailable }: SpotifyFreeImportProps) => {
 
   const hasItems = items.length > 0;
 
-  const helperText = useMemo(() => {
-    if (!proAvailable) {
-      return 'Importiere Spotify-Listen ohne OAuth: Eine Referenz pro Zeile ("Artist - Title | Album | Year") oder Spotify-Track-Link.';
-    }
-    return 'Auch mit aktiven Spotify-Credentials kannst du Listen ohne API-Zugriff vorbereiten. Die Jobs nutzen Soulseek direkt.';
-  }, [proAvailable]);
+  const helperText =
+    'Importiere Spotify-Listen ohne OAuth: Eine Referenz pro Zeile ("Artist - Title | Album | Year") oder Spotify-Track-Link.';
 
   const handleUploadChange = async (event: ChangeEvent<HTMLInputElement>) => {
     if (!event.target.files || event.target.files.length === 0) {

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { Loader2, ShieldAlert } from 'lucide-react';
 import {
   Button,
@@ -80,6 +80,19 @@ const SettingsPage = () => {
     plex: false,
     soulseek: false
   });
+
+  const credentialHint = useMemo(() => {
+    if (!spotifyStatus) {
+      return null;
+    }
+    if (!spotifyStatus.pro_available) {
+      return 'Spotify-Credentials fehlen oder sind unvollständig. Hinterlege Client-ID, Client-Secret und Redirect-URI, um die PRO-Anbindung freizuschalten.';
+    }
+    if (!spotifyStatus.authenticated) {
+      return 'Credentials erkannt – Authentifiziere dich im Backend, um PRO-Funktionen zu aktivieren.';
+    }
+    return 'Spotify PRO ist vollständig verbunden und einsatzbereit.';
+  }, [spotifyStatus]);
 
   useEffect(() => {
     const fetchStatus = async () => {
@@ -187,11 +200,21 @@ const SettingsPage = () => {
                       Verbindungsstatus: {spotifyStatus.status === 'connected' ? 'Verbunden' : spotifyStatus.status === 'unauthenticated' ? 'Nicht authentifiziert' : 'Nicht konfiguriert'}
                     </p>
                     <p className="text-xs text-muted-foreground">
-                      FREE-Import ist immer verfügbar. PRO-Funktionen benötigen gültige Spotify-Credentials.
+                      {spotifyStatus.free_available
+                        ? 'FREE-Import steht bereit und nutzt Soulseek für Downloads.'
+                        : 'FREE-Import ist derzeit nicht verfügbar. Prüfe Worker-Status und Soulseek-Anbindung.'}
                     </p>
                   </div>
                 </div>
-                <div className="grid gap-3 sm:grid-cols-2">
+                <div className="grid gap-3 sm:grid-cols-3">
+                  <div className="rounded-md border border-border p-3 text-sm">
+                    <p className="font-medium text-foreground">FREE verfügbar</p>
+                    <p className="text-muted-foreground">
+                      {spotifyStatus.free_available
+                        ? 'Ja – Worker aktiv und Soulseek erreichbar.'
+                        : 'Nein – bitte Worker-Status und Soulseek prüfen.'}
+                    </p>
+                  </div>
                   <div className="rounded-md border border-border p-3 text-sm">
                     <p className="font-medium text-foreground">PRO verfügbar</p>
                     <p className="text-muted-foreground">
@@ -205,11 +228,16 @@ const SettingsPage = () => {
                     </p>
                   </div>
                 </div>
-                {!spotifyStatus.pro_available && (
-                  <p className="text-sm text-amber-600 dark:text-amber-400">
-                    Hinterlege Client-ID, Client-Secret und Redirect-URI, um PRO-Funktionen freizuschalten.
+                {credentialHint ? (
+                  <p className={`text-sm ${spotifyStatus.pro_available && spotifyStatus.authenticated ? 'text-emerald-600 dark:text-emerald-400' : 'text-amber-600 dark:text-amber-400'}`}>
+                    {credentialHint}
                   </p>
-                )}
+                ) : null}
+                {!spotifyStatus.free_available ? (
+                  <p className="text-sm text-amber-600 dark:text-amber-400">
+                    Der FREE-Import ist deaktiviert. Prüfe die Soulseek-Konfiguration und die entsprechenden Worker.
+                  </p>
+                ) : null}
               </div>
             ) : (
               <p className="text-sm text-muted-foreground">Statusinformationen sind derzeit nicht verfügbar.</p>

--- a/frontend/src/pages/SpotifyPage.tsx
+++ b/frontend/src/pages/SpotifyPage.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { Loader2, ShieldAlert } from 'lucide-react';
 
 import SpotifyFreeImport from '../components/SpotifyFreeImport';
@@ -7,15 +8,18 @@ import type { SpotifyStatusResponse } from '../api/types';
 import { ApiError } from '../api/client';
 import { useToast } from '../hooks/useToast';
 import {
+  Button,
   Card,
   CardContent,
   CardDescription,
+  CardFooter,
   CardHeader,
   CardTitle
 } from '../components/ui/shadcn';
 
 const SpotifyPage = () => {
   const { toast } = useToast();
+  const navigate = useNavigate();
   const [status, setStatus] = useState<SpotifyStatusResponse | null>(null);
   const [isLoading, setIsLoading] = useState(true);
 
@@ -33,6 +37,24 @@ const SpotifyPage = () => {
     };
     fetchStatus();
   }, [toast]);
+
+  const proDisabled = !status?.pro_available;
+  const proActionHint = useMemo(() => {
+    if (!status) {
+      return null;
+    }
+    if (!status.pro_available) {
+      return 'Spotify-Credentials fehlen oder sind ungültig. Hinterlege Client-ID, Client-Secret und Redirect-URI in den Einstellungen, um PRO-Funktionen zu aktivieren.';
+    }
+    if (!status.authenticated) {
+      return 'Die Spotify-Credentials sind vorhanden. Starte einen OAuth-Login im Harmony-Backend, um PRO-Funktionen zu nutzen.';
+    }
+    return null;
+  }, [status]);
+
+  const handleNavigate = (path: string) => {
+    navigate(path);
+  };
 
   return (
     <div className="space-y-6">
@@ -58,26 +80,42 @@ const SpotifyPage = () => {
                     Verbindungsstatus: {status.status === 'connected' ? 'Verbunden' : status.status === 'unauthenticated' ? 'Nicht authentifiziert' : 'Nicht konfiguriert'}
                   </p>
                   <p className="text-xs text-slate-500 dark:text-slate-400">
-                    FREE-Import ist immer verfügbar. PRO-Funktionen erfordern gültige Spotify-Credentials.
+                    {status.free_available
+                      ? 'FREE-Import steht bereit und nutzt Soulseek für die Downloads.'
+                      : 'FREE-Import ist derzeit nicht verfügbar. Prüfe Worker-Status und Soulseek-Verbindung.'}
                   </p>
                 </div>
               </div>
-              <div className="grid gap-3 sm:grid-cols-2">
+              <div className="grid gap-3 sm:grid-cols-3">
+                <div className="rounded-md border border-slate-200 p-3 text-sm dark:border-slate-800">
+                  <p className="font-medium text-slate-900 dark:text-slate-100">FREE verfügbar</p>
+                  <p className="text-slate-600 dark:text-slate-400">
+                    {status.free_available
+                      ? 'Ja – Worker aktiv und Soulseek erreichbar.'
+                      : 'Nein – bitte Worker-Status und Soulseek prüfen.'}
+                  </p>
+                </div>
                 <div className="rounded-md border border-slate-200 p-3 text-sm dark:border-slate-800">
                   <p className="font-medium text-slate-900 dark:text-slate-100">PRO verfügbar</p>
-                  <p className="text-slate-600 dark:text-slate-400">{status.pro_available ? 'Ja – OAuth-Credentials gesetzt.' : 'Nein – Zugangsdaten fehlen.'}</p>
+                  <p className="text-slate-600 dark:text-slate-400">
+                    {status.pro_available ? 'Ja – OAuth-Credentials gesetzt.' : 'Nein – Zugangsdaten fehlen.'}
+                  </p>
                 </div>
                 <div className="rounded-md border border-slate-200 p-3 text-sm dark:border-slate-800">
                   <p className="font-medium text-slate-900 dark:text-slate-100">Authentifiziert</p>
-                  <p className="text-slate-600 dark:text-slate-400">{status.authenticated ? 'Aktive Session vorhanden.' : 'Noch kein Login durchgeführt.'}</p>
+                  <p className="text-slate-600 dark:text-slate-400">
+                    {status.authenticated ? 'Aktive Session vorhanden.' : 'Noch kein Login durchgeführt.'}
+                  </p>
                 </div>
               </div>
-              {!status.pro_available && (
+              {proActionHint ? (
+                <p className="text-sm text-amber-600 dark:text-amber-400">{proActionHint}</p>
+              ) : null}
+              {!status.free_available ? (
                 <p className="text-sm text-amber-600 dark:text-amber-400">
-                  Spotify-Credentials fehlen oder sind ungültig. Hinterlegen Sie Client-ID, Client-Secret und Redirect-URI in den Einstellungen,
-                  um PRO-Funktionen zu aktivieren.
+                  Der FREE-Import ist deaktiviert. Prüfe die Soulseek-Konfiguration und starte den Import-Worker neu.
                 </p>
-              )}
+              ) : null}
             </div>
           ) : (
             <p className="text-sm text-slate-600 dark:text-slate-400">Statusinformationen sind derzeit nicht verfügbar.</p>
@@ -85,7 +123,43 @@ const SpotifyPage = () => {
         </CardContent>
       </Card>
 
-      <SpotifyFreeImport proAvailable={status?.pro_available ?? false} />
+      <Card className="shadow-sm">
+        <CardHeader>
+          <CardTitle>Spotify PRO Aktionen</CardTitle>
+          <CardDescription>
+            Nutze die integrierten Spotify-APIs für automatische Bibliotheks-Synchronisation und Kurations-Workflows.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <p className="text-sm text-slate-600 dark:text-slate-300">
+            PRO-Funktionen greifen auf die Spotify-API zu. Ohne gültige Credentials bleiben die Aktionen deaktiviert.
+            Nach erfolgreicher Authentifizierung stehen Watchlist, Artist-Importe und Backfill-Aufträge bereit.
+          </p>
+          <div className="flex flex-wrap gap-2">
+            <Button type="button" onClick={() => handleNavigate('/library?tab=watchlist')} disabled={proDisabled}>
+              Watchlist öffnen
+            </Button>
+            <Button
+              type="button"
+              variant="secondary"
+              onClick={() => handleNavigate('/library?tab=artists')}
+              disabled={proDisabled}
+            >
+              Künstlerbibliothek
+            </Button>
+            <Button type="button" variant="outline" onClick={() => handleNavigate('/settings')}>
+              Einstellungen
+            </Button>
+          </div>
+        </CardContent>
+        {proActionHint ? (
+          <CardFooter>
+            <p className="text-xs text-amber-600 dark:text-amber-400">{proActionHint}</p>
+          </CardFooter>
+        ) : null}
+      </Card>
+
+      <SpotifyFreeImport />
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- display Spotify FREE and PRO capabilities together on the overview page with contextual availability hints and disabled PRO actions when credentials are missing
- surface detailed credential guidance on the Spotify settings card and streamline the FREE import helper copy
- update tests and ToDo backlog for the new status-driven flow

## Testing
- npm test -- --runTestsByPath src/__tests__/SettingsPage.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68e1456866ec83219147b369c666c186