### PR TITLE
feat: improve Soulseek download retry flow

### DIFF
--- a/frontend/src/__tests__/SoulseekPage.test.tsx
+++ b/frontend/src/__tests__/SoulseekPage.test.tsx
@@ -211,6 +211,41 @@ describe('SoulseekPage', () => {
     expect(screen.getByText(/Aktuell sind keine Downloads aktiv/)).toBeInTheDocument();
   });
 
+  it('deaktiviert den Retry-Button für Dead-Letter-Downloads', () => {
+    const downloadData: NormalizedSoulseekDownload[] = [
+      {
+        id: '42',
+        filename: 'album-track.mp3',
+        username: 'alice',
+        state: 'dead_letter',
+        progress: 0,
+        priority: null,
+        retryCount: 0,
+        lastError: 'Permanent failure',
+        createdAt: null,
+        updatedAt: null,
+        queuedAt: null,
+        startedAt: null,
+        completedAt: null,
+        nextRetryAt: null,
+        raw: {} as any
+      }
+    ];
+
+    mockedUseQuery.mockImplementation(({ queryKey }) => {
+      const key = joinQueryKey(queryKey);
+      if (key === 'soulseek:downloads:active') {
+        return createQueryResult({ data: downloadData });
+      }
+      return createQueryResult();
+    });
+
+    renderWithProviders(<SoulseekPage />, { route: '/soulseek' });
+
+    const retryButton = screen.getByRole('button', { name: 'Retry' });
+    expect(retryButton).toBeDisabled();
+  });
+
   it('plant fehlgeschlagene Downloads erneut ein und aktualisiert die Liste', async () => {
     const refetchMock = jest.fn().mockResolvedValue(undefined);
     const toastMock = jest.fn();


### PR DESCRIPTION
## Summary
- add a dedicated mutation for Soulseek download requeues and refresh data only after successful retries
- update the Soulseek download list to surface pending retry feedback and block retries without identifiers or in dead-letter state
- extend the Soulseek page tests to cover success, dead-letter, and generic failure flows for the retry action

## Testing
- `npm test -- SoulseekPage` *(fails: missing jest binary in environment)*

## ToDo-Update
- Keine Änderungen erforderlich

------
https://chatgpt.com/codex/tasks/task_e_68e191e9dbec8321b0c6893032ccbd82