### PR TITLE
test: add Soulseek dashboard coverage

### DIFF
--- a/ToDo.md
+++ b/ToDo.md
@@ -41,14 +41,14 @@ Subtasks:
 
 ID: TD-20251012-001
 Titel: Soulseek- und Matching-Ansichten mit Live-Daten versorgen
-Status: todo
+Status: in-progress
 Priorität: P2
 Scope: frontend
 Owner: codex
 Created_at: 2025-10-12T09:00:00Z
-Updated_at: 2025-10-12T09:00:00Z
+Updated_at: 2025-10-12T19:45:00Z
 Tags: navigation, integrations, soulseek, matching
-Beschreibung: Die neuen Navigationspunkte für Soulseek und Matching zeigen aktuell nur Platzhaltertexte. Für ein vollständiges Nutzererlebnis müssen die Komponenten API-Aufrufe der Downloader- und Matching-Services integrieren. Zusätzlich soll die Navigation den aktuellen Integrationsstatus widerspiegeln und Rückmeldungen bei Fehlern geben. Dokumentation und Monitoring-Hooks müssen mit den neuen Ansichten abgeglichen werden.
+Beschreibung: Die neuen Navigationspunkte für Soulseek und Matching zeigen aktuell nur Platzhaltertexte. Für ein vollständiges Nutzererlebnis müssen die Komponenten API-Aufrufe der Downloader- und Matching-Services integrieren. Zusätzlich soll die Navigation den aktuellen Integrationsstatus widerspiegeln und Rückmeldungen bei Fehlern geben. Dokumentation und Monitoring-Hooks müssen mit den neuen Ansichten abgeglichen werden. Die Soulseek-Ansicht ist inklusive Dashboard-Logik, Tests und Dokumentation umgesetzt; die Matching-Ansicht steht weiterhin aus.
 Akzeptanzkriterien:
 - SoulseekPage lädt Status- und Konfigurationsdaten aus dem Backend und visualisiert aktive Freigaben.
 - MatchingPage zeigt laufende und ausstehende Zuordnungen inklusive Fehlerzuständen an.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -58,6 +58,19 @@ FastAPI-Router kapseln die öffentliche API und werden in `app/main.py` registri
 
 Hinweis: Die verbleibenden Module unter `app/routers/` dienen nur noch als Kompatibilitäts-Shims und re-exportieren die eigentlichen Router aus `app/api/…`.
 
+#### Soulseek UI Dashboard
+
+- Die Frontend-Ansicht **„Soulseek“** bündelt drei Kernbereiche für Operator:innen:
+  - **Verbindung & Integrationen:** nutzt `/soulseek/status` und `/integrations`, um den Connectivity-Status sowie Provider-Health inklusive Detailhinweisen (z. B. fehlende Credentials) anzuzeigen.
+  - **Konfigurationsübersicht:** lädt die relevanten `SLSKD_*`-Einstellungen über `/settings`, maskiert Secrets und markiert fehlende Pflichtwerte (Basis-URL/API-Key) deutlich.
+  - **Aktive Uploads:** ruft `/soulseek/uploads` bzw. `/soulseek/uploads/all` ab, stellt Fortschritt, Benutzer:innen, Größe und Durchsatz als Tabelle dar und signalisiert Fehlerzustände mit Retry-Möglichkeit.
+- **Interpretation der Hinweise:**
+  - Das Badge **„Verbunden“** bestätigt, dass der Backend-Proxy (`slskd`) erreichbar ist. **„Getrennt“** bedeutet, dass Downloads/Uploads blockiert sind und Worker in Folge mit Retries starten.
+  - Der Abschnitt **„Provider-Gesundheit“** spiegelt die `/integrations`-Bewertung wider. `degraded` deutet auf optionale, aber relevante Warnungen hin (z. B. fehlende Bandbreitenlimits), `down` auf harte Ausfälle oder fehlende Credentials. Detailfelder listen die Rohwerte aus dem Health-Endpunkt.
+  - In der Konfiguration kennzeichnet ein rotes Badge fehlende Pflichtwerte. Maskierte Secrets erscheinen als `••••••`; Operator:innen können so prüfen, ob Werte grundsätzlich gesetzt sind, ohne sie offenzulegen.
+  - Die Upload-Tabelle zeigt jeden aktiven Share mit Status, Fortschritt, Transfergröße und Geschwindigkeit. Bei leerem Ergebnis informiert der Hinweis „Aktuell sind keine Uploads aktiv“, Fehlerzustände liefern einen Retry-Button, der erneut `/soulseek/uploads` aufruft.
+- Die Seite dient als Operations-Dashboard für den Soulseek-Daemon: Warnhinweise bei Ausfällen oder fehlender Konfiguration helfen, bevor Sync-Worker oder Upload-Freigaben ins Stocken geraten.
+
 ### Hintergrund-Worker
 
 Der Lifespan startet zuerst den Orchestrator (Scheduler, Dispatcher, WatchlistTimer), der Queue-Jobs priorisiert, Heartbeats pflegt und Watchlist-Ticks kontrolliert. Anschließend werden – sofern `WORKERS_ENABLED` aktiv ist – die eigentlichen Worker registriert und vom Dispatcher anhand ihrer Job-Typen aufgerufen.

--- a/frontend/jest.setup.ts
+++ b/frontend/jest.setup.ts
@@ -1,5 +1,34 @@
 import '@testing-library/jest-dom';
 
