### PR TITLE
fix: remove spotify free upload flow

### DIFF
--- a/frontend/src/api/services/spotify.ts
+++ b/frontend/src/api/services/spotify.ts
@@ -13,8 +13,6 @@ import type {
   SpotifyFreeEnqueueResponse,
   SpotifyFreeParsePayload,
   SpotifyFreeParseResponse,
-  SpotifyFreeUploadPayload,
-  SpotifyFreeUploadResponse,
   SpotifyImage,
   SpotifyStatusResponse,
   SpotifyRawAlbum,
@@ -196,11 +194,6 @@ export const enqueueSpotifyFreeTracks = async (
 ): Promise<SpotifyFreeEnqueueResponse> =>
   request<SpotifyFreeEnqueueResponse>({ method: 'POST', url: apiUrl('/spotify/free/enqueue'), data: payload });
 
-export const uploadSpotifyFreeFile = async (
-  payload: SpotifyFreeUploadPayload
-): Promise<SpotifyFreeUploadResponse> =>
-  request<SpotifyFreeUploadResponse>({ method: 'POST', url: apiUrl('/spotify/free/upload'), data: payload });
-
 export type {
   ArtistPreferenceEntry,
   NormalizedTrack,
@@ -212,8 +205,6 @@ export type {
   SpotifyFreeEnqueueResponse,
   SpotifyFreeParsePayload,
   SpotifyFreeParseResponse,
-  SpotifyFreeUploadPayload,
-  SpotifyFreeUploadResponse,
   SpotifySearchResults,
   SpotifyStatusResponse,
   SpotifyTrackSearchResult

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -144,17 +144,8 @@ export interface SpotifyFreeParsePayload {
   file_token?: string | null;
 }
 
-export interface SpotifyFreeUploadPayload {
-  filename: string;
-  content: string;
-}
-
 export interface SpotifyFreeParseResponse {
   items: NormalizedTrack[];
-}
-
-export interface SpotifyFreeUploadResponse {
-  file_token: string;
 }
 
 export interface SpotifyFreeEnqueuePayload {


### PR DESCRIPTION
## Summary
- remove the Spotify FREE upload flow from the import component and adjust the right column to the link workflow copy
- delete the unused upload service helper and associated types

## Testing
- npm --prefix frontend run lint

## ToDo-Update
- Keine Änderungen erforderlich; bestehende Sortierung geprüft.

------
https://chatgpt.com/codex/tasks/task_e_68e15481f87083219f6e6d779aa4aaaa