### PR TITLE
CODX-LOCAL-001: flag integration health outages

### DIFF
--- a/frontend/src/__tests__/LayoutSidebar.test.tsx
+++ b/frontend/src/__tests__/LayoutSidebar.test.tsx
@@ -146,18 +146,20 @@ describe('Layout sidebar interactions', () => {
     expect(indicator).toHaveClass('sr-only');
   });
 
-  it('falls back to plain labels when integration health cannot be loaded', () => {
+  it('shows offline indicators when integration health queries fail', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
     mockedUseIntegrationHealth.mockReturnValue({
       services: {
         soulseek: {
           online: false,
-          degraded: false,
+          degraded: true,
           misconfigured: false,
           status: 'unknown'
         },
         matching: {
           online: false,
-          degraded: false,
+          degraded: true,
           misconfigured: false,
           status: 'unknown'
         }
@@ -174,8 +176,14 @@ describe('Layout sidebar interactions', () => {
       { route: '/dashboard' }
     );
 
-    const soulseekLink = screen.getByRole('link', { name: 'Soulseek' });
-    expect(within(soulseekLink).queryByText(/Offline|Fehler|Eingeschränkt/)).not.toBeInTheDocument();
+    const soulseekLink = screen.getByRole('link', { name: /Soulseek – Warnung: Dienst offline/i });
+    expect(within(soulseekLink).getByText('Offline')).toBeInTheDocument();
+
+    const matchingLink = screen.getByRole('link', { name: /Matching – Warnung: Dienst offline/i });
+    expect(within(matchingLink).getByText('Offline')).toBeInTheDocument();
+
+    expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
   });
 
   it('restores the collapsed state from localStorage and persists user changes', async () => {

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useMemo, useState } from 'react';
+import { ReactNode, useEffect, useMemo, useState } from 'react';
 import { Link, NavLink, useLocation } from 'react-router-dom';
 import { CircleDot, Menu, Moon, PanelLeftClose, PanelLeftOpen, Sun } from 'lucide-react';
 import { cn } from '../lib/utils';
@@ -44,7 +44,16 @@ const Layout = ({ children }: LayoutProps) => {
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const [sidebarCollapsed, setSidebarCollapsed] = usePersistentState<boolean>('layout:sidebarCollapsed', false);
   const location = useLocation();
-  const { services } = useIntegrationHealth();
+  const { services, errors } = useIntegrationHealth();
+
+  useEffect(() => {
+    if (errors.system) {
+      console.warn('System health query failed', errors.system);
+    }
+    if (errors.integrations) {
+      console.warn('Integration health query failed', errors.integrations);
+    }
+  }, [errors.integrations, errors.system]);
 
   const activeTitle = useMemo(() => {
     const match = navigationItems.find((item) => location.pathname.startsWith(item.to));

--- a/frontend/src/hooks/__tests__/useIntegrationHealth.test.ts
+++ b/frontend/src/hooks/__tests__/useIntegrationHealth.test.ts
@@ -1,0 +1,112 @@
+import { renderHook } from '@testing-library/react';
+
+import { useIntegrationHealth } from '../useIntegrationHealth';
+import { useQuery } from '../../lib/query';
+import type { SystemStatusResponse } from '../../api/types';
+import type { IntegrationsData } from '../../api/services/soulseek';
+
+jest.mock('../../lib/query', () => {
+  const actual = jest.requireActual('../../lib/query');
+  return {
+    ...actual,
+    useQuery: jest.fn()
+  };
+});
+
+const mockedUseQuery = useQuery as jest.MockedFunction<typeof useQuery>;
+
+type QueryResult<T> = {
+  data: T | undefined;
+  error: unknown;
+  isLoading: boolean;
+  isError: boolean;
+  refetch: jest.Mock;
+};
+
+const createQueryResult = <T,>(overrides: Partial<QueryResult<T>> = {}): QueryResult<T> => ({
+  data: undefined,
+  error: undefined,
+  isLoading: false,
+  isError: false,
+  refetch: jest.fn(),
+  ...overrides
+});
+
+const joinQueryKey = (queryKey: unknown): string => {
+  if (Array.isArray(queryKey)) {
+    return queryKey.join(':');
+  }
+  return String(queryKey);
+};
+
+describe('useIntegrationHealth', () => {
+  beforeEach(() => {
+    mockedUseQuery.mockReset();
+  });
+
+  it('marks services as degraded when either health query errors', () => {
+    const systemStatus: SystemStatusResponse = {
+      status: 'ok',
+      connections: {
+        soulseek: 'ok',
+        matching: 'ok'
+      }
+    };
+    const integrations: IntegrationsData = {
+      overall: 'ok',
+      providers: [
+        { name: 'soulseek', status: 'ok' },
+        { name: 'matching', status: 'ok' }
+      ]
+    };
+
+    mockedUseQuery.mockImplementation(({ queryKey }) => {
+      const key = joinQueryKey(queryKey);
+      if (key === 'system:status') {
+        return createQueryResult<SystemStatusResponse>({
+          data: systemStatus,
+          error: new Error('downstream unavailable'),
+          isError: true
+        });
+      }
+      if (key === 'integrations:overview') {
+        return createQueryResult<IntegrationsData>({
+          data: integrations
+        });
+      }
+      throw new Error(`Unexpected query key: ${key}`);
+    });
+
+    const { result } = renderHook(() => useIntegrationHealth());
+
+    expect(result.current.services.soulseek.degraded).toBe(true);
+    expect(result.current.services.soulseek.online).toBe(false);
+    expect(result.current.services.matching.degraded).toBe(true);
+    expect(result.current.services.matching.online).toBe(false);
+  });
+
+  it('flags services as degraded when payloads are missing after loading', () => {
+    mockedUseQuery.mockImplementation(({ queryKey }) => {
+      const key = joinQueryKey(queryKey);
+      if (key === 'system:status') {
+        return createQueryResult<SystemStatusResponse>({
+          data: undefined,
+          isLoading: false
+        });
+      }
+      if (key === 'integrations:overview') {
+        return createQueryResult<IntegrationsData>({
+          data: undefined,
+          isLoading: false
+        });
+      }
+      throw new Error(`Unexpected query key: ${key}`);
+    });
+
+    const { result } = renderHook(() => useIntegrationHealth());
+
+    expect(result.current.services.soulseek.degraded).toBe(true);
+    expect(result.current.services.soulseek.online).toBe(false);
+    expect(result.current.services.matching.degraded).toBe(true);
+  });
+});


### PR DESCRIPTION
## Kurzfassung
**Was/Warum:** Markiert Integrationsdienste bei fehlgeschlagenen Health-Abfragen als gestört, damit die Sidebar weiterhin Ausfälle signalisiert und loggt die Fehler für Transparenz.
**TASK_ID:** CODX-LOCAL-001

## Änderungen (Dateien)
- Neu/Geändert/Gelöscht:
  - Geändert: `frontend/src/hooks/useIntegrationHealth.ts`, `frontend/src/components/Layout.tsx`, `frontend/src/__tests__/LayoutSidebar.test.tsx`
  - Neu: `frontend/src/hooks/__tests__/useIntegrationHealth.test.ts`

## Tests & Nachweise
- Befehle/Logs/Screens:
  - `npm test -- LayoutSidebar useIntegrationHealth` *(fehlgeschlagen: "> jest: not found" – Abhängigkeiten im Container nicht installiert)*
- Coverage (geänderte Module): ≥ 85 % | Begründete Ausnahme: Frontend-Tests konnten wegen fehlender `jest`-Binary nicht ausgeführt werden.

## Verträge
- Public-API: unverändert
- DB/Migration: nein

## Migration & Deployment
- Migration ausgeführt (`alembic upgrade head`): nein
- ENV-Defaults geprüft/kommuniziert (siehe README „Orchestrator & Queue-Steuerung“, `docs/workers.md`): keine Änderungen erforderlich

## Doku & ToDo
- README/CHANGELOG/ADR aktualisiert: nein
- ToDo.md aktualisiert (Nachweis-Link): nicht erforderlich – keine neuen Aufgaben identifiziert

## Checkliste
- [x] AGENTS.md gelesen & Scope-Guard geprüft
- [x] Keine Secrets/`BACKUP`/Lizenzdateien verändert
- [ ] `pytest -q`, `mypy app`, `ruff`, `black --check` grün oder Ausnahme dokumentiert *(Frontend-only Änderung; Jest im Container nicht verfügbar)*

------
https://chatgpt.com/codex/tasks/task_e_68e196cc0fd88321b4af681672335e89