### PR TITLE
Fix toast smoke test to use uncontrolled state

### DIFF
--- a/frontend/src/__tests__/radix.smoke.test.tsx
+++ b/frontend/src/__tests__/radix.smoke.test.tsx
@@ -107,7 +107,7 @@ describe('Radix primitives smoke tests', () => {
 
     try {
       renderWithToastProvider(
-        <ToastPrimitive.Root open duration={100}>
+        <ToastPrimitive.Root defaultOpen duration={100}>
           <ToastPrimitive.Title>Toast title</ToastPrimitive.Title>
           <ToastPrimitive.Description>Toast description</ToastPrimitive.Description>
         </ToastPrimitive.Root>


### PR DESCRIPTION
## Summary
- switch the Radix toast smoke test to defaultOpen so the toast auto-dismisses when timers advance

## Testing
- npm test -- --runTestsByPath src/__tests__/radix.smoke.test.tsx *(fails: `jest` binary not available in container PATH)*

No ToDo changes required.

------
https://chatgpt.com/codex/tasks/task_e_68e3a523c8c88321aee7b7d0ed1891b0