### PR TITLE
fix: highlight dead-letter statuses as danger

### DIFF
--- a/frontend/src/__tests__/SoulseekPage.test.tsx
+++ b/frontend/src/__tests__/SoulseekPage.test.tsx
@@ -242,6 +242,9 @@ describe('SoulseekPage', () => {
 
     renderWithProviders(<SoulseekPage />, { route: '/soulseek' });
 
+    const badge = screen.getByRole('status', { name: /wartet auf eingriff/i });
+    expect(badge).toHaveClass('bg-rose-100');
+
     const retryButton = screen.getByRole('button', { name: 'Retry' });
     expect(retryButton).toBeDisabled();
   });

--- a/frontend/src/__tests__/StatusBadge.test.tsx
+++ b/frontend/src/__tests__/StatusBadge.test.tsx
@@ -18,4 +18,18 @@ describe('StatusBadge', () => {
     const badge = screen.getByRole('status', { name: /dead letter/i });
     expect(badge).toHaveClass('bg-rose-100');
   });
+
+  it('normalizes spaced dead letter states to danger', () => {
+    render(<StatusBadge status="dead letter" />);
+
+    const badge = screen.getByRole('status', { name: /dead letter/i });
+    expect(badge).toHaveClass('bg-rose-100');
+  });
+
+  it('treats short fail aliases as danger', () => {
+    render(<StatusBadge status="fail" />);
+
+    const badge = screen.getByRole('status', { name: /fail/i });
+    expect(badge).toHaveClass('bg-rose-100');
+  });
 });

--- a/frontend/src/components/StatusBadge.tsx
+++ b/frontend/src/components/StatusBadge.tsx
@@ -27,53 +27,60 @@ const titleCase = (value: string): string =>
     .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
     .join(' ');
 
+const POSITIVE_STATES = new Set([
+  'connected',
+  'ok',
+  'healthy',
+  'online',
+  'completed',
+  'active',
+  'running',
+  'up',
+  'available'
+]);
+
+const WARNING_STATES = new Set([
+  'degraded',
+  'warning',
+  'limited',
+  'uploading',
+  'pending',
+  'queued',
+  'starting',
+  'partial'
+]);
+
+const DANGER_STATES = new Set([
+  'disconnected',
+  'down',
+  'failed',
+  'failure',
+  'fail',
+  'error',
+  'offline',
+  'cancelled',
+  'blocked',
+  'dead_letter',
+  'dead-letter',
+  'deadletter'
+]);
+
 const inferTone = (value: string): StatusTone => {
-  const normalized = value.toLowerCase();
-  if (
-    [
-      'connected',
-      'ok',
-      'healthy',
-      'online',
-      'completed',
-      'active',
-      'running',
-      'up',
-      'available'
-    ].includes(normalized)
-  ) {
+  const normalized = value.trim().toLowerCase();
+  const compact = normalized.replace(/[\s_-]+/gu, '');
+
+  if (POSITIVE_STATES.has(normalized)) {
     return 'positive';
   }
-  if (
-    [
-      'degraded',
-      'warning',
-      'limited',
-      'uploading',
-      'pending',
-      'queued',
-      'starting',
-      'partial'
-    ].includes(normalized)
-  ) {
+
+  if (WARNING_STATES.has(normalized)) {
     return 'warning';
   }
-  if (
-    [
-      'disconnected',
-      'down',
-      'failed',
-      'error',
-      'offline',
-      'cancelled',
-      'blocked',
-      'dead_letter',
-      'dead-letter',
-      'deadletter'
-    ].includes(normalized)
-  ) {
+
+  if (DANGER_STATES.has(normalized) || compact.startsWith('deadletter')) {
     return 'danger';
   }
+
   return 'info';
 };
 


### PR DESCRIPTION
## Summary
- expand StatusBadge tone inference to cover dead-letter aliases and short fail statuses
- assert Soulseek downloads render a danger badge when stuck in dead_letter
- broaden StatusBadge unit coverage for the new tone handling

## Testing
- ⚠️ `npm test -- StatusBadge` *(fails: jest binary unavailable without installing dependencies)*
- ⚠️ `npm install` *(fails: npm registry access forbidden in execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e195f065bc832183cfcee04bdaee79