### PR TITLE
[CODX-FE-TEST-303] Add jsdom pointer capture polyfills to the test setup

### DIFF
--- a/frontend/jest.config.cjs
+++ b/frontend/jest.config.cjs
@@ -2,7 +2,11 @@ const config = {
   preset: 'ts-jest/presets/default-esm',
   testEnvironment: 'jsdom',
   extensionsToTreatAsEsm: ['.ts', '.tsx'],
-  setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
+  setupFilesAfterEnv: [
+    '<rootDir>/src/test/setup-dom-polyfills.ts',
+    '<rootDir>/src/test/setup-testing-library.ts',
+    '<rootDir>/jest.setup.ts'
+  ],
   globals: {
     'ts-jest': {
       useESM: true,

--- a/frontend/jest.setup.ts
+++ b/frontend/jest.setup.ts
@@ -1,4 +1,3 @@
-import '@testing-library/jest-dom';
 import * as React from 'react';
 
 jest.mock('@radix-ui/react-tooltip', () => {
@@ -61,12 +60,3 @@ const importMetaEnv = {
   ...importMetaEnv
 };
 
-if (typeof (globalThis as typeof globalThis & { ResizeObserver?: unknown }).ResizeObserver === 'undefined') {
-  class ResizeObserverStub {
-    observe() {}
-    unobserve() {}
-    disconnect() {}
-  }
-
-  (globalThis as typeof globalThis & { ResizeObserver?: unknown }).ResizeObserver = ResizeObserverStub;
-}

--- a/frontend/src/test/setup-dom-polyfills.ts
+++ b/frontend/src/test/setup-dom-polyfills.ts
@@ -1,0 +1,63 @@
+// Pointer capture polyfills for jsdom
+if (!('hasPointerCapture' in HTMLElement.prototype)) {
+  // @ts-expect-error jsdom lacks this API
+  (HTMLElement.prototype as any).hasPointerCapture = () => false;
+}
+
+if (!('setPointerCapture' in HTMLElement.prototype)) {
+  // @ts-expect-error jsdom lacks this API
+  (HTMLElement.prototype as any).setPointerCapture = () => {};
+}
+
+if (!('releasePointerCapture' in HTMLElement.prototype)) {
+  // @ts-expect-error jsdom lacks this API
+  (HTMLElement.prototype as any).releasePointerCapture = () => {};
+}
+
+// PointerEvent polyfill
+(function setupPointerEventPolyfill() {
+  const g = globalThis as typeof globalThis & { PointerEvent?: typeof PointerEvent };
+
+  if (typeof g.PointerEvent === 'undefined') {
+    class MockPointerEvent extends MouseEvent {
+      pointerId: number;
+      pointerType: string;
+      isPrimary: boolean;
+
+      constructor(type: string, init?: MouseEventInit & { pointerId?: number; pointerType?: string; isPrimary?: boolean }) {
+        super(type, init);
+        this.pointerId = init?.pointerId ?? 1;
+        this.pointerType = init?.pointerType ?? 'mouse';
+        this.isPrimary = init?.isPrimary ?? true;
+      }
+    }
+
+    g.PointerEvent = MockPointerEvent as unknown as typeof PointerEvent;
+  }
+})();
+
+// Optional: common web API stubs used by UI libs
+if (typeof (globalThis as typeof globalThis & { ResizeObserver?: unknown }).ResizeObserver === 'undefined') {
+  class ResizeObserverStub {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+
+  (globalThis as typeof globalThis & { ResizeObserver?: unknown }).ResizeObserver = ResizeObserverStub;
+}
+
+if (typeof (window as typeof window & { matchMedia?: typeof window.matchMedia }).matchMedia === 'undefined') {
+  (window as typeof window & { matchMedia?: typeof window.matchMedia }).matchMedia = (query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener() {},
+    removeListener() {},
+    addEventListener() {},
+    removeEventListener() {},
+    dispatchEvent() {
+      return false;
+    }
+  });
+}

--- a/frontend/src/test/setup-testing-library.ts
+++ b/frontend/src/test/setup-testing-library.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/frontend/vitest.setup.ts
+++ b/frontend/vitest.setup.ts
@@ -1,1 +1,2 @@
-import '@testing-library/jest-dom';
+import './src/test/setup-dom-polyfills';
+import './src/test/setup-testing-library';


### PR DESCRIPTION
## Summary
- add jsdom pointer capture and PointerEvent polyfills in a shared setup module for the jsdom environment
- register the new setup helpers for both Jest and Vitest so React Testing Library helpers and polyfills load before specs

## Testing
- `npm run test -- --runTestsByPath src/__tests__/ActivityFeed.test.tsx` *(fails: Cannot find module '@radix-ui/react-select' because the dependency is unavailable in the current sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68e16fc99b108321bb26753c2f4cd6ec