### PR TITLE
feat: add soulseek download monitoring UI

### DIFF
--- a/ToDo.md
+++ b/ToDo.md
@@ -62,6 +62,28 @@ Subtasks:
 - Navigation erweitern und Badges gestalten.
 - Tests und Dokumentation aktualisieren.
 
+ID: TD-20251014-001
+Titel: Soulseek-Dashboard zeigt Download-Überwachung
+Status: done
+Priorität: P2
+Scope: frontend
+Owner: codex
+Created_at: 2025-10-14T09:00:00Z
+Updated_at: 2025-10-14T09:00:00Z
+Tags: soulseek, operations, dashboard
+Beschreibung: Das Soulseek-Dashboard visualisierte bisher nur Uploads, wodurch Operator:innen den Zustand der Download-Warteschlange im Backend prüfen mussten. Die neue Ansicht integriert aktive und historische Downloads inklusive Priorität, Retry-Zähler und Fehlermeldungen direkt in der UI. Umschalter für aktive vs. alle Transfers sowie Live-Refresh erleichtern das Monitoring nach manuellen Eingriffen.
+Akzeptanzkriterien:
+- UI bindet `/soulseek/downloads` und `/soulseek/downloads/all` ein und zeigt relevante Felder (State, Fortschritt, Priorität, Retry-Zähler, Fehler) tabellarisch an.
+- Operator:innen können zwischen aktiven und sämtlichen Downloads umschalten und eine Aktualisierung anstoßen.
+- Tests decken Erfolgs-, Fehler-, Lade- und Leerszenarien der Download-Abfrage ab.
+Risiko/Impact: Niedrig; reine UI- und Service-Erweiterung ohne Änderungen an der Backend-Semantik.
+Dependencies: Soulseek-Router-Endpunkte für Downloads müssen erreichbar bleiben.
+Verweise: PR TBD
+Subtasks:
+- Downloads-Service im Frontend typisieren und normalisieren.
+- Komponenten & SoulseekPage um Download-Tabellen erweitern.
+- Tests und Dokumentation ergänzen.
+
 ID: TD-20251012-001
 Titel: Soulseek- und Matching-Ansichten mit Live-Daten versorgen
 Status: done

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -60,15 +60,17 @@ Hinweis: Die verbleibenden Module unter `app/routers/` dienen nur noch als Kompa
 
 #### Soulseek UI Dashboard
 
-- Die Frontend-Ansicht **„Soulseek“** bündelt drei Kernbereiche für Operator:innen:
+- Die Frontend-Ansicht **„Soulseek“** bündelt vier Kernbereiche für Operator:innen:
   - **Verbindung & Integrationen:** nutzt `/soulseek/status` und `/integrations`, um den Connectivity-Status sowie Provider-Health inklusive Detailhinweisen (z. B. fehlende Credentials) anzuzeigen.
   - **Konfigurationsübersicht:** lädt die relevanten `SLSKD_*`-Einstellungen über `/settings`, maskiert Secrets und markiert fehlende Pflichtwerte (Basis-URL/API-Key) deutlich.
   - **Aktive Uploads:** ruft `/soulseek/uploads` bzw. `/soulseek/uploads/all` ab, stellt Fortschritt, Benutzer:innen, Größe und Durchsatz als Tabelle dar und signalisiert Fehlerzustände mit Retry-Möglichkeit.
+  - **Download-Überwachung:** bindet `/soulseek/downloads` und `/soulseek/downloads/all` ein, zeigt Priorität, Retry-Zähler und letzte Fehler pro Transfer und erlaubt den Wechsel zwischen aktiven und historischen Downloads.
 - **Interpretation der Hinweise:**
   - Das Badge **„Verbunden“** bestätigt, dass der Backend-Proxy (`slskd`) erreichbar ist. **„Getrennt“** bedeutet, dass Downloads/Uploads blockiert sind und Worker in Folge mit Retries starten.
   - Der Abschnitt **„Provider-Gesundheit“** spiegelt die `/integrations`-Bewertung wider. `degraded` deutet auf optionale, aber relevante Warnungen hin (z. B. fehlende Bandbreitenlimits), `down` auf harte Ausfälle oder fehlende Credentials. Detailfelder listen die Rohwerte aus dem Health-Endpunkt.
   - In der Konfiguration kennzeichnet ein rotes Badge fehlende Pflichtwerte. Maskierte Secrets erscheinen als `••••••`; Operator:innen können so prüfen, ob Werte grundsätzlich gesetzt sind, ohne sie offenzulegen.
   - Die Upload-Tabelle zeigt jeden aktiven Share mit Status, Fortschritt, Transfergröße und Geschwindigkeit. Bei leerem Ergebnis informiert der Hinweis „Aktuell sind keine Uploads aktiv“, Fehlerzustände liefern einen Retry-Button, der erneut `/soulseek/uploads` aufruft.
