### PR TITLE
TASK_ID: Reload orchestrator retry policy defaults

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -950,6 +950,17 @@ def _load_retry_policy(env: Mapping[str, Any]) -> RetryPolicyConfig:
     )
 
 
+def resolve_retry_policy(env: Mapping[str, Any] | None = None) -> RetryPolicyConfig:
+    """Load the retry policy configuration from the provided environment."""
+
+    env_map: Mapping[str, Any]
+    if env is None:
+        env_map = os.environ
+    else:
+        env_map = env
+    return _load_retry_policy(env_map)
+
+
 settings = Settings.load()
 
 log_event(

--- a/tests/config/test_orchestrator_config.py
+++ b/tests/config/test_orchestrator_config.py
@@ -66,9 +66,10 @@ def test_load_sync_retry_policy_uses_settings(monkeypatch) -> None:
         "RETRY_JITTER_PCT": "10",
     }
     config = Settings.load(env)
-    monkeypatch.setattr(orchestrator_handlers, "settings", config)
 
-    policy = orchestrator_handlers.load_sync_retry_policy()
+    policy = orchestrator_handlers.load_sync_retry_policy(
+        defaults=config.retry_policy
+    )
 
     assert policy.max_attempts == 4
     assert policy.base_seconds == 45.0

--- a/tests/orchestrator/test_retry_policy.py
+++ b/tests/orchestrator/test_retry_policy.py
@@ -1,0 +1,20 @@
+"""Tests for orchestrator retry policy configuration reloading."""
+
+from __future__ import annotations
+
+from app.orchestrator import handlers
+
+
+def test_retry_policy_respects_environment_overrides(monkeypatch) -> None:
+    """Environment changes should take effect on the next policy load."""
+
+    monkeypatch.delenv("RETRY_MAX_ATTEMPTS", raising=False)
+    monkeypatch.setenv("RETRY_MAX_ATTEMPTS", "3")
+
+    first_policy = handlers.load_sync_retry_policy()
+    assert first_policy.max_attempts == 3
+
+    monkeypatch.setenv("RETRY_MAX_ATTEMPTS", "7")
+
+    updated_policy = handlers.load_sync_retry_policy()
+    assert updated_policy.max_attempts == 7


### PR DESCRIPTION
TASK_ID: N/A

## Summary
- add a helper in the configuration layer to resolve retry policy defaults from the current environment
- update the orchestrator retry policy loader to use the helper and support optional overrides
- add regression coverage ensuring environment overrides take effect immediately

## Testing
- pytest tests/orchestrator/test_retry_policy.py

No ToDo changes required.

------
https://chatgpt.com/codex/tasks/task_e_68e22cbf1c1483218db5ad0b7fc786b9