### PR TITLE
fix: ensure queue job dedupe updates after integrity error

### DIFF
--- a/app/workers/persistence.py
+++ b/app/workers/persistence.py
@@ -274,9 +274,17 @@ def _upsert_queue_job(
             if _is_duplicate_integrity_error(exc):
                 existing = _select_existing(with_lock=False)
                 if existing is not None:
+                    deduped = _apply_existing_job_updates(
+                        existing,
+                        payload=payload,
+                        priority=priority,
+                        scheduled_for=scheduled_for,
+                        now=now,
+                    )
                     session.add(existing)
-                    _log_dedupe()
-                    return existing, True
+                    if deduped:
+                        _log_dedupe()
+                    return existing, deduped
 
                 attempts += 1
                 time.sleep(min(0.01, 0.001 * attempts))


### PR DESCRIPTION
## Summary
- update integrity error dedupe path to reapply incoming payload, priority, and schedule
- add regression test covering integrity error retry path to ensure latest payload and priority persist

## Testing
- pytest tests/workers/test_enqueue_concurrency.py::test_enqueue_integrity_error_applies_latest_updates

No ToDo changes required.

------
https://chatgpt.com/codex/tasks/task_e_68e34720f83c832181eeaece925e31db