### PR TITLE
[TASK_ID: N/A] Replace deprecated HTTP status constants

### DIFF
--- a/app/middleware/errors.py
+++ b/app/middleware/errors.py
@@ -164,7 +164,7 @@ async def _handle_request_validation(request: Request, exc: RequestValidationErr
     return to_response(
         message="Request validation failed.",
         code=ErrorCode.VALIDATION_ERROR,
-        status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+        status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
         request_path=request.url.path,
         method=request.method,
         meta=meta,

--- a/app/routers/imports_router.py
+++ b/app/routers/imports_router.py
@@ -56,7 +56,7 @@ async def create_free_import(
     if body_size > hard_cap_bytes:
         raise ValidationAppError(
             "payload exceeds maximum allowed size",
-            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            status_code=status.HTTP_413_CONTENT_TOO_LARGE,
         )
 
     content_type = request.headers.get("content-type")
@@ -72,7 +72,7 @@ async def create_free_import(
     except TooManyItemsError as exc:
         raise ValidationAppError(
             f"received {exc.provided} links which exceeds hard limit {exc.limit}",
-            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            status_code=status.HTTP_413_CONTENT_TOO_LARGE,
         ) from exc
     except InvalidPayloadError as exc:
         raise ValidationAppError(f"invalid payload: {exc.message}") from exc

--- a/tests/api/test_error_contract.py
+++ b/tests/api/test_error_contract.py
@@ -39,7 +39,7 @@ def test_request_validation_error_envelope(client: SimpleTestClient) -> None:
         json={"playlist_links": "not-a-list"},
     )
 
-    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
     payload = response.json()
     assert payload["ok"] is False
     assert payload["error"]["code"] == "VALIDATION_ERROR"


### PR DESCRIPTION
## Summary
- replace deprecated HTTP status constants in validation and import error responses to silence runtime deprecation warnings
- align the error contract test with the new FastAPI constants

## Testing
- pytest tests/api/test_error_contract.py tests/test_imports_free.py -q

No ToDo changes required.

------
https://chatgpt.com/codex/tasks/task_e_68e2cf386dbc8321aed85f868852788c