### PR TITLE
feat: expose retryable Soulseek download states

### DIFF
--- a/app/routers/soulseek_router.py
+++ b/app/routers/soulseek_router.py
@@ -27,6 +27,7 @@ from app.schemas import (
     SoulseekDownloadRequest,
     SoulseekDownloadResponse,
     SoulseekDownloadStatus,
+    SOULSEEK_RETRYABLE_STATES,
     SoulseekSearchRequest,
     SoulseekSearchResponse,
     StatusResponse,
@@ -574,7 +575,10 @@ def soulseek_downloads(session: Session = Depends(get_db)) -> SoulseekDownloadSt
 
     stmt = select(Download).order_by(Download.created_at.desc())
     downloads = session.execute(stmt).scalars().all()
-    return SoulseekDownloadStatus(downloads=downloads)
+    return SoulseekDownloadStatus(
+        downloads=downloads,
+        retryable_states=list(SOULSEEK_RETRYABLE_STATES),
+    )
 
 
 @router.post("/downloads/{download_id}/requeue", status_code=202)

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -122,6 +122,7 @@ export interface SoulseekDownloadEntry {
 
 export interface SoulseekDownloadsResponse {
   downloads?: unknown;
+  retryable_states?: unknown;
 }
 
 export interface ProviderInfo {

--- a/frontend/src/components/SoulseekDownloadList.tsx
+++ b/frontend/src/components/SoulseekDownloadList.tsx
@@ -21,8 +21,6 @@ const formatStateLabel = (state: string): string => {
   return labels[normalized] ?? state.charAt(0).toUpperCase() + state.slice(1);
 };
 
-const RETRYABLE_STATES = new Set(['failed']);
-
 const formatTimestamp = (value: string | null): string | null => {
   if (!value) {
     return null;
@@ -59,6 +57,7 @@ export interface SoulseekDownloadListProps {
   onRetryDownload?: (download: NormalizedSoulseekDownload) => void;
   retryingDownloadId?: string | null;
   isRetryPending?: boolean;
+  retryableStates?: readonly string[];
 }
 
 const SoulseekDownloadList = ({
@@ -68,8 +67,15 @@ const SoulseekDownloadList = ({
   onRetryFetch,
   onRetryDownload,
   retryingDownloadId,
-  isRetryPending = false
+  isRetryPending = false,
+  retryableStates
 }: SoulseekDownloadListProps) => {
+  const normalizedRetryableStates = new Set(
+    (retryableStates && retryableStates.length > 0 ? retryableStates : ['failed']).map((state) =>
+      state.toLowerCase()
+    )
+  );
+
   if (isLoading) {
     return <p className="text-sm text-muted-foreground">Downloads werden geladen …</p>;
   }
@@ -116,7 +122,10 @@ const SoulseekDownloadList = ({
           const hasIdentifier = Boolean(normalizedId);
           const isDeadLetter = normalizedState === 'dead_letter';
           const canRetry =
-            Boolean(onRetryDownload) && hasIdentifier && !isDeadLetter && RETRYABLE_STATES.has(normalizedState);
+            Boolean(onRetryDownload) &&
+            hasIdentifier &&
+            !isDeadLetter &&
+            normalizedRetryableStates.has(normalizedState);
           const isQueuedForRetry = Boolean(
             hasIdentifier && retryingDownloadId != null && normalizedId === retryingDownloadId
           );

--- a/frontend/src/pages/SoulseekPage.tsx
+++ b/frontend/src/pages/SoulseekPage.tsx
@@ -15,6 +15,7 @@ import {
   type NormalizedSoulseekDownload,
   type NormalizedSoulseekUpload,
   type SoulseekConfigurationEntry,
+  type SoulseekDownloadsResult,
   SoulseekRequeueError
 } from '../api/services/soulseek';
 import type { SoulseekConnectionStatus } from '../api/types';
@@ -98,7 +99,7 @@ const SoulseekPage = () => {
     queryFn: () => getSoulseekUploads({ includeAll: showAllUploads })
   });
 
-  const downloadsQuery = useQuery<NormalizedSoulseekDownload[]>({
+  const downloadsQuery = useQuery<SoulseekDownloadsResult>({
     queryKey: ['soulseek', 'downloads', showAllDownloads ? 'all' : 'active'],
     queryFn: () => getSoulseekDownloads({ includeAll: showAllDownloads })
   });
@@ -382,13 +383,14 @@ const SoulseekPage = () => {
         </CardHeader>
         <CardContent>
           <SoulseekDownloadList
-            downloads={downloadsQuery.data}
+            downloads={downloadsQuery.data?.downloads}
             isLoading={downloadsQuery.isLoading}
             isError={downloadsQuery.isError}
             onRetryFetch={() => downloadsQuery.refetch()}
             onRetryDownload={handleRetryDownload}
             retryingDownloadId={retryingDownloadId}
             isRetryPending={isRequeuePending}
+            retryableStates={downloadsQuery.data?.retryableStates}
           />
         </CardContent>
       </Card>

--- a/tests/snapshots/openapi.json
+++ b/tests/snapshots/openapi.json
@@ -2558,6 +2558,13 @@
             },
             "title": "Downloads",
             "type": "array"
+          },
+          "retryable_states": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Retryable States",
+            "type": "array"
           }
         },
         "required": [


### PR DESCRIPTION
## Summary
- surface retryable Soulseek download states via the API schema and response so clients can detect server-approved retries
- teach the frontend service, page and download list to use the reported retryable states instead of hard-coded values
- extend backend and frontend tests plus the OpenAPI snapshot to cover the new field and dynamic retry logic

## Testing
- pytest tests/test_soulseek.py
- npm test -- SoulseekPage *(fails: jest binary missing before dependencies install)*
- npm install *(fails: registry access for @radix-ui/react-toast is forbidden in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e20df45ed08321854e354b7e95cde1