+jest.mock('@radix-ui/react-tooltip', () => {
+  const React = require('react');
+  const renderChildren = (children?: React.ReactNode) =>
+    React.createElement(React.Fragment, null, children);
+  const MockProvider = ({ children }: { children?: React.ReactNode }) => renderChildren(children);
+  const MockRoot = ({ children }: { children?: React.ReactNode }) => renderChildren(children);
+  const MockPortal = ({ children }: { children?: React.ReactNode }) => renderChildren(children);
+  const MockTrigger = React.forwardRef<HTMLElement, { children?: React.ReactNode }>((props, ref) => {
+    const { children, ...rest } = props;
+    if (React.isValidElement(children)) {
+      return React.cloneElement(children, { ref, ...rest });
+    }
+    return React.createElement('span', { ref, ...rest }, children);
+  });
+  const MockContent = React.forwardRef<HTMLDivElement, { children?: React.ReactNode }>((props, ref) => {
+    const { children, ...rest } = props;
+    return React.createElement('div', { ref, ...rest }, children);
+  });
+
+  return {
+    __esModule: true,
+    Provider: MockProvider,
+    Root: MockRoot,
+    Trigger: MockTrigger,
+    Portal: MockPortal,
+    Content: MockContent
+  };
+});
+
 const globalProcess = (globalThis as { process?: { env?: Record<string, string | undefined> } }).process;
 if (globalProcess) {
   globalProcess.env = {

--- a/frontend/src/__tests__/AppRoutes.test.tsx
+++ b/frontend/src/__tests__/AppRoutes.test.tsx
@@ -1,25 +1,44 @@
-import { render, screen } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { screen } from '@testing-library/react';
 
 import AppRoutes from '../routes';
+import { renderWithProviders } from '../test-utils';
+import {
+  getIntegrationsReport,
+  getSoulseekConfiguration,
+  getSoulseekStatus,
+  getSoulseekUploads
+} from '../api/services/soulseek';
+
+jest.mock('../api/services/soulseek', () => ({
+  getSoulseekStatus: jest.fn(),
+  getSoulseekUploads: jest.fn(),
+  getIntegrationsReport: jest.fn(),
+  getSoulseekConfiguration: jest.fn()
+}));
+
+const mockedGetSoulseekStatus = getSoulseekStatus as jest.MockedFunction<typeof getSoulseekStatus>;
+const mockedGetSoulseekUploads = getSoulseekUploads as jest.MockedFunction<typeof getSoulseekUploads>;
+const mockedGetIntegrationsReport = getIntegrationsReport as jest.MockedFunction<typeof getIntegrationsReport>;
+const mockedGetSoulseekConfiguration = getSoulseekConfiguration as jest.MockedFunction<
+  typeof getSoulseekConfiguration
+>;
 
 describe('AppRoutes', () => {
-  const renderWithRoute = (route: string) =>
-    render(
-      <MemoryRouter initialEntries={[route]}>
-        <AppRoutes />
-      </MemoryRouter>
-    );
+  const renderWithRoute = (route: string) => renderWithProviders(<AppRoutes />, { route });
 
-  it('renders the Soulseek page without redirecting', () => {
+  beforeEach(() => {
+    mockedGetSoulseekStatus.mockResolvedValue({ status: 'connected' });
+    mockedGetSoulseekUploads.mockResolvedValue([]);
+    mockedGetIntegrationsReport.mockResolvedValue({ overall: 'ok', providers: [] });
+    mockedGetSoulseekConfiguration.mockResolvedValue([]);
+  });
+
+  it('renders the Soulseek page without redirecting', async () => {
     renderWithRoute('/soulseek');
 
-    expect(
-      screen.getByRole('heading', { name: /Soulseek/i, level: 1 })
-    ).toBeInTheDocument();
-    expect(
-      screen.getByText(/Soulseek-Community, um neue Musikquellen zu entdecken/i)
-    ).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /Soulseek/i, level: 1 })).toBeInTheDocument();
+    expect(screen.getByText(/Verbindung wird geprüft/i)).toBeInTheDocument();
+    expect(await screen.findByText(/Aktive Uploads/i)).toBeInTheDocument();
   });
 
   it('renders the Matching page without redirecting', () => {

--- a/frontend/src/__tests__/SoulseekPage.test.tsx
+++ b/frontend/src/__tests__/SoulseekPage.test.tsx
@@ -1,0 +1,119 @@
+import { screen } from '@testing-library/react';
+
+import SoulseekPage from '../pages/SoulseekPage';
+import { renderWithProviders } from '../test-utils';
+import { useQuery } from '../lib/query';
+import type { IntegrationsData } from '../api/services/soulseek';
+import type { SoulseekConfigurationEntry } from '../api/services/soulseek';
+import type { SoulseekStatusResponse } from '../api/types';
+
+jest.mock('../lib/query', () => {
+  const actual = jest.requireActual('../lib/query');
+  return {
+    ...actual,
+    useQuery: jest.fn()
+  };
+});
+
+const mockedUseQuery = useQuery as jest.MockedFunction<typeof useQuery>;
+
+type QueryResult<T> = {
+  data: T | undefined;
+  error: unknown;
+  isLoading: boolean;
+  isError: boolean;
+  refetch: jest.Mock;
+};
+
+const createQueryResult = <T,>(overrides: Partial<QueryResult<T>> = {}): QueryResult<T> => ({
+  data: undefined,
+  error: undefined,
+  isLoading: false,
+  isError: false,
+  refetch: jest.fn(),
+  ...overrides
+});
+
+describe('SoulseekPage', () => {
+  beforeEach(() => {
+    mockedUseQuery.mockReset();
+  });
+
+  it('zeigt Status, Konfiguration und Uploads an', () => {
+    const statusData: SoulseekStatusResponse = { status: 'connected' };
+    const integrationData: IntegrationsData = {
+      overall: 'degraded',
+      providers: [
+        {
+          name: 'soulseek',
+          status: 'down',
+          details: { reason: 'missing_credentials' }
+        }
+      ]
+    };
+    const configurationData: SoulseekConfigurationEntry[] = [
+      {
+        key: 'SLSKD_URL',
+        label: 'Basis-URL',
+        value: 'https://slskd.example',
+        displayValue: 'https://slskd.example',
+        present: true,
+        masked: false
+      }
+    ];
+
+    mockedUseQuery.mockImplementation(({ queryKey }) => {
+      const [, scope] = queryKey as [string, string];
+      switch (scope) {
+        case 'status':
+          return createQueryResult({ data: statusData });
+        case 'providers':
+          return createQueryResult({ data: integrationData });
+        case 'configuration':
+          return createQueryResult({ data: configurationData });
+        case 'uploads':
+          return createQueryResult({ data: [] });
+        default:
+          return createQueryResult();
+      }
+    });
+
+    renderWithProviders(<SoulseekPage />, { route: '/soulseek' });
+
+    expect(screen.getByRole('heading', { name: /Soulseek/i, level: 1 })).toBeInTheDocument();
+    expect(screen.getByText('Basis-URL')).toBeInTheDocument();
+    expect(screen.getByLabelText(/Status: Verbunden/i)).toBeInTheDocument();
+    expect(screen.getByText(/Verbunden/)).toBeInTheDocument();
+    expect(screen.getByText(/missing_credentials/)).toBeInTheDocument();
+    expect(screen.getByText(/Aktuell sind keine Uploads aktiv/)).toBeInTheDocument();
+  });
+
+  it('zeigt einen Fehlerhinweis, wenn Uploads nicht geladen werden können', () => {
+    mockedUseQuery.mockImplementation(({ queryKey }) => {
+      const [, scope] = queryKey as [string, string];
+      if (scope === 'uploads') {
+        return createQueryResult({ isError: true, error: new Error('boom') });
+      }
+      return createQueryResult();
+    });
+
+    renderWithProviders(<SoulseekPage />, { route: '/soulseek' });
+
+    expect(screen.getByText('Uploads konnten nicht geladen werden.')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Erneut versuchen' })).toBeInTheDocument();
+  });
+
+  it('zeigt Ladezustände an, solange Daten angefordert werden', () => {
+    mockedUseQuery.mockImplementation(({ queryKey }) => {
+      const [, scope] = queryKey as [string, string];
+      if (scope === 'uploads') {
+        return createQueryResult({ isLoading: true });
+      }
+      return createQueryResult();
+    });
+
+    renderWithProviders(<SoulseekPage />, { route: '/soulseek' });
+
+    expect(screen.getByText(/Uploads werden geladen/)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/api/services/soulseek.ts
+++ b/frontend/src/api/services/soulseek.ts
@@ -1,0 +1,193 @@
+import { apiUrl, request } from '../client';
+import { getSettings } from './system';
+import type {
+  IntegrationsData,
+  IntegrationsResponse,
+  ProviderInfo,
+  SettingsResponse,
+  SoulseekStatusResponse,
+  SoulseekUploadEntry,
+  SoulseekUploadsResponse
+} from '../types';
+
+const SECRET_KEY_PATTERN = /(SECRET|TOKEN|KEY|PASSWORD)/iu;
+const KNOWN_SOULSEEK_KEYS = ['SLSKD_URL', 'SLSKD_API_KEY'];
+
+const toStringOrNull = (value: unknown): string | null => {
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  }
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return String(value);
+  }
+  return null;
+};
+
+const toNumberOrNull = (value: unknown): number | null => {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === 'string') {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+};
+
+const ensureArray = (value: unknown): unknown[] => {
+  if (Array.isArray(value)) {
+    return value;
+  }
+  if (value === null || value === undefined) {
+    return [];
+  }
+  return [value];
+};
+
+const normalizeUpload = (entry: unknown): NormalizedSoulseekUpload | null => {
+  if (!entry || typeof entry !== 'object') {
+    return null;
+  }
+
+  const record = entry as SoulseekUploadEntry;
+  const id = toStringOrNull(record.id);
+  const filename = toStringOrNull(record.filename);
+  const username = toStringOrNull(record.username ?? (record as { user?: unknown }).user);
+  const state = toStringOrNull(record.state) ?? 'unknown';
+  const progress = toNumberOrNull(record.progress);
+  const size = toNumberOrNull(record.size ?? (record as { filesize?: unknown }).filesize);
+  const speed = toNumberOrNull(record.speed ?? (record as { speed_bps?: unknown }).speed_bps);
+  const queuedAt = toStringOrNull(record.queued_at ?? (record as { queuedAt?: unknown }).queuedAt);
+  const startedAt = toStringOrNull(record.started_at ?? (record as { startedAt?: unknown }).startedAt);
+  const completedAt = toStringOrNull(
+    record.completed_at ?? (record as { completedAt?: unknown }).completedAt
+  );
+
+  return {
+    id,
+    filename,
+    username,
+    state,
+    progress,
+    size,
+    speed,
+    queuedAt,
+    startedAt,
+    completedAt,
+    raw: record
+  };
+};
+
+const normalizeProvider = (entry: unknown): ProviderInfo | null => {
+  if (!entry || typeof entry !== 'object') {
+    return null;
+  }
+  const record = entry as Record<string, unknown>;
+  const name = toStringOrNull(record.name);
+  if (!name) {
+    return null;
+  }
+  const status = toStringOrNull(record.status) ?? 'unknown';
+  const details =
+    record.details && typeof record.details === 'object' && !Array.isArray(record.details)
+      ? (record.details as Record<string, unknown>)
+      : null;
+  return { name, status, details };
+};
+
+const prettifySettingKey = (key: string): string => {
+  const labelMap: Record<string, string> = {
+    SLSKD_URL: 'Basis-URL',
+    SLSKD_API_KEY: 'API-Schlüssel'
+  };
+  if (labelMap[key]) {
+    return labelMap[key];
+  }
+  const normalized = key.replace(/^SLSKD_/u, '').replace(/_/gu, ' ');
+  return normalized
+    .split(' ')
+    .filter(Boolean)
+    .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1).toLowerCase())
+    .join(' ');
+};
+
+export interface NormalizedSoulseekUpload {
+  id: string | null;
+  filename: string | null;
+  username: string | null;
+  state: string;
+  progress: number | null;
+  size: number | null;
+  speed: number | null;
+  queuedAt: string | null;
+  startedAt: string | null;
+  completedAt: string | null;
+  raw: SoulseekUploadEntry;
+}
+
+export interface SoulseekConfigurationEntry {
+  key: string;
+  label: string;
+  value: string | null;
+  displayValue: string | null;
+  present: boolean;
+  masked: boolean;
+}
+
+export const getSoulseekStatus = async (): Promise<SoulseekStatusResponse> =>
+  request<SoulseekStatusResponse>({ method: 'GET', url: apiUrl('/soulseek/status') });
+
+export const getSoulseekUploads = async ({
+  includeAll = false
+}: { includeAll?: boolean } = {}): Promise<NormalizedSoulseekUpload[]> => {
+  const endpoint = includeAll ? '/soulseek/uploads/all' : '/soulseek/uploads';
+  const payload = await request<SoulseekUploadsResponse>({ method: 'GET', url: apiUrl(endpoint) });
+  const uploads = ensureArray(payload.uploads);
+  return uploads.map(normalizeUpload).filter((entry): entry is NormalizedSoulseekUpload => entry !== null);
+};
+
+export const getIntegrationsReport = async (): Promise<IntegrationsData> => {
+  const payload = await request<IntegrationsResponse>({ method: 'GET', url: apiUrl('/integrations') });
+  if (!payload.ok || !payload.data) {
+    throw new Error('Integrations response missing data');
+  }
+  const providers = ensureArray(payload.data.providers)
+    .map(normalizeProvider)
+    .filter((provider): provider is ProviderInfo => provider !== null);
+  return {
+    overall: toStringOrNull(payload.data.overall) ?? 'unknown',
+    providers
+  };
+};
+
+export const getSoulseekConfiguration = async (): Promise<SoulseekConfigurationEntry[]> => {
+  const settingsPayload = await getSettings();
+  const entries = normalizeSoulseekSettings(settingsPayload);
+  return entries.sort((a, b) => a.label.localeCompare(b.label, 'de'));
+};
+
+const normalizeSoulseekSettings = (payload: SettingsResponse): SoulseekConfigurationEntry[] => {
+  const settings = payload.settings ?? {};
+  const keys = new Set<string>(KNOWN_SOULSEEK_KEYS);
+  Object.keys(settings)
+    .filter((key) => key.startsWith('SLSKD_'))
+    .forEach((key) => keys.add(key));
+
+  return Array.from(keys).map((key) => {
+    const rawValue = settings[key];
+    const normalizedValue = toStringOrNull(rawValue);
+    const present = normalizedValue !== null;
+    const masked = present && SECRET_KEY_PATTERN.test(key);
+    return {
+      key,
+      label: prettifySettingKey(key),
+      value: normalizedValue,
+      displayValue: masked ? '••••••' : normalizedValue,
+      present,
+      masked
+    };
+  });
+};
+
+export type { IntegrationsData };

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -77,6 +77,47 @@ export interface ServiceHealthResponse {
 
 export type ServiceIdentifier = 'spotify' | 'plex' | 'soulseek';
 
+export type SoulseekConnectionStatus = 'connected' | 'disconnected' | (string & {});
+
+export interface SoulseekStatusResponse {
+  status: SoulseekConnectionStatus;
+}
+
+export interface SoulseekUploadEntry {
+  id?: string;
+  filename?: string;
+  username?: string | null;
+  state?: string;
+  progress?: number | null;
+  size?: number | null;
+  speed?: number | null;
+  queued_at?: string | null;
+  started_at?: string | null;
+  completed_at?: string | null;
+  [key: string]: unknown;
+}
+
+export interface SoulseekUploadsResponse {
+  uploads?: unknown;
+}
+
+export interface ProviderInfo {
+  name: string;
+  status: string;
+  details?: Record<string, unknown> | null;
+}
+
+export interface IntegrationsData {
+  overall: string;
+  providers: ProviderInfo[];
+}
+
+export interface IntegrationsResponse {
+  ok: boolean;
+  data?: IntegrationsData | null;
+  error?: Record<string, unknown> | null;
+}
+
 export interface ArtistPreferenceEntry {
   artist_id: string;
   release_id: string;

--- a/frontend/src/components/SoulseekUploadList.tsx
+++ b/frontend/src/components/SoulseekUploadList.tsx
@@ -1,0 +1,169 @@
+import StatusBadge from './StatusBadge';
+import { Progress } from './ui/progress';
+import { Button } from './ui/shadcn';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from './ui/table';
+import type { NormalizedSoulseekUpload } from '../api/services/soulseek';
+import { mapProgressToPercent } from '../lib/utils';
+
+const formatSize = (value: number | null): string => {
+  if (value === null || Number.isNaN(value)) {
+    return '–';
+  }
+  const thresholds = [
+    { limit: 1024 ** 3, suffix: 'GB' },
+    { limit: 1024 ** 2, suffix: 'MB' },
+    { limit: 1024, suffix: 'KB' }
+  ];
+  for (const { limit, suffix } of thresholds) {
+    if (value >= limit) {
+      return `${(value / limit).toFixed(1)} ${suffix}`;
+    }
+  }
+  if (value >= 0) {
+    return `${Math.round(value)} B`;
+  }
+  return '–';
+};
+
+const formatSpeed = (value: number | null): string => {
+  if (value === null || Number.isNaN(value)) {
+    return '–';
+  }
+  if (value >= 1024 ** 2) {
+    return `${(value / 1024 ** 2).toFixed(1)} MB/s`;
+  }
+  if (value >= 1024) {
+    return `${(value / 1024).toFixed(1)} KB/s`;
+  }
+  if (value >= 0) {
+    return `${Math.round(value)} B/s`;
+  }
+  return '–';
+};
+
+const formatStateLabel = (state: string): string => {
+  const normalized = state.toLowerCase();
+  const labels: Record<string, string> = {
+    uploading: 'Wird hochgeladen',
+    queued: 'Wartend',
+    completed: 'Abgeschlossen',
+    failed: 'Fehlgeschlagen',
+    cancelled: 'Abgebrochen',
+    paused: 'Pausiert'
+  };
+  return labels[normalized] ?? state.charAt(0).toUpperCase() + state.slice(1);
+};
+
+const formatTimestamp = (value: string | null): string | null => {
+  if (!value) {
+    return null;
+  }
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+  return date.toLocaleString();
+};
+
+export interface SoulseekUploadListProps {
+  uploads?: NormalizedSoulseekUpload[];
+  isLoading: boolean;
+  isError: boolean;
+  onRetry?: () => void;
+}
+
+const SoulseekUploadList = ({ uploads, isLoading, isError, onRetry }: SoulseekUploadListProps) => {
+  if (isLoading) {
+    return <p className="text-sm text-muted-foreground">Uploads werden geladen …</p>;
+  }
+
+  if (isError) {
+    return (
+      <div className="flex items-center justify-between gap-4 rounded-md border border-rose-200 bg-rose-50 p-4 text-sm text-rose-800 dark:border-rose-900/60 dark:bg-rose-900/20 dark:text-rose-200">
+        <span>Uploads konnten nicht geladen werden.</span>
+        {onRetry ? (
+          <Button variant="outline" size="sm" onClick={onRetry}>
+            Erneut versuchen
+          </Button>
+        ) : null}
+      </div>
+    );
+  }
+
+  if (!uploads || uploads.length === 0) {
+    return <p className="text-sm text-muted-foreground">Aktuell sind keine Uploads aktiv.</p>;
+  }
+
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>Datei</TableHead>
+          <TableHead>Status</TableHead>
+          <TableHead>Fortschritt</TableHead>
+          <TableHead>Benutzer</TableHead>
+          <TableHead>Größe</TableHead>
+          <TableHead>Geschwindigkeit</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {uploads.map((upload, index) => {
+          const progressValue =
+            upload.progress === null || Number.isNaN(upload.progress)
+              ? null
+              : mapProgressToPercent(upload.progress);
+          const rowKey = upload.id ?? `${upload.filename ?? 'upload'}-${index}`;
+          return (
+            <TableRow key={rowKey}>
+              <TableCell>
+                <div className="space-y-1">
+                  <span className="text-sm font-medium text-foreground">
+                    {upload.filename ?? upload.id ?? 'Unbenanntes Upload'}
+                  </span>
+                  {upload.id ? (
+                    <span className="text-xs text-muted-foreground">ID: {upload.id}</span>
+                  ) : null}
+                </div>
+              </TableCell>
+              <TableCell>
+                <div className="space-y-1">
+                  <StatusBadge status={upload.state} label={formatStateLabel(upload.state)} />
+                  {formatTimestamp(upload.startedAt) ? (
+                    <span className="block text-xs text-muted-foreground">
+                      Gestartet: {formatTimestamp(upload.startedAt)}
+                    </span>
+                  ) : formatTimestamp(upload.queuedAt) ? (
+                    <span className="block text-xs text-muted-foreground">
+                      Warteschlange seit: {formatTimestamp(upload.queuedAt)}
+                    </span>
+                  ) : null}
+                </div>
+              </TableCell>
+              <TableCell className="w-48">
+                {progressValue !== null ? (
+                  <div className="space-y-1">
+                    <Progress value={progressValue} aria-label={`Fortschritt ${progressValue}%`} />
+                    <span className="block text-xs text-muted-foreground">{progressValue}%</span>
+                  </div>
+                ) : (
+                  <span className="text-sm text-muted-foreground">Keine Angaben</span>
+                )}
+              </TableCell>
+              <TableCell>
+                <span className="text-sm text-foreground">{upload.username ?? '–'}</span>
+              </TableCell>
+              <TableCell>
+                <span className="text-sm text-foreground">{formatSize(upload.size)}</span>
+              </TableCell>
+              <TableCell>
+                <span className="text-sm text-foreground">{formatSpeed(upload.speed)}</span>
+              </TableCell>
+            </TableRow>
+          );
+        })}
+      </TableBody>
+    </Table>
+  );
+};
+
+export default SoulseekUploadList;

--- a/frontend/src/components/StatusBadge.tsx
+++ b/frontend/src/components/StatusBadge.tsx
@@ -1,0 +1,97 @@
+import { cn } from '../lib/utils';
+
+type StatusTone = 'positive' | 'warning' | 'danger' | 'info';
+
+const toneClasses: Record<StatusTone, string> = {
+  positive:
+    'bg-emerald-100 text-emerald-900 dark:bg-emerald-900/40 dark:text-emerald-100 border border-emerald-200 dark:border-emerald-700',
+  warning:
+    'bg-amber-100 text-amber-900 dark:bg-amber-900/40 dark:text-amber-100 border border-amber-200 dark:border-amber-700',
+  danger:
+    'bg-rose-100 text-rose-900 dark:bg-rose-900/40 dark:text-rose-100 border border-rose-200 dark:border-rose-700',
+  info:
+    'bg-slate-200 text-slate-900 dark:bg-slate-800/70 dark:text-slate-100 border border-slate-300 dark:border-slate-600'
+};
+
+const toneIcons: Record<StatusTone, string> = {
+  positive: '✅',
+  warning: '⚠️',
+  danger: '⛔',
+  info: 'ℹ️'
+};
+
+const titleCase = (value: string): string =>
+  value
+    .split(/\s+|_|-/u)
+    .filter(Boolean)
+    .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
+    .join(' ');
+
+const inferTone = (value: string): StatusTone => {
+  const normalized = value.toLowerCase();
+  if (
+    [
+      'connected',
+      'ok',
+      'healthy',
+      'online',
+      'completed',
+      'active',
+      'running',
+      'up',
+      'available'
+    ].includes(normalized)
+  ) {
+    return 'positive';
+  }
+  if (
+    [
+      'degraded',
+      'warning',
+      'limited',
+      'uploading',
+      'pending',
+      'queued',
+      'starting',
+      'partial'
+    ].includes(normalized)
+  ) {
+    return 'warning';
+  }
+  if (
+    ['disconnected', 'down', 'failed', 'error', 'offline', 'cancelled', 'blocked'].includes(normalized)
+  ) {
+    return 'danger';
+  }
+  return 'info';
+};
+
+export interface StatusBadgeProps {
+  status: string;
+  label?: string;
+  tone?: StatusTone;
+  className?: string;
+}
+
+const StatusBadge = ({ status, label, tone, className }: StatusBadgeProps) => {
+  const resolvedTone = tone ?? inferTone(status);
+  const resolvedLabel = label ?? titleCase(status);
+  const icon = toneIcons[resolvedTone];
+
+  return (
+    <span
+      role="status"
+      aria-label={`Status: ${resolvedLabel}`}
+      className={cn(
+        'inline-flex items-center gap-1 rounded-full px-2 py-1 text-xs font-medium tracking-wide',
+        toneClasses[resolvedTone],
+        className
+      )}
+    >
+      <span aria-hidden="true">{icon}</span>
+      <span>{resolvedLabel}</span>
+    </span>
+  );
+};
+
+export default StatusBadge;

--- a/frontend/src/pages/SoulseekPage.tsx
+++ b/frontend/src/pages/SoulseekPage.tsx
@@ -1,17 +1,302 @@
-const SoulseekPage = () => (
-  <section className="space-y-6">
-    <header className="space-y-2">
-      <h1 className="text-2xl font-semibold text-slate-900 dark:text-slate-100">Soulseek</h1>
-      <p className="text-sm text-slate-600 dark:text-slate-400">
-        Verbinde deinen Harmony-Katalog mit der Soulseek-Community, um neue Musikquellen zu entdecken
-        und Downloads zu orchestrieren.
-      </p>
-    </header>
-    <div className="rounded-xl border border-dashed border-slate-300 bg-white/80 p-6 text-sm text-slate-500 shadow-sm dark:border-slate-700 dark:bg-slate-900/60 dark:text-slate-300">
-      Die Soulseek-Integration ist in Vorbereitung. Hier erscheinen demnächst Verbindungsdetails, Freigabe-Status
-      und eine Übersicht aktiver Suchanfragen.
-    </div>
-  </section>
-);
+import { useMemo, useState } from 'react';
+
+import StatusBadge from '../components/StatusBadge';
+import SoulseekUploadList from '../components/SoulseekUploadList';
+import { Button, Card, CardContent, CardDescription, CardHeader, CardTitle } from '../components/ui/shadcn';
+import {
+  getIntegrationsReport,
+  getSoulseekConfiguration,
+  getSoulseekStatus,
+  getSoulseekUploads,
+  type IntegrationsData,
+  type NormalizedSoulseekUpload,
+  type SoulseekConfigurationEntry
+} from '../api/services/soulseek';
+import type { SoulseekConnectionStatus } from '../api/types';
+import { useQuery } from '../lib/query';
+
+interface StatusLabelMapping {
+  ok?: Record<string, string>;
+  degraded?: Record<string, string>;
+  down?: Record<string, string>;
+  other?: Record<string, string>;
+}
+
+const formatStatusLabel = (status: string, mapping: StatusLabelMapping) => {
+  const normalized = status.toLowerCase();
+  if (mapping.ok && normalized in mapping.ok) {
+    return mapping.ok[normalized];
+  }
+  if (mapping.degraded && normalized in mapping.degraded) {
+    return mapping.degraded[normalized];
+  }
+  if (mapping.down && normalized in mapping.down) {
+    return mapping.down[normalized];
+  }
+  if (mapping.other && normalized in mapping.other) {
+    return mapping.other[normalized];
+  }
+  return status.charAt(0).toUpperCase() + status.slice(1);
+};
+
+const formatDetailKey = (key: string) =>
+  key
+    .split(/\.|_|-/u)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
+
+const formatDetailValue = (value: unknown): string => {
+  if (Array.isArray(value)) {
+    return value.map((item) => formatDetailValue(item)).join(', ');
+  }
+  if (value === null || value === undefined) {
+    return '–';
+  }
+  if (value instanceof Date) {
+    return value.toLocaleString();
+  }
+  if (typeof value === 'object') {
+    return JSON.stringify(value);
+  }
+  if (typeof value === 'boolean') {
+    return value ? 'Ja' : 'Nein';
+  }
+  return String(value);
+};
+
+const SoulseekPage = () => {
+  const [showAllUploads, setShowAllUploads] = useState(false);
+
+  const statusQuery = useQuery<{ status: SoulseekConnectionStatus }>({
+    queryKey: ['soulseek', 'status'],
+    queryFn: getSoulseekStatus
+  });
+
+  const integrationsQuery = useQuery<IntegrationsData>({
+    queryKey: ['integrations', 'providers'],
+    queryFn: getIntegrationsReport
+  });
+
+  const configurationQuery = useQuery<SoulseekConfigurationEntry[]>({
+    queryKey: ['soulseek', 'configuration'],
+    queryFn: getSoulseekConfiguration
+  });
+
+  const uploadsQuery = useQuery<NormalizedSoulseekUpload[]>({
+    queryKey: ['soulseek', 'uploads', showAllUploads ? 'all' : 'active'],
+    queryFn: () => getSoulseekUploads({ includeAll: showAllUploads })
+  });
+
+  const connectionStatus = statusQuery.data?.status ?? 'unknown';
+  const connectionLabelMap = {
+    ok: 'Verbunden',
+    connected: 'Verbunden',
+    disconnected: 'Getrennt',
+    unknown: 'Unbekannt'
+  };
+  const connectionLabel = connectionLabelMap[connectionStatus] ?? connectionLabelMap.unknown;
+  const connectionTone = connectionStatus === 'connected' ? 'positive' : connectionStatus === 'disconnected' ? 'danger' : 'info';
+
+  const integrationOverview = integrationsQuery.data;
+
+  const soulseekProvider = useMemo(() => {
+    if (!integrationOverview) {
+      return undefined;
+    }
+    return integrationOverview.providers.find((provider) =>
+      provider.name.toLowerCase().includes('soulseek') || provider.name.toLowerCase().includes('slskd')
+    );
+  }, [integrationOverview]);
+
+  const providerDetails = useMemo(() => {
+    if (!soulseekProvider || !soulseekProvider.details) {
+      return [] as Array<[string, string]>;
+    }
+    return Object.entries(soulseekProvider.details).map(([key, value]) => [key, formatDetailValue(value)]);
+  }, [soulseekProvider]);
+
+  const configurationEntries = configurationQuery.data ?? [];
+
+  return (
+    <section className="space-y-6">
+      <header className="space-y-2">
+        <h1 className="text-2xl font-semibold text-slate-900 dark:text-slate-100">Soulseek</h1>
+        <p className="text-sm text-slate-600 dark:text-slate-400">
+          Überblick über den slskd-Status, Konfiguration und aktive Upload-Freigaben.
+        </p>
+      </header>
+
+      <div className="grid gap-6 lg:grid-cols-2">
+        <Card>
+          <CardHeader>
+            <CardTitle>Verbindung &amp; Integrationen</CardTitle>
+            <CardDescription>
+              Prüft die direkte Verbindung zum Soulseek-Daemon und den Integrationsstatus des Providers.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-6">
+            <section className="space-y-2">
+              <h2 className="text-sm font-semibold text-foreground">Verbindungsstatus</h2>
+              {statusQuery.isLoading ? (
+                <p className="text-sm text-muted-foreground">Verbindung wird geprüft …</p>
+              ) : statusQuery.isError ? (
+                <div className="flex items-center justify-between gap-3 rounded-md border border-rose-200 bg-rose-50 p-3 text-sm text-rose-800 dark:border-rose-900/60 dark:bg-rose-900/20 dark:text-rose-200">
+                  <span>Der Verbindungsstatus konnte nicht abgerufen werden.</span>
+                  <Button variant="outline" size="sm" onClick={() => statusQuery.refetch()}>
+                    Erneut prüfen
+                  </Button>
+                </div>
+              ) : (
+                <div className="space-y-1">
+                  <StatusBadge status={connectionStatus} label={connectionLabel} tone={connectionTone} />
+                  <p className="text-sm text-muted-foreground">
+                    {connectionStatus === 'connected'
+                      ? 'Harmony kommuniziert erfolgreich mit slskd.'
+                      : 'Keine bestätigte Verbindung zum Soulseek-Daemon.'}
+                  </p>
+                </div>
+              )}
+            </section>
+
+            <section className="space-y-2">
+              <h2 className="text-sm font-semibold text-foreground">Provider-Gesundheit</h2>
+              {integrationsQuery.isLoading ? (
+                <p className="text-sm text-muted-foreground">Integrationsdaten werden geladen …</p>
+              ) : integrationsQuery.isError ? (
+                <div className="rounded-md border border-amber-200 bg-amber-50 p-3 text-sm text-amber-900 dark:border-amber-900/60 dark:bg-amber-900/20 dark:text-amber-100">
+                  Integrationsstatus konnte nicht geladen werden.
+                </div>
+              ) : integrationOverview ? (
+                <div className="space-y-3">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <span className="text-sm font-medium text-foreground">Gesamtzustand</span>
+                    <StatusBadge
+                      status={integrationOverview.overall}
+                      label={formatStatusLabel(integrationOverview.overall, {
+                        ok: { ok: 'Stabil' },
+                        degraded: { degraded: 'Eingeschränkt' },
+                        down: { down: 'Ausfall' },
+                        other: { unknown: 'Unbekannt' }
+                      })}
+                    />
+                  </div>
+                  {soulseekProvider ? (
+                    <div className="space-y-2">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <span className="text-sm font-medium text-foreground">Soulseek (slskd)</span>
+                        <StatusBadge
+                          status={soulseekProvider.status}
+                          label={formatStatusLabel(soulseekProvider.status, {
+                            ok: { ok: 'Bereit' },
+                            degraded: { degraded: 'Eingeschränkt' },
+                            down: { down: 'Ausfall' },
+                            other: { unknown: 'Unbekannt' }
+                          })}
+                        />
+                      </div>
+                      {providerDetails.length > 0 ? (
+                        <dl className="grid gap-2">
+                          {providerDetails.map(([key, value]) => (
+                            <div key={key} className="space-y-0.5">
+                              <dt className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                                {formatDetailKey(key)}
+                              </dt>
+                              <dd className="text-sm text-foreground">{value}</dd>
+                            </div>
+                          ))}
+                        </dl>
+                      ) : (
+                        <p className="text-sm text-muted-foreground">Keine zusätzlichen Details gemeldet.</p>
+                      )}
+                    </div>
+                  ) : (
+                    <p className="text-sm text-muted-foreground">
+                      Keine spezifischen Gesundheitsdaten für Soulseek verfügbar.
+                    </p>
+                  )}
+                </div>
+              ) : null}
+            </section>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Konfiguration</CardTitle>
+            <CardDescription>
+              Zusammenfassung der wichtigsten slskd-Einstellungen inklusive Maskierung sensibler Werte.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            {configurationQuery.isLoading ? (
+              <p className="text-sm text-muted-foreground">Konfiguration wird geladen …</p>
+            ) : configurationQuery.isError ? (
+              <div className="rounded-md border border-rose-200 bg-rose-50 p-3 text-sm text-rose-800 dark:border-rose-900/60 dark:bg-rose-900/20 dark:text-rose-200">
+                Konfiguration konnte nicht geladen werden.
+              </div>
+            ) : configurationEntries.length > 0 ? (
+              <div className="grid gap-4 sm:grid-cols-2">
+                {configurationEntries.map((entry) => (
+                  <div
+                    key={entry.key}
+                    className="space-y-2 rounded-lg border border-slate-200 p-3 dark:border-slate-700"
+                  >
+                    <div className="flex items-center justify-between gap-2">
+                      <div>
+                        <p className="text-sm font-medium text-foreground">{entry.label}</p>
+                        <p className="text-[11px] uppercase tracking-wide text-muted-foreground">{entry.key}</p>
+                      </div>
+                      <StatusBadge
+                        status={entry.present ? 'configured' : 'missing'}
+                        label={entry.present ? 'Hinterlegt' : 'Fehlt'}
+                        tone={entry.present ? 'positive' : 'danger'}
+                      />
+                    </div>
+                    <p className="break-words text-sm text-muted-foreground">
+                      {entry.displayValue ?? 'Kein Wert hinterlegt'}
+                    </p>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <p className="text-sm text-muted-foreground">Keine slskd-spezifischen Einstellungen gefunden.</p>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+
+      <Card>
+        <CardHeader className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <div className="space-y-1">
+            <CardTitle>Aktive Uploads</CardTitle>
+            <CardDescription>Freigaben, die aktuell über den Soulseek-Daemon bereitgestellt werden.</CardDescription>
+          </div>
+          <div className="flex flex-wrap items-center gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              aria-pressed={showAllUploads}
+              onClick={() => setShowAllUploads((value) => !value)}
+            >
+              {showAllUploads ? 'Nur aktive Uploads anzeigen' : 'Alle Uploads anzeigen'}
+            </Button>
+            <Button variant="outline" size="sm" onClick={() => uploadsQuery.refetch()}>
+              Aktualisieren
+            </Button>
+          </div>
+        </CardHeader>
+        <CardContent>
+          <SoulseekUploadList
+            uploads={uploadsQuery.data}
+            isLoading={uploadsQuery.isLoading}
+            isError={uploadsQuery.isError}
+            onRetry={() => uploadsQuery.refetch()}
+          />
+        </CardContent>
+      </Card>
+    </section>
+  );
+};
 
 export default SoulseekPage;


### PR DESCRIPTION
## Summary
- document how operators should read the Soulseek dashboard badges and upload states
- extend the SoulseekPage test suite to assert the connection badge and retry affordance
- refresh the ToDo entry to note that the Soulseek dashboard now ships with tests and docs

## Testing
- npm test -- SoulseekPage.test.tsx AppRoutes.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68e15a177be08321acac1d73d83d7b54