### PR TITLE
fix: invalidate playlist cache after sync updates

### DIFF
--- a/app/routers/sync_router.py
+++ b/app/routers/sync_router.py
@@ -116,7 +116,14 @@ def _get_playlist_worker(request: Request) -> PlaylistSyncWorker | None:
     except Exception as exc:  # pragma: no cover - defensive logging
         logger.error("Unable to initialise Spotify client for playlist sync: %s", exc)
         return None
-    worker = PlaylistSyncWorker(spotify_client, interval_seconds=900.0)
+    response_cache = getattr(request.app.state, "response_cache", None)
+    api_base_path = getattr(request.app.state, "api_base_path", "") or ""
+    worker = PlaylistSyncWorker(
+        spotify_client,
+        interval_seconds=900.0,
+        response_cache=response_cache,
+        api_base_path=api_base_path,
+    )
     request.app.state.playlist_worker = worker
     return worker
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1400,7 +1400,10 @@ def client(monkeypatch: pytest.MonkeyPatch) -> SimpleTestClient:
         test_client.app.state.lyrics_worker = stub_lyrics
         test_client.app.state.sync_worker = SyncWorker(stub_soulseek, lyrics_worker=stub_lyrics)
         test_client.app.state.playlist_worker = PlaylistSyncWorker(
-            stub_spotify, interval_seconds=0.1
+            stub_spotify,
+            interval_seconds=0.1,
+            response_cache=getattr(test_client.app.state, "response_cache", None),
+            api_base_path=getattr(test_client.app.state, "api_base_path", "") or "",
         )
         test_client.app.state.provider_gateway_stub = stub_gateway
         test_client.app.state.integration_service_stub = stub_service


### PR DESCRIPTION
## Summary
- ensure the playlist sync worker invalidates cached playlist listings after persisting updates
- pass the FastAPI response cache and API base path to the worker in router and test fixtures
- extend the Spotify playlist integration test to verify cache refresh via ETag changes after updates

- No ToDo changes required.

## Testing
- pytest tests/test_spotify.py::test_playlist_sync_worker_persists_playlists

------
https://chatgpt.com/codex/tasks/task_e_68e22e5241908321972d9a45401d4b77