### PR TITLE
TASK_ID: Add Bandit security scan to CI

### DIFF
--- a/.github/workflows/autopush.yml
+++ b/.github/workflows/autopush.yml
@@ -16,5 +16,8 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
+          pip install -r requirements-dev.txt
+      - name: Bandit
+        run: bandit -r app
       - name: Run tests
         run: pytest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Pytest
         run: pytest -q
       - name: Bandit
-        run: bandit -q -r app
+        run: bandit -r app
       - name: pip-audit (advisories only)
         run: pip-audit -r requirements.txt || true
       - name: Radon

--- a/Makefile
+++ b/Makefile
@@ -22,10 +22,10 @@ quality:
 
 security:
 ifeq ($(OFF),true)
-	@echo "⚠️ CI_OFFLINE=true → skipping security tools (bandit, pip-audit)."
+\t@echo "⚠️ CI_OFFLINE=true → skipping security tools (bandit, pip-audit)."
 else
-	bandit -q -r app
-	pip-audit -r requirements.txt || true
+\tbandit -r app
+\tpip-audit -r requirements.txt || true
 endif
 
 analyze:

--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ black --check .
 mypy app
 pytest -q
 python scripts/audit_wiring.py
+bandit -r app
 
 cd frontend
 npm ci
@@ -231,6 +232,9 @@ npm test
 npm run typecheck
 npm run build
 ```
+
+Der Security-Scan blockt unsichere Muster frühzeitig. `bandit -r app` entspricht dem neuen CI-Step und sollte vor jedem Commit
+lokal ausgeführt werden, damit Findings gar nicht erst im Pull Request landen.
 
 ## Datenbank-Migrationen
 


### PR DESCRIPTION
## Summary
- install the development extras in the autopush workflow and add a dedicated Bandit scan before running pytest
- run Bandit without the quiet flag in the main CI workflow and the Makefile security target to surface findings
- document the new `bandit -r app` check in the README so contributors run it locally

## Testing
- `pytest -q` *(fails: known priority ordering test already red on main)*
- `bandit -r app` *(fails: Bandit cannot be installed in the offline execution environment)*

No ToDo changes required.


------
https://chatgpt.com/codex/tasks/task_e_68e2370ecef483218f996751b52da9ba