### PR TITLE
TASK_ID TBD: align album track counts in matching confidence

### DIFF
--- a/ToDo.md
+++ b/ToDo.md
@@ -83,6 +83,28 @@ Subtasks:
 - Status-Polling nach Auth-Callback integrieren und UI-Feedback ergänzen.
 - Tracking für erfolgreiche und gescheiterte OAuth-Versuche hinzufügen.
 
+ID: TD-20251012-005
+Titel: Matching-Scoring mit Album-Trackzahlen validieren
+Status: todo
+Priorität: P2
+Scope: backend
+Owner: codex
+Created_at: 2025-10-12T17:00:00Z
+Updated_at: 2025-10-12T17:00:00Z
+Tags: matching, scoring, integrations
+Beschreibung: Die neuen Bonusroutinen für Album-Trackzahlen sind bislang nur durch Unit-Tests abgesichert. Um Regressionen zu vermeiden, sollen repräsentative Provider-Datensätze gesammelt und End-to-End-Matchingläufe mit unterschiedlichen Albumgrößen dokumentiert werden. Zusätzlich braucht es Monitoring-Kennzahlen, die Trackcount-Abweichungen und deren Einfluss auf Scores sichtbar machen. Erkenntnisse aus den Tests sollen in die Matching-Konfiguration einfließen und dokumentiert werden.
+Akzeptanzkriterien:
+- Beispielhafte Spotify- und Soulseek-Datensätze werden mit realistischen Trackcount-Verteilungen gepflegt und versioniert.
+- Automatisierte Integrationstests prüfen Bonus und Penalty bei Trackcount-Abgleich in der Matching-Pipeline.
+- Dashboards oder Logs erfassen Trackcount-Deltas inklusive Score-Verlauf zur Laufzeit.
+Risiko/Impact: Mittel; falsche Kalibrierung kann Score-Vertrauen mindern oder Downloads blockieren.
+Dependencies: Matching-Konfigurations- und Telemetrie-Pipeline.
+Verweise: TASK TBD
+Subtasks:
+- Datensätze recherchieren und als Fixtures aufbereiten.
+- Integrationstests für Matching-Flows ergänzen.
+- Monitoring-Hooks samt Dokumentation aktualisieren.
+
 ID: TD-20251012-004
 Titel: Sidebar-Kollapszustand persistieren
 Status: todo

--- a/tests/core/test_matching_engine_album_tracks.py
+++ b/tests/core/test_matching_engine_album_tracks.py
@@ -1,0 +1,49 @@
+import pytest
+
+from app.core.matching_engine import calculate_slskd_match_confidence
+from app.core.types import ensure_track_dto
+
+
+def test_ensure_album_dto_falls_back_to_metadata_track_counts() -> None:
+    spotify_track = {
+        "name": "Aligned Song",
+        "artists": [{"name": "Sample Artist"}],
+        "album": {
+            "name": "Aligned Album",
+            "metadata": {"track_count": 11},
+        },
+    }
+
+    dto = ensure_track_dto(spotify_track, default_source="spotify")
+
+    assert dto.album is not None
+    assert dto.album.total_tracks == 11
+
+
+def test_match_confidence_rewards_album_track_alignment() -> None:
+    spotify_track = {
+        "name": "Aligned Song",
+        "artists": [{"name": "Sample Artist"}],
+        "album": {
+            "name": "Aligned Album",
+            "metadata": {"track_count": 10},
+        },
+    }
+    base_candidate = {
+        "name": "Aligned Song",
+        "artist": "Sample Artist",
+        "metadata": {"bitrate": 128},
+    }
+
+    aligned_entry = {**base_candidate, "album": {"name": "Aligned Album", "total_tracks": 10}}
+    off_by_one_entry = {**base_candidate, "album": {"name": "Aligned Album", "total_tracks": 9}}
+    diverging_entry = {**base_candidate, "album": {"name": "Aligned Album", "total_tracks": 3}}
+
+    aligned_confidence = calculate_slskd_match_confidence(spotify_track, aligned_entry)
+    off_by_one_confidence = calculate_slskd_match_confidence(spotify_track, off_by_one_entry)
+    diverging_confidence = calculate_slskd_match_confidence(spotify_track, diverging_entry)
+
+    assert aligned_confidence >= off_by_one_confidence
+    assert aligned_confidence - diverging_confidence >= 0.1
+    assert off_by_one_confidence - diverging_confidence >= 0.05
+    assert diverging_confidence < 1.0


### PR DESCRIPTION
## Summary
- carry Spotify and Soulseek album track count hints through the normalizers and DTO coercion
- adjust Soulseek matching confidence to reward aligned album sizes and penalise large deltas
- cover the new behaviour with unit tests and document follow-up telemetry work in ToDo.md

## Testing
- `pytest tests/core/test_matching_engine_album_tracks.py`

## ToDo-Update
- Added: TD-20251012-005

------
https://chatgpt.com/codex/tasks/task_e_68e14e93389c832184a564d3b5c04c59