+  - Die Download-Tabelle aggregiert Daten aus persistenter Datenbank und Live-Queue, inklusive Priorität, Retry-Historie und Zeitstempeln. Über die Umschalter „Alle Downloads anzeigen“/„Nur aktive Downloads“ lassen sich Altlasten prüfen; der Retry-Button stößt eine erneute Synchronisation der Liste an, sodass Operator:innen nach manuellen Requeues den Zustand kontrollieren können.
 - Die Seite dient als Operations-Dashboard für den Soulseek-Daemon: Warnhinweise bei Ausfällen oder fehlender Konfiguration helfen, bevor Sync-Worker oder Upload-Freigaben ins Stocken geraten.
 - **Navigation-Warnhinweise:** Die linke Seitenleiste übernimmt die gleichen Integrationssignale. Ein gelbes Badge „Eingeschränkt“ weist auf degradierte Dienste hin (z. B. wenn `/integrations` `degraded` meldet), rote Badges „Offline“ bzw. „Fehler“ kennzeichnen fehlende Konfiguration oder nicht erreichbare Services. Tooltips und Screenreader-Texte wiederholen die Warnung – auch im eingeklappten Zustand der Navigation – damit Operator:innen die Soulseek- und Matching-Dashboards gezielt aufrufen können.
 

--- a/frontend/src/__tests__/SoulseekPage.test.tsx
+++ b/frontend/src/__tests__/SoulseekPage.test.tsx
@@ -4,7 +4,10 @@ import SoulseekPage from '../pages/SoulseekPage';
 import { renderWithProviders } from '../test-utils';
 import { useQuery } from '../lib/query';
 import type { IntegrationsData } from '../api/services/soulseek';
-import type { SoulseekConfigurationEntry } from '../api/services/soulseek';
+import type {
+  SoulseekConfigurationEntry,
+  NormalizedSoulseekDownload
+} from '../api/services/soulseek';
 import type { SoulseekStatusResponse } from '../api/types';
 
 jest.mock('../lib/query', () => {
@@ -34,6 +37,13 @@ const createQueryResult = <T,>(overrides: Partial<QueryResult<T>> = {}): QueryRe
   ...overrides
 });
 
