### PR TITLE
fix: normalise activity timestamps to utc

### DIFF
--- a/app/utils/activity.py
+++ b/app/utils/activity.py
@@ -33,8 +33,17 @@ class ActivityEntry:
     def as_dict(self) -> Dict[str, object]:
         """Return a serialisable representation of the entry."""
 
+        def _serialise_timestamp(dt: datetime) -> str:
+            """Normalise datetimes to UTC and serialise with a trailing Z."""
+
+            if dt.tzinfo is None or dt.tzinfo.utcoffset(dt) is None:
+                normalised = dt.replace(tzinfo=timezone.utc)
+            else:
+                normalised = dt.astimezone(timezone.utc)
+            return normalised.isoformat().replace("+00:00", "Z")
+
         payload: Dict[str, object] = {
-            "timestamp": self.timestamp.isoformat() + "Z",
+            "timestamp": _serialise_timestamp(self.timestamp),
             "type": self.type,
             "status": self.status,
         }

--- a/tests/test_activity.py
+++ b/tests/test_activity.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from datetime import datetime, timedelta, timezone
+
 from app.utils.activity import record_activity
 
 
@@ -33,3 +35,13 @@ def test_activity_endpoint_limits_to_fifty_entries(client) -> None:
     assert len(entries) == 50
     assert entries[0]["details"]["index"] == 59
     assert entries[-1]["details"]["index"] == 10
+
+
+def test_record_activity_serialises_timezone_aware_timestamp() -> None:
+    aware_timestamp = datetime(2024, 5, 4, 12, 30, 45, tzinfo=timezone(timedelta(hours=2)))
+
+    payload = record_activity("test", "completed", timestamp=aware_timestamp)
+
+    timestamp = payload["timestamp"]
+    assert timestamp.endswith("Z")
+    assert timestamp.count("Z") == 1


### PR DESCRIPTION
## Summary
- normalise activity entry timestamps to UTC and serialise with a trailing Z
- add a regression test ensuring timezone-aware timestamps render with a single Z suffix

## Testing
- pytest tests/test_activity.py

No ToDo changes required.

------
https://chatgpt.com/codex/tasks/task_e_68e27d178034832195aade783befbec5