### PR TITLE
chore: fix lint warnings and document lint workflow

### DIFF
--- a/app/api/cache_policy.py
+++ b/app/api/cache_policy.py
@@ -40,9 +40,7 @@ CACHEABLE_RESPONSES: Final[Mapping[int, Mapping[str, object]]] = {
             "Successful response with cache metadata. Subsequent cache hits may "
             "include an Age header."
         ),
-        "headers": {
-            key: value for key, value in _CACHE_POLICY_HEADERS.items() if key != "Age"
-        },
+        "headers": {key: value for key, value in _CACHE_POLICY_HEADERS.items() if key != "Age"},
     },
     304: {
         "description": _CACHE_HEADERS_DESCRIPTION,

--- a/app/api/spotify.py
+++ b/app/api/spotify.py
@@ -81,12 +81,8 @@ class TrackIdsPayload(BaseModel):
 
 class SpotifyStatusResponse(BaseModel):
     status: Literal["connected", "unauthenticated", "unconfigured"]
-    free_available: bool = Field(
-        ..., description="Whether FREE ingest features are available."
-    )
-    pro_available: bool = Field(
-        ..., description="Whether Spotify API integrations are configured."
-    )
+    free_available: bool = Field(..., description="Whether FREE ingest features are available.")
+    pro_available: bool = Field(..., description="Whether Spotify API integrations are configured.")
     authenticated: bool = Field(
         ..., description="Indicates if the Spotify client currently holds a valid session."
     )

--- a/app/config.py
+++ b/app/config.py
@@ -712,9 +712,7 @@ def _parse_optional_int(
         logger.warning("Ignoring invalid integer override value: %s", value)
         return None
     if minimum is not None and resolved < minimum:
-        logger.warning(
-            "Integer override %s below minimum %s; clamping", value, minimum
-        )
+        logger.warning("Integer override %s below minimum %s; clamping", value, minimum)
         resolved = minimum
     if maximum is not None and resolved > maximum:
         resolved = maximum
@@ -735,9 +733,7 @@ def _parse_optional_float(
         logger.warning("Ignoring invalid float override value: %s", value)
         return None
     if minimum is not None and resolved < minimum:
-        logger.warning(
-            "Float override %s below minimum %s; clamping", value, minimum
-        )
+        logger.warning("Float override %s below minimum %s; clamping", value, minimum)
         resolved = minimum
     if maximum is not None and resolved > maximum:
         resolved = maximum
@@ -898,14 +894,10 @@ def _load_environment_config(env: Mapping[str, Any]) -> EnvironmentConfig:
     workers_enabled_raw = env.get("WORKERS_ENABLED")
     workers_enabled_override = _parse_bool_override(workers_enabled_raw)
     disable_workers = _as_bool(
-        str(env.get("HARMONY_DISABLE_WORKERS"))
-        if "HARMONY_DISABLE_WORKERS" in env
-        else None,
+        str(env.get("HARMONY_DISABLE_WORKERS")) if "HARMONY_DISABLE_WORKERS" in env else None,
         default=False,
     )
-    visibility_override = _parse_optional_int(
-        env.get("WORKER_VISIBILITY_TIMEOUT_S"), minimum=5
-    )
+    visibility_override = _parse_optional_int(env.get("WORKER_VISIBILITY_TIMEOUT_S"), minimum=5)
     watchlist_interval = _parse_optional_float(env.get("WATCHLIST_INTERVAL"))
     watchlist_timer_enabled = _parse_bool_override(env.get("WATCHLIST_TIMER_ENABLED"))
 
@@ -1365,9 +1357,7 @@ def load_config() -> AppConfig:
     post_processors_raw = os.getenv("ARTWORK_POST_PROCESSORS")
     if post_processors_raw:
         processor_entries = post_processors_raw.replace("\n", ",").split(",")
-        post_processors = tuple(
-            entry.strip() for entry in processor_entries if entry.strip()
-        )
+        post_processors = tuple(entry.strip() for entry in processor_entries if entry.strip())
     else:
         post_processors = ()
 
@@ -1660,9 +1650,7 @@ def load_config() -> AppConfig:
     require_auth_override = _parse_bool_override(os.getenv("FEATURE_REQUIRE_AUTH"))
     rate_limit_override = _parse_bool_override(os.getenv("FEATURE_RATE_LIMITING"))
     rate_limit_enabled = (
-        security_defaults.rate_limiting
-        if rate_limit_override is None
-        else rate_limit_override
+        security_defaults.rate_limiting if rate_limit_override is None else rate_limit_override
     )
 
     rate_limit_config = RateLimitMiddlewareConfig(

--- a/app/db.py
+++ b/app/db.py
@@ -174,17 +174,13 @@ __all__ = [
 ]
 
 
-def _call_with_session(
-    func: SessionCallable[T], *, factory: SessionFactory | None = None
-) -> T:
+def _call_with_session(func: SessionCallable[T], *, factory: SessionFactory | None = None) -> T:
     context = factory() if factory is not None else session_scope()
     with context as session:
         return func(session)
 
 
-async def run_session(
-    func: SessionCallable[T], *, factory: SessionFactory | None = None
-) -> T:
+async def run_session(func: SessionCallable[T], *, factory: SessionFactory | None = None) -> T:
     """Execute ``func`` with a database session in a worker thread."""
 
     return await asyncio.to_thread(_call_with_session, func, factory=factory)

--- a/app/integrations/normalizers.py
+++ b/app/integrations/normalizers.py
@@ -371,9 +371,7 @@ def normalize_slskd_track(
     album = None
     if album_name:
         album_metadata = {
-            key: metadata[key]
-            for key in _TRACK_COUNT_KEYS
-            if metadata.get(key) is not None
+            key: metadata[key] for key in _TRACK_COUNT_KEYS if metadata.get(key) is not None
         }
         album = ProviderAlbum(
             name=album_name,

--- a/app/main.py
+++ b/app/main.py
@@ -4,12 +4,12 @@ from __future__ import annotations
 
 import asyncio
 import inspect
-from collections.abc import AsyncIterator, Awaitable, Callable
+from collections.abc import AsyncIterator, Callable
 from contextlib import asynccontextmanager
 from datetime import datetime, timezone
 from typing import Any, Mapping
 
-from fastapi import APIRouter, FastAPI, Request, Response
+from fastapi import APIRouter, FastAPI
 from fastapi.openapi.utils import get_openapi
 
 from app.api import router_registry
@@ -142,11 +142,7 @@ def _resolve_watchlist_interval(override: float | None) -> float:
 
 
 def _resolve_visibility_timeout(override: int | None) -> int:
-    resolved = (
-        override
-        if override is not None
-        else settings.orchestrator.visibility_timeout_s
-    )
+    resolved = override if override is not None else settings.orchestrator.visibility_timeout_s
     return max(5, resolved)
 
 

--- a/app/orchestrator/dispatcher.py
+++ b/app/orchestrator/dispatcher.py
@@ -249,7 +249,9 @@ class Dispatcher:
             except Exception as exc:
                 stop_heartbeat.set()
                 lease_lost_event = lease_lost_signal
-                lease_lost = bool(lease_lost_event.is_set()) if lease_lost_event is not None else False
+                lease_lost = (
+                    bool(lease_lost_event.is_set()) if lease_lost_event is not None else False
+                )
                 await self._handle_failure(job, exc, start, lease_lost=lease_lost)
             else:
                 if lease_lost_triggered:

--- a/app/orchestrator/handlers.py
+++ b/app/orchestrator/handlers.py
@@ -153,9 +153,7 @@ def load_sync_retry_policy(
         resolved_defaults.base_seconds,
     )
 
-    resolved_jitter = (
-        jitter_pct if jitter_pct is not None else resolved_defaults.jitter_pct
-    )
+    resolved_jitter = jitter_pct if jitter_pct is not None else resolved_defaults.jitter_pct
     try:
         resolved_jitter = float(resolved_jitter)
     except (TypeError, ValueError):

--- a/app/schemas/__init__.py
+++ b/app/schemas/__init__.py
@@ -159,7 +159,7 @@ class DownloadFileRequest(BaseModel):
 
     @property
     def resolved_filename(self) -> str:
-        return (self.filename or self.name or "unknown")
+        return self.filename or self.name or "unknown"
 
     def to_payload(self) -> Dict[str, Any]:
         payload = self.model_dump(by_alias=True, exclude_none=True)
@@ -169,9 +169,7 @@ class DownloadFileRequest(BaseModel):
 
 class SoulseekDownloadRequest(BaseModel):
     username: str = Field(..., description="Soulseek username hosting the files")
-    files: List[DownloadFileRequest] = Field(
-        ..., description="List of files to download"
-    )
+    files: List[DownloadFileRequest] = Field(..., description="List of files to download")
 
     @field_validator("username")
     @classmethod
@@ -227,9 +225,7 @@ def _default_retryable_states() -> List[str]:
     allowed_db_states = set(_CANONICAL_DOWNLOAD_STATE_MAP.keys()) - set(
         _REQUEUE_PROHIBITED_DB_STATES
     )
-    canonical_states = {
-        _canonical_download_state(state) for state in allowed_db_states
-    }
+    canonical_states = {_canonical_download_state(state) for state in allowed_db_states}
     return sorted(canonical_states)
 
 

--- a/app/services/download_service.py
+++ b/app/services/download_service.py
@@ -146,9 +146,7 @@ class DownloadService:
         offset: int,
     ) -> List[Download]:
         try:
-            query = self._build_download_query(
-                include_all=include_all, status_filter=status_filter
-            )
+            query = self._build_download_query(include_all=include_all, status_filter=status_filter)
             return query.offset(offset).limit(limit).all()
         except AppError:
             raise
@@ -347,9 +345,7 @@ class DownloadService:
         }
 
     async def retry_download(self, download_id: int) -> Dict[str, Any]:
-        original = await self._run_session(
-            lambda session: _prepare_retry(session, download_id)
-        )
+        original = await self._run_session(lambda session: _prepare_retry(session, download_id))
 
         try:
             await self._transfers.cancel_download(download_id)
@@ -472,9 +468,7 @@ def _mark_downloads_failed(session: Session, download_ids: Sequence[int]) -> Non
         return
 
     try:
-        downloads = (
-            session.query(Download).filter(Download.id.in_(tuple(download_ids))).all()
-        )
+        downloads = session.query(Download).filter(Download.id.in_(tuple(download_ids))).all()
         now = datetime.utcnow()
         for download in downloads:
             download.state = "failed"
@@ -543,14 +537,10 @@ def _prepare_retry(session: Session, download_id: int) -> RetryPreparation:
     filename = payload_copy.get("filename") or download.filename
     if not filename:
         logger.error("Retry rejected for download %s due to missing filename", download_id)
-        raise ValidationAppError(
-            "Download cannot be retried because filename is unknown"
-        )
+        raise ValidationAppError("Download cannot be retried because filename is unknown")
 
     filesize = (
-        payload_copy.get("filesize")
-        or payload_copy.get("size")
-        or payload_copy.get("file_size")
+        payload_copy.get("filesize") or payload_copy.get("size") or payload_copy.get("file_size")
     )
     if filesize is not None:
         payload_copy.setdefault("filesize", filesize)

--- a/app/workers/artwork_worker.py
+++ b/app/workers/artwork_worker.py
@@ -787,9 +787,7 @@ class ArtworkWorker:
                     },
                 )
 
-    def _import_post_processors(
-        self, dotted_paths: Sequence[str]
-    ) -> list[PostProcessingHook]:
+    def _import_post_processors(self, dotted_paths: Sequence[str]) -> list[PostProcessingHook]:
         hooks: list[PostProcessingHook] = []
         for path in dotted_paths:
             if not path:

--- a/app/workers/lyrics_worker.py
+++ b/app/workers/lyrics_worker.py
@@ -190,9 +190,7 @@ class LyricsWorker:
             return {"lyrics": result}
         return None
 
-    async def _update_download(
-        self, download_id: int, *, status: str, path: str | None
-    ) -> None:
+    async def _update_download(self, download_id: int, *, status: str, path: str | None) -> None:
 
         def _apply(session: Session) -> None:
             download = session.get(Download, int(download_id))

--- a/app/workers/persistence.py
+++ b/app/workers/persistence.py
@@ -88,18 +88,15 @@ def _resolve_visibility_timeout(payload: Mapping[str, Any], override: int | None
 
     payload_value = payload.get("visibility_timeout")
     from app.dependencies import get_app_config  # lazy import to avoid circular dependency
+
     config = get_app_config()
     worker_env = config.environment.workers
     env_override = worker_env.visibility_timeout_s
     resolved_default = (
-        env_override
-        if env_override is not None
-        else settings.orchestrator.visibility_timeout_s
+        env_override if env_override is not None else settings.orchestrator.visibility_timeout_s
     )
     try:
-        payload_resolved = (
-            int(payload_value) if payload_value is not None else resolved_default
-        )
+        payload_resolved = int(payload_value) if payload_value is not None else resolved_default
     except (TypeError, ValueError):
         payload_resolved = resolved_default
     return max(5, payload_resolved)
@@ -725,9 +722,7 @@ async def lease_async(
 ) -> QueueJobDTO | None:
     """Async wrapper around :func:`lease`."""
 
-    return await asyncio.to_thread(
-        lease, job_id, job_type=job_type, lease_seconds=lease_seconds
-    )
+    return await asyncio.to_thread(lease, job_id, job_type=job_type, lease_seconds=lease_seconds)
 
 
 async def complete_async(

--- a/app/workers/playlist_sync_worker.py
+++ b/app/workers/playlist_sync_worker.py
@@ -148,9 +148,7 @@ class PlaylistSyncWorker:
             try:
                 await self._response_cache.invalidate_prefix(prefix)
             except Exception as exc:  # pragma: no cover - defensive guard
-                logger.warning(
-                    "Failed to invalidate playlist cache prefix %s: %s", prefix, exc
-                )
+                logger.warning("Failed to invalidate playlist cache prefix %s: %s", prefix, exc)
 
     def _resolve_cache_prefixes(self) -> tuple[str, ...]:
         if self._cache_prefixes is not None:

--- a/docs/backend-guidelines.md
+++ b/docs/backend-guidelines.md
@@ -53,8 +53,14 @@ Diese Guidelines definieren Standards für den Aufbau und die Pflege von Backend
 - CI führt Tests und Linter standardmäßig aus.  
 
 ## 8. Dokumentation
-- API-Endpunkte mit Beispielen dokumentieren (Markdown, OpenAPI).  
-- Architekturübersicht (Schichten, Hauptmodule).  
-- Worker-Dokumentation (Aufgabe, Intervalle, Fehlerbehandlung).  
-- Changelog nach [Keep a Changelog](https://keepachangelog.com/).  
+- API-Endpunkte mit Beispielen dokumentieren (Markdown, OpenAPI).
+- Architekturübersicht (Schichten, Hauptmodule).
+- Worker-Dokumentation (Aufgabe, Intervalle, Fehlerbehandlung).
+- Changelog nach [Keep a Changelog](https://keepachangelog.com/).
+
+## 9. Linting & Formatting
+- Vor jedem Commit sind die Python-Linting- und Format-Gates lokal auszuführen.
+- Verwende `ruff check --fix app tests`, um alle automatisierbaren Verstöße direkt zu beheben.
+- Ergänzend stellt `black app tests` sicher, dass der Code konsistent formatiert ist; `black --check app tests` verifiziert den Status für die CI.
+- Läuft `ruff check app tests` ohne Findings, müssen verbliebene Hinweise (z. B. ungenutzte Importe) manuell adressiert werden.
 

--- a/tests/api/test_spotify_free_ingest.py
+++ b/tests/api/test_spotify_free_ingest.py
@@ -46,7 +46,9 @@ async def test_free_ingest_pipeline_uses_async_db_executor(
 ) -> None:
     delay = 0.25
     original_runner = get_session_runner()
-    client.app.dependency_overrides[get_session_runner] = lambda: _slow_runner(delay, original_runner)
+    client.app.dependency_overrides[get_session_runner] = lambda: _slow_runner(
+        delay, original_runner
+    )
 
     ticker_count = 0
 

--- a/tests/config/test_orchestrator_config.py
+++ b/tests/config/test_orchestrator_config.py
@@ -67,9 +67,7 @@ def test_load_sync_retry_policy_uses_settings(monkeypatch) -> None:
     }
     config = Settings.load(env)
 
-    policy = orchestrator_handlers.load_sync_retry_policy(
-        defaults=config.retry_policy
-    )
+    policy = orchestrator_handlers.load_sync_retry_policy(defaults=config.retry_policy)
 
     assert policy.max_attempts == 4
     assert policy.base_seconds == 45.0

--- a/tests/core/test_matching_engine_album_tracks.py
+++ b/tests/core/test_matching_engine_album_tracks.py
@@ -1,5 +1,3 @@
-import pytest
-
 from app.core.matching_engine import calculate_slskd_match_confidence
 from app.core.types import ensure_track_dto
 

--- a/tests/logging/test_router_events.py
+++ b/tests/logging/test_router_events.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import importlib
 import sys
 from types import SimpleNamespace
-from typing import Any, cast
+from typing import Any
 
 import pytest
 from fastapi import HTTPException
@@ -126,25 +126,18 @@ async def test_soulseek_status_failure_logs_error_event(caplog, monkeypatch) -> 
 
 
 @pytest.mark.asyncio
-async def test_sync_router_missing_credentials_logs_blocked_event(
-    caplog, monkeypatch
-) -> None:
+async def test_sync_router_missing_credentials_logs_blocked_event(caplog, monkeypatch) -> None:
     monkeypatch.setattr(sync_router_module.logger, "disabled", False)
+
     async def fake_missing_credentials(session_runner):  # pragma: no cover - simple stub
         return {"spotify": ("token",)}
 
-    monkeypatch.setattr(
-        sync_router_module, "_missing_credentials", fake_missing_credentials
-    )
-    monkeypatch.setattr(
-        sync_router_module, "record_activity", lambda *args, **kwargs: None
-    )
+    monkeypatch.setattr(sync_router_module, "_missing_credentials", fake_missing_credentials)
+    monkeypatch.setattr(sync_router_module, "record_activity", lambda *args, **kwargs: None)
 
     with caplog.at_level("INFO", logger="app.routers.sync_router"):
         with pytest.raises(HTTPException):
-            await sync_router_module.trigger_manual_sync(
-                request=object(), session_runner=None
-            )
+            await sync_router_module.trigger_manual_sync(request=object(), session_runner=None)
 
     record = _first_record(caplog, "api.sync.trigger")
     assert record.component == "router.sync"

--- a/tests/orchestrator/test_dispatcher.py
+++ b/tests/orchestrator/test_dispatcher.py
@@ -180,9 +180,7 @@ async def test_dispatcher_executes_job_and_marks_complete(
     assert storage.dlq_calls == []
 
     commit_events = [
-        payload
-        for event_name, payload in captured_events
-        if event_name == "orchestrator.commit"
+        payload for event_name, payload in captured_events if event_name == "orchestrator.commit"
     ]
     assert commit_events
     payload = commit_events[-1]
@@ -192,9 +190,7 @@ async def test_dispatcher_executes_job_and_marks_complete(
     assert payload["attempts"] == 1
 
     heartbeat_events = [
-        payload
-        for event_name, payload in captured_events
-        if event_name == "orchestrator.heartbeat"
+        payload for event_name, payload in captured_events if event_name == "orchestrator.heartbeat"
     ]
     assert heartbeat_events
     assert heartbeat_events[-1]["status"] == "stopped"
@@ -238,9 +234,7 @@ async def test_dispatcher_retries_with_backoff(
     assert storage.complete_calls == []
 
     commit_events = [
-        payload
-        for event_name, payload in captured_events
-        if event_name == "orchestrator.commit"
+        payload for event_name, payload in captured_events if event_name == "orchestrator.commit"
     ]
     assert commit_events
     payload = commit_events[-1]
@@ -300,9 +294,7 @@ async def test_dispatcher_moves_job_to_dlq_when_retries_exhausted(
     assert storage.complete_calls == []
 
     dlq_events = [
-        payload
-        for event_name, payload in captured_events
-        if event_name == "orchestrator.dlq"
+        payload for event_name, payload in captured_events if event_name == "orchestrator.dlq"
     ]
     assert dlq_events
     payload = dlq_events[-1]
@@ -361,14 +353,12 @@ async def test_dispatcher_stops_job_when_lease_lost(
     assert "lost" in heartbeat_statuses
     assert heartbeat_records[-1].job_type == "sync"
 
-    assert not any(
-        record.getMessage() == "orchestrator.commit" for record in caplog.records
-    )
+    assert not any(record.getMessage() == "orchestrator.commit" for record in caplog.records)
 
 
 @pytest.mark.asyncio
 async def test_handle_failure_skips_when_lease_lost(
-    captured_events: list[tuple[str, Mapping[str, Any]]]
+    captured_events: list[tuple[str, Mapping[str, Any]]],
 ) -> None:
     scheduler = StubScheduler([[]])
     storage = StubPersistence()
@@ -393,9 +383,7 @@ async def test_handle_failure_skips_when_lease_lost(
     assert storage.dlq_calls == []
 
     heartbeat_events = [
-        payload
-        for event_name, payload in captured_events
-        if event_name == "orchestrator.heartbeat"
+        payload for event_name, payload in captured_events if event_name == "orchestrator.heartbeat"
     ]
     assert heartbeat_events
     assert heartbeat_events[-1]["status"] == "skip_failure"

--- a/tests/routers/test_async_db_responsiveness.py
+++ b/tests/routers/test_async_db_responsiveness.py
@@ -66,7 +66,9 @@ async def test_free_import_uses_async_session(
 ) -> None:
     delay = 0.2
     original_runner = get_session_runner()
-    client.app.dependency_overrides[get_session_runner] = lambda: _slow_runner(delay, original_runner)
+    client.app.dependency_overrides[get_session_runner] = lambda: _slow_runner(
+        delay, original_runner
+    )
 
     try:
         async with time_budget.limit(0.75) as elapsed:
@@ -95,7 +97,9 @@ async def test_manual_sync_checks_credentials_off_thread(
 ) -> None:
     delay = 0.2
     original_runner = get_session_runner()
-    client.app.dependency_overrides[get_session_runner] = lambda: _slow_runner(delay, original_runner)
+    client.app.dependency_overrides[get_session_runner] = lambda: _slow_runner(
+        delay, original_runner
+    )
 
     playlist_calls = {"count": 0}
 
@@ -195,9 +199,7 @@ async def test_download_retry_uses_async_session(
 
     try:
         async with time_budget.limit(0.75) as elapsed:
-            response = await async_client.post(
-                api_path(f"/download/{download_id}/retry")
-            )
+            response = await async_client.post(api_path(f"/download/{download_id}/retry"))
         assert response.status_code == 202
         assert elapsed() >= delay
     finally:

--- a/tests/routers/test_download_errors.py
+++ b/tests/routers/test_download_errors.py
@@ -108,7 +108,4 @@ def test_retry_download_invalid_state_returns_validation_error(
     body = response.json()
     assert body["ok"] is False
     assert body["error"]["code"] == "VALIDATION_ERROR"
-    assert (
-        body["error"]["message"]
-        == "Download cannot be retried in its current state"
-    )
+    assert body["error"]["message"] == "Download cannot be retried in its current state"

--- a/tests/routers/test_request_deadlines.py
+++ b/tests/routers/test_request_deadlines.py
@@ -13,9 +13,7 @@ from tests.fixtures.async_client import AsyncDeadlineClient
 from tests.helpers import api_path
 
 
-def _install_slow_session_runner(
-    monkeypatch: pytest.MonkeyPatch, delay: float
-) -> None:
+def _install_slow_session_runner(monkeypatch: pytest.MonkeyPatch, delay: float) -> None:
     original_db_run_session = db.run_session
 
     async def slow_run_session(func, *, factory=None):

--- a/tests/services/test_cache_logging_and_ttl.py
+++ b/tests/services/test_cache_logging_and_ttl.py
@@ -89,6 +89,7 @@ async def test_zero_ttl_entry_expires_immediately(monkeypatch) -> None:
 
     assert await cache.get("key") is None
 
+
 def _last_service_event(events: list[tuple[str, dict[str, object]]]) -> dict[str, object]:
     for name, payload in reversed(events):
         if name == "service.cache":

--- a/tests/services/test_download_service.py
+++ b/tests/services/test_download_service.py
@@ -77,7 +77,9 @@ def test_update_priority_persists_and_notifies_worker(monkeypatch, db_session) -
         notified.update({"job_id": job_id, "priority": priority, "job_type": job_type})
         return True
 
-    monkeypatch.setattr("app.services.download_service.update_worker_priority", fake_update_priority)
+    monkeypatch.setattr(
+        "app.services.download_service.update_worker_priority", fake_update_priority
+    )
 
     download.job_id = 42
     db_session.commit()

--- a/tests/services/test_errors_mapping.py
+++ b/tests/services/test_errors_mapping.py
@@ -63,9 +63,7 @@ def test_to_api_error_from_value_error() -> None:
 
 
 def test_to_api_error_from_transfers_error() -> None:
-    exc = TransfersDependencyError(
-        "slskd unavailable", status_code=502, details={"hint": "retry"}
-    )
+    exc = TransfersDependencyError("slskd unavailable", status_code=502, details={"hint": "retry"})
     mapped = to_api_error(exc, provider="slskd")
     assert mapped.error.code == "DEPENDENCY_ERROR"
     assert mapped.error.details == {

--- a/tests/test_spotify.py
+++ b/tests/test_spotify.py
@@ -5,6 +5,7 @@ from tests.simple_client import SimpleTestClient
 from app.db import session_scope
 from app.models import Playlist
 
+
 def test_playlist_sync_worker_persists_playlists(client: SimpleTestClient) -> None:
     stub = client.app.state.spotify_stub
     stub.playlists = [

--- a/tests/test_spotify_mode_gate.py
+++ b/tests/test_spotify_mode_gate.py
@@ -14,9 +14,7 @@ def test_spotify_status_reports_capabilities(client: SimpleTestClient) -> None:
     assert payload["status"] in {"connected", "unauthenticated"}
 
 
-def test_spotify_pro_features_require_credentials(
-    client: SimpleTestClient, monkeypatch
-) -> None:
+def test_spotify_pro_features_require_credentials(client: SimpleTestClient, monkeypatch) -> None:
     from app.dependencies import get_spotify_client as dependency_spotify_client
 
     for key in ("SPOTIFY_CLIENT_ID", "SPOTIFY_CLIENT_SECRET", "SPOTIFY_REDIRECT_URI"):

--- a/tests/workers/test_async_session_yielding.py
+++ b/tests/workers/test_async_session_yielding.py
@@ -227,7 +227,9 @@ async def test_handle_matching_yields_with_slow_db(monkeypatch: pytest.MonkeyPat
             return 0.9
 
     session = _FakeSession()
-    session_factory = lambda: _FakeSessionContext(session)
+
+    def session_factory() -> _FakeSessionContext:
+        return _FakeSessionContext(session)
 
     started, _ = _install_slow_run_session(
         monkeypatch,

--- a/tests/workers/test_sync_worker.py
+++ b/tests/workers/test_sync_worker.py
@@ -38,7 +38,9 @@ class RecordingSoulseekClient:
 
 
 @pytest.mark.asyncio
-async def test_sync_worker_processes_jobs_with_async_persistence(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_sync_worker_processes_jobs_with_async_persistence(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Jobs are executed using the async persistence wrappers."""
 
     reset_engine_for_tests()


### PR DESCRIPTION
## Summary
- run the Ruff auto-fixer across `app/` and `tests/` and address remaining warnings (including import placement and factory helper style)
- format the affected Python modules with Black to match the enforced style
- document the required linting and formatting commands in the backend development guide

## Testing
- ruff check app tests
- black --check app tests

------
https://chatgpt.com/codex/tasks/task_e_68e235b930bc8321be1816d10bbfcfd6