+const joinQueryKey = (queryKey: unknown): string => {
+  if (Array.isArray(queryKey)) {
+    return queryKey.join(':');
+  }
+  return String(queryKey);
+};
+
 describe('SoulseekPage', () => {
   beforeEach(() => {
     mockedUseQuery.mockReset();
@@ -62,17 +72,39 @@ describe('SoulseekPage', () => {
       }
     ];
 
+    const downloadData: NormalizedSoulseekDownload[] = [
+      {
+        id: '42',
+        filename: 'album-track.mp3',
+        username: 'alice',
+        state: 'failed',
+        progress: 0.42,
+        priority: 5,
+        retryCount: 2,
+        lastError: 'Timeout',
+        createdAt: '2024-01-01T10:00:00Z',
+        updatedAt: '2024-01-01T10:05:00Z',
+        queuedAt: '2024-01-01T09:55:00Z',
+        startedAt: null,
+        completedAt: null,
+        nextRetryAt: null,
+        raw: {} as any
+      }
+    ];
+
     mockedUseQuery.mockImplementation(({ queryKey }) => {
-      const [, scope] = queryKey as [string, string];
-      switch (scope) {
-        case 'status':
+      const key = joinQueryKey(queryKey);
+      switch (key) {
+        case 'soulseek:status':
           return createQueryResult({ data: statusData });
-        case 'providers':
+        case 'integrations:providers':
           return createQueryResult({ data: integrationData });
-        case 'configuration':
+        case 'soulseek:configuration':
           return createQueryResult({ data: configurationData });
-        case 'uploads':
+        case 'soulseek:uploads:active':
           return createQueryResult({ data: [] });
+        case 'soulseek:downloads:active':
+          return createQueryResult({ data: downloadData });
         default:
           return createQueryResult();
       }
@@ -86,12 +118,17 @@ describe('SoulseekPage', () => {
     expect(screen.getByText(/Verbunden/)).toBeInTheDocument();
     expect(screen.getByText(/missing_credentials/)).toBeInTheDocument();
     expect(screen.getByText(/Aktuell sind keine Uploads aktiv/)).toBeInTheDocument();
+    expect(screen.getByText('album-track.mp3')).toBeInTheDocument();
+    expect(screen.getByText('Priorität: 5')).toBeInTheDocument();
+    expect(screen.getByText('2 Retries')).toBeInTheDocument();
+    expect(screen.getByText('Fehler: Timeout')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Retry' })).toBeInTheDocument();
   });
 
   it('zeigt einen Fehlerhinweis, wenn Uploads nicht geladen werden können', () => {
     mockedUseQuery.mockImplementation(({ queryKey }) => {
-      const [, scope] = queryKey as [string, string];
-      if (scope === 'uploads') {
+      const key = joinQueryKey(queryKey);
+      if (key === 'soulseek:uploads:active') {
         return createQueryResult({ isError: true, error: new Error('boom') });
       }
       return createQueryResult();
@@ -105,8 +142,8 @@ describe('SoulseekPage', () => {
 
   it('zeigt Ladezustände an, solange Daten angefordert werden', () => {
     mockedUseQuery.mockImplementation(({ queryKey }) => {
-      const [, scope] = queryKey as [string, string];
-      if (scope === 'uploads') {
+      const key = joinQueryKey(queryKey);
+      if (key === 'soulseek:uploads:active') {
         return createQueryResult({ isLoading: true });
       }
       return createQueryResult();
@@ -115,5 +152,48 @@ describe('SoulseekPage', () => {
     renderWithProviders(<SoulseekPage />, { route: '/soulseek' });
 
     expect(screen.getByText(/Uploads werden geladen/)).toBeInTheDocument();
+  });
+
+  it('zeigt einen Fehlerhinweis, wenn Downloads nicht geladen werden können', () => {
+    mockedUseQuery.mockImplementation(({ queryKey }) => {
+      const key = joinQueryKey(queryKey);
+      if (key === 'soulseek:downloads:active') {
+        return createQueryResult({ isError: true, error: new Error('boom') });
+      }
+      return createQueryResult();
+    });
+
+    renderWithProviders(<SoulseekPage />, { route: '/soulseek' });
+
+    expect(screen.getByText('Downloads konnten nicht geladen werden.')).toBeInTheDocument();
+    expect(screen.getAllByRole('button', { name: 'Erneut versuchen' })).not.toHaveLength(0);
+  });
+
+  it('zeigt den Ladezustand für Downloads an', () => {
+    mockedUseQuery.mockImplementation(({ queryKey }) => {
+      const key = joinQueryKey(queryKey);
+      if (key === 'soulseek:downloads:active') {
+        return createQueryResult({ isLoading: true });
+      }
+      return createQueryResult();
+    });
+
+    renderWithProviders(<SoulseekPage />, { route: '/soulseek' });
+
+    expect(screen.getByText(/Downloads werden geladen/)).toBeInTheDocument();
+  });
+
+  it('informiert, wenn keine Downloads vorliegen', () => {
+    mockedUseQuery.mockImplementation(({ queryKey }) => {
+      const key = joinQueryKey(queryKey);
+      if (key === 'soulseek:downloads:active') {
+        return createQueryResult({ data: [] });
+      }
+      return createQueryResult();
+    });
+
+    renderWithProviders(<SoulseekPage />, { route: '/soulseek' });
+
+    expect(screen.getByText(/Aktuell sind keine Downloads aktiv/)).toBeInTheDocument();
   });
 });

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -101,6 +101,29 @@ export interface SoulseekUploadsResponse {
   uploads?: unknown;
 }
 
+export interface SoulseekDownloadEntry {
+  id?: number | string | null;
+  filename?: string | null;
+  username?: string | null;
+  state?: string | null;
+  progress?: number | null;
+  priority?: number | null;
+  created_at?: string | null;
+  updated_at?: string | null;
+  queued_at?: string | null;
+  started_at?: string | null;
+  completed_at?: string | null;
+  finished_at?: string | null;
+  retry_count?: number | null;
+  next_retry_at?: string | null;
+  last_error?: string | null;
+  [key: string]: unknown;
+}
+
+export interface SoulseekDownloadsResponse {
+  downloads?: unknown;
+}
+
 export interface ProviderInfo {
   name: string;
   status: string;

--- a/frontend/src/components/SoulseekDownloadList.tsx
+++ b/frontend/src/components/SoulseekDownloadList.tsx
@@ -1,0 +1,197 @@
+import StatusBadge from './StatusBadge';
+import { Progress } from './ui/progress';
+import { Button } from './ui/shadcn';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from './ui/table';
+import type { NormalizedSoulseekDownload } from '../api/services/soulseek';
+import { mapProgressToPercent } from '../lib/utils';
+
+const formatStateLabel = (state: string): string => {
+  const normalized = state.toLowerCase();
+  const labels: Record<string, string> = {
+    pending: 'Wartend',
+    queued: 'Wartend',
+    in_progress: 'Läuft',
+    downloading: 'Läuft',
+    completed: 'Abgeschlossen',
+    failed: 'Fehlgeschlagen',
+    dead_letter: 'Wartet auf Eingriff'
+  };
+  return labels[normalized] ?? state.charAt(0).toUpperCase() + state.slice(1);
+};
+
+const formatTimestamp = (value: string | null): string | null => {
+  if (!value) {
+    return null;
+  }
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+  return date.toLocaleString();
+};
+
+const formatPriority = (value: number | null): string => {
+  if (value === null || Number.isNaN(value)) {
+    return '–';
+  }
+  return `${value}`;
+};
+
+const formatRetryCount = (value: number): string => {
+  if (!Number.isFinite(value) || value <= 0) {
+    return 'Keine Retries';
+  }
+  if (value === 1) {
+    return '1 Retry';
+  }
+  return `${value} Retries`;
+};
+
+export interface SoulseekDownloadListProps {
+  downloads?: NormalizedSoulseekDownload[];
+  isLoading: boolean;
+  isError: boolean;
+  onRetryFetch?: () => void;
+  onRetryDownload?: (download: NormalizedSoulseekDownload) => void;
+}
+
+const SoulseekDownloadList = ({
+  downloads,
+  isLoading,
+  isError,
+  onRetryFetch,
+  onRetryDownload
+}: SoulseekDownloadListProps) => {
+  if (isLoading) {
+    return <p className="text-sm text-muted-foreground">Downloads werden geladen …</p>;
+  }
+
+  if (isError) {
+    return (
+      <div className="flex items-center justify-between gap-4 rounded-md border border-rose-200 bg-rose-50 p-4 text-sm text-rose-800 dark:border-rose-900/60 dark:bg-rose-900/20 dark:text-rose-200">
+        <span>Downloads konnten nicht geladen werden.</span>
+        {onRetryFetch ? (
+          <Button variant="outline" size="sm" onClick={onRetryFetch}>
+            Erneut versuchen
+          </Button>
+        ) : null}
+      </div>
+    );
+  }
+
+  if (!downloads || downloads.length === 0) {
+    return <p className="text-sm text-muted-foreground">Aktuell sind keine Downloads aktiv.</p>;
+  }
+
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>Datei</TableHead>
+          <TableHead>Status</TableHead>
+          <TableHead>Fortschritt</TableHead>
+          <TableHead>Benutzer</TableHead>
+          <TableHead>Priorität / Retries</TableHead>
+          <TableHead>Zeitstempel</TableHead>
+          <TableHead>Aktionen</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {downloads.map((download, index) => {
+          const progressValue =
+            download.progress === null || Number.isNaN(download.progress)
+              ? null
+              : mapProgressToPercent(download.progress);
+          const rowKey = download.id ?? `${download.filename ?? 'download'}-${index}`;
+          const canRetry = (() => {
+            const normalized = download.state.toLowerCase();
+            return normalized === 'failed' || normalized === 'dead_letter';
+          })();
+          const queuedLabel = formatTimestamp(download.queuedAt);
+          const startedLabel = formatTimestamp(download.startedAt);
+          const completedLabel = formatTimestamp(download.completedAt);
+          const createdLabel = formatTimestamp(download.createdAt);
+          const updatedLabel = formatTimestamp(download.updatedAt);
+
+          return (
+            <TableRow key={rowKey}>
+              <TableCell>
+                <div className="space-y-1">
+                  <span className="text-sm font-medium text-foreground">
+                    {download.filename ?? download.id ?? 'Unbekannter Download'}
+                  </span>
+                  {download.id ? (
+                    <span className="text-xs text-muted-foreground">ID: {download.id}</span>
+                  ) : null}
+                </div>
+              </TableCell>
+              <TableCell>
+                <div className="space-y-1">
+                  <StatusBadge status={download.state} label={formatStateLabel(download.state)} />
+                  {download.lastError ? (
+                    <span className="block text-xs text-rose-600 dark:text-rose-300">
+                      Fehler: {download.lastError}
+                    </span>
+                  ) : null}
+                  {download.nextRetryAt ? (
+                    <span className="block text-xs text-muted-foreground">
+                      Nächster Retry: {formatTimestamp(download.nextRetryAt) ?? 'Unbekannt'}
+                    </span>
+                  ) : null}
+                </div>
+              </TableCell>
+              <TableCell className="w-48">
+                {progressValue !== null ? (
+                  <div className="space-y-1">
+                    <Progress value={progressValue} aria-label={`Fortschritt ${progressValue}%`} />
+                    <span className="block text-xs text-muted-foreground">{progressValue}%</span>
+                  </div>
+                ) : (
+                  <span className="text-sm text-muted-foreground">Keine Angaben</span>
+                )}
+              </TableCell>
+              <TableCell>
+                <div className="space-y-1">
+                  <span className="text-sm text-foreground">{download.username ?? '–'}</span>
+                  {queuedLabel ? (
+                    <span className="block text-xs text-muted-foreground">Wartet seit: {queuedLabel}</span>
+                  ) : null}
+                  {!queuedLabel && startedLabel ? (
+                    <span className="block text-xs text-muted-foreground">Gestartet: {startedLabel}</span>
+                  ) : null}
+                  {completedLabel ? (
+                    <span className="block text-xs text-muted-foreground">Abgeschlossen: {completedLabel}</span>
+                  ) : null}
+                </div>
+              </TableCell>
+              <TableCell>
+                <div className="space-y-1">
+                  <span className="text-sm text-foreground">Priorität: {formatPriority(download.priority)}</span>
+                  <span className="block text-xs text-muted-foreground">{formatRetryCount(download.retryCount)}</span>
+                </div>
+              </TableCell>
+              <TableCell>
+                <div className="space-y-1 text-xs text-muted-foreground">
+                  {createdLabel ? <span>Erstellt: {createdLabel}</span> : null}
+                  {updatedLabel ? <span>Aktualisiert: {updatedLabel}</span> : null}
+                </div>
+              </TableCell>
+              <TableCell>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  disabled={!onRetryDownload || !canRetry}
+                  onClick={() => onRetryDownload?.(download)}
+                >
+                  Retry
+                </Button>
+              </TableCell>
+            </TableRow>
+          );
+        })}
+      </TableBody>
+    </Table>
+  );
+};
+
+export default SoulseekDownloadList;


### PR DESCRIPTION
## Summary
- add typed Soulseek download helpers that normalize API responses for active and historical queues
- render a reusable SoulseekDownloadList component and expose download monitoring controls on the Soulseek dashboard
- update docs, tests, and ToDo backlog so operators understand the new download view and its coverage

## Testing
- npm test -- SoulseekPage.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68e17728e740832192287c19c78aebab