### PR TITLE
feat: refresh retry policy from runtime settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -512,6 +512,8 @@ try-Zugriffs im CI bewusst ausgelassen.
 | `DLQ_PURGE_LIMIT` | int | `1000` | Limit für Bulk-Purge. | — |
 | `MUSIC_DIR` | path | `./music` | Zielpfad für organisierte Downloads. | — |
 
+> **Retry-Präzedenz:** `load_sync_retry_policy()` wertet zunächst explizite Funktionsargumente aus, danach übergebene Defaults (z. B. Tests oder Provider), anschließend die aktuellen ENV-/Settings-Werte und zuletzt die Code-Defaults aus `app/config.py`. Nutze `refresh_sync_retry_policy()` oder `SyncWorker.refresh_retry_policy()`, um geänderte ENV-Werte ohne Neustart zu übernehmen.
+
 > **Hinweis:** Spotify- und slskd-Zugangsdaten können über `/settings` in der Datenbank persistiert werden. Beim Laden der Anwendung haben Datenbankwerte Vorrang vor Umgebungsvariablen; ENV-Variablen dienen als Fallback und Basis für neue Deployments. Eine ausführliche Laufzeitreferenz inkl. Überschneidungen mit Datenbank-Settings befindet sich in [`docs/ops/runtime-config.md`](docs/ops/runtime-config.md).
 
 ### Orchestrator & Queue-Steuerung

--- a/app/workers/sync_worker.py
+++ b/app/workers/sync_worker.py
@@ -220,6 +220,15 @@ class SyncWorker:
         except (TypeError, ValueError):
             return 0
 
+    @property
+    def retry_policy(self) -> RetryConfig:
+        return self._retry_config
+
+    def refresh_retry_policy(self) -> None:
+        """Reload the retry policy from the latest runtime configuration."""
+
+        self._retry_config = load_sync_retry_policy(force_reload=True)
+
     @staticmethod
     def _extract_file_priority(file_info: Dict[str, Any]) -> int:
         return SyncWorker._coerce_priority(file_info.get("priority"))

--- a/docs/ops/runtime-config.md
+++ b/docs/ops/runtime-config.md
@@ -39,7 +39,7 @@ Diese Anleitung ergänzt die Tabellen im [README](../../README.md#betrieb--konfi
 - Spotify/slskd-Zeitlimits (`SPOTIFY_TIMEOUT_MS`, `SLSKD_TIMEOUT_MS`) greifen sowohl in REST-Endpunkten als auch in Workern (z. B. Watchlist).
 - `WATCHLIST_*`-Variablen begrenzen Lastspitzen: reduziere `WATCHLIST_MAX_CONCURRENCY`, wenn SQLite-Locks auftreten, oder schalte auf `WATCHLIST_DB_IO_MODE=async`, sobald eine asynchrone Datenbank verwendet wird.
 - Download-Retries (`RETRY_*`) konfigurieren die Sync-/Retry-Handler des Orchestrators; die historischen `RETRY_SCAN_*`-Werte werden nur noch für Legacy-Fallbacks gelesen.
-- Die Retry-Defaults (`RETRY_MAX_ATTEMPTS`, `RETRY_BASE_SECONDS`, `RETRY_JITTER_PCT`) liegen gesammelt in `settings.retry_policy` und speisen sowohl den Orchestrator als auch Worker.
+- Die Download-Retry-Defaults (`RETRY_MAX_ATTEMPTS`, `RETRY_BASE_SECONDS`, `RETRY_JITTER_PCT`) werden bei jedem Aufruf von `load_sync_retry_policy()` frisch aus den Runtime-Quellen geladen. Die Auflösung folgt der Reihenfolge: explizite Funktionsargumente → bereitgestellte Default-Configs → aktuelle ENV-/Settings-Werte → Code-Defaults aus `app/config.py`. Über `refresh_sync_retry_policy()` bzw. `SyncWorker.refresh_retry_policy()` lassen sich ENV-Anpassungen ohne Prozessneustart übernehmen.
 - Matching-Flags (`FEATURE_MATCHING_EDITION_AWARE`, `MATCH_*`) beeinflussen sowohl REST (`/matching`) als auch den Hintergrund-Worker.
 
 ## Frontend & Runtime Injection


### PR DESCRIPTION
## Summary
- reload the orchestrator retry policy from live settings with a thread-safe cache and refresh helper
- allow the sync worker to refresh its retry configuration at runtime and cover the behavior in tests
- document retry precedence and runtime overrides in the configuration guides

## Testing
- pytest tests/test_download_retry.py
- pytest tests/orchestrator/test_retry_policy.py

No ToDo changes required.

------
https://chatgpt.com/codex/tasks/task_e_68e24688899483218ac6490ab665e38a