### PR TITLE
fix: handle queue job dedupe conflicts

### DIFF
--- a/tests/workers/test_enqueue_concurrency.py
+++ b/tests/workers/test_enqueue_concurrency.py
@@ -2,14 +2,24 @@
 
 from __future__ import annotations
 
+import os
+import uuid
+from pathlib import Path
+from typing import Any
 import anyio
 import threading
 from concurrent.futures import ThreadPoolExecutor
-import pytest
-from sqlalchemy import func, select
 
-from app.db import session_scope
+import pytest
+import sqlalchemy as sa
+from sqlalchemy import func, select
+from sqlalchemy.engine import make_url
+from sqlalchemy.exc import ProgrammingError
+from sqlalchemy.schema import CreateSchema, DropSchema
+
+from app.db import init_db, reset_engine_for_tests, session_scope
 from app.models import QueueJob
+from app.workers import persistence
 from app.workers.persistence import enqueue
 
 
@@ -108,4 +118,137 @@ async def test_enqueue_parallel_requests_return_existing_job() -> None:
 
         record_stmt = select(QueueJob).where(QueueJob.type == job_type)
         record = session.execute(record_stmt).scalars().one()
-        assert record.payload["payload"]["attempt"] in range(concurrency)
+        payload_data = record.payload.get("payload") if isinstance(record.payload, dict) else None
+        assert isinstance(payload_data, dict)
+        assert payload_data.get("attempt") in range(concurrency)
+
+
+@pytest.fixture(params=["sqlite", "postgresql"], ids=["sqlite", "postgresql"])
+def queue_database_backend(
+    request: pytest.FixtureRequest,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path_factory: pytest.TempPathFactory,
+):
+    original_url = os.environ["DATABASE_URL"]
+    backend = request.param
+    schema_name: str | None = None
+    base_engine: sa.Engine | None = None
+    configured_url: str | None = None
+
+    try:
+        if backend == "sqlite":
+            db_path = tmp_path_factory.mktemp("queue-db") / f"{uuid.uuid4().hex}.db"
+            configured_url = f"sqlite:///{db_path}"
+            monkeypatch.setenv("DATABASE_URL", configured_url)
+            reset_engine_for_tests()
+            init_db()
+            yield backend
+        else:
+            database_url = os.getenv("DATABASE_URL")
+            if not database_url:
+                pytest.skip("DATABASE_URL is not configured for PostgreSQL tests")
+
+            url = make_url(database_url)
+            if url.get_backend_name() != "postgresql":
+                pytest.skip("PostgreSQL URL required for worker persistence tests")
+
+            schema_name = f"test_workers_{uuid.uuid4().hex}"
+            base_engine = sa.create_engine(url)
+            with base_engine.connect() as connection:
+                connection.execute(CreateSchema(schema_name))
+                connection.commit()
+
+            scoped_url = url.set(query={**url.query, "options": f"-csearch_path={schema_name}"})
+            configured_url = str(scoped_url)
+            monkeypatch.setenv("DATABASE_URL", configured_url)
+            reset_engine_for_tests()
+            init_db()
+            yield backend
+    finally:
+        reset_engine_for_tests()
+        monkeypatch.setenv("DATABASE_URL", original_url)
+
+        if backend == "sqlite" and configured_url is not None:
+            sqlite_url = make_url(configured_url)
+            database = sqlite_url.database or ""
+            if database:
+                db_path = Path(database)
+                for suffix in ("", "-journal", "-wal", "-shm"):
+                    candidate = db_path.with_name(f"{db_path.name}{suffix}")
+                    if candidate.exists():
+                        candidate.unlink()
+
+        if backend == "postgresql" and base_engine is not None and schema_name is not None:
+            with base_engine.connect() as connection:
+                try:
+                    connection.execute(DropSchema(schema_name, cascade=True))
+                    connection.commit()
+                except ProgrammingError:
+                    connection.rollback()
+            base_engine.dispose()
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("queue_database_backend", ["sqlite", "postgresql"], indirect=True)
+async def test_enqueue_conflict_returns_existing_job_on_integrity_error(
+    queue_database_backend: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    job_type = f"conflict-{queue_database_backend}"
+    template = {"idempotency_key": f"{job_type}-job"}
+    concurrency = 8
+    barrier = threading.Barrier(concurrency)
+
+    dedupe_events: list[dict[str, Any]] = []
+    lock = threading.Lock()
+    original_debug = persistence.logger.debug
+
+    def capture_debug(message: str, *args: Any, **kwargs: Any) -> None:
+        extra = kwargs.get("extra")
+        if isinstance(extra, dict) and extra.get("event") == "queue.job.dedupe":
+            with lock:
+                dedupe_events.append({"message": message, "extra": extra})
+        original_debug(message, *args, **kwargs)
+
+    monkeypatch.setattr(persistence.logger, "debug", capture_debug)
+
+    def run_parallel() -> list[int]:
+        results: list[int] = []
+
+        def worker(idx: int) -> int:
+            payload = dict(template)
+            payload["payload"] = {"attempt": idx}
+            barrier.wait()
+            job = enqueue(job_type, payload)
+            return job.id
+
+        with ThreadPoolExecutor(max_workers=concurrency) as executor:
+            for job_id in executor.map(worker, range(concurrency)):
+                results.append(job_id)
+
+        return results
+
+    results = await anyio.to_thread.run_sync(run_parallel)
+
+    assert len(results) == concurrency
+    assert len(set(results)) == 1
+
+    existing_id = results[0]
+    final_payload = dict(template)
+    final_payload["payload"] = {"attempt": concurrency}
+    final_job = await anyio.to_thread.run_sync(enqueue, job_type, final_payload)
+    assert final_job.id == existing_id
+
+    assert dedupe_events, "Expected a dedupe log entry for concurrent enqueue conflict"
+    assert any(event["extra"].get("job_type") == job_type for event in dedupe_events)
+    assert any(event["extra"].get("dialect") == queue_database_backend for event in dedupe_events)
+
+    with session_scope() as session:
+        stmt = select(func.count()).select_from(QueueJob).where(QueueJob.type == job_type)
+        count = session.execute(stmt).scalar_one()
+        assert count == 1
+
+        record_stmt = select(QueueJob).where(QueueJob.type == job_type)
+        record = session.execute(record_stmt).scalars().one()
+        payload_data = record.payload.get("payload") if isinstance(record.payload, dict) else None
+        assert isinstance(payload_data, dict)
+        assert payload_data.get("attempt") in range(concurrency + 1)


### PR DESCRIPTION
## Summary
- ensure queue job upserts handle duplicate IntegrityError/OperationalError conflicts by re-selecting the existing job and emitting structured dedupe logs
- add concurrency coverage across SQLite and PostgreSQL backends that captures dedupe reuse events via a patched logger

## Testing
- pytest tests/workers/test_enqueue_concurrency.py -q

No ToDo changes required.


------
https://chatgpt.com/codex/tasks/task_e_68e23bb4376883219f3b2f9145ee148b