### PR TITLE
fix: widen enqueue concurrency payload assertion

### DIFF
--- a/tests/workers/test_enqueue_concurrency.py
+++ b/tests/workers/test_enqueue_concurrency.py
@@ -51,7 +51,7 @@ async def test_enqueue_idempotent_concurrency_creates_single_row() -> None:
         record = session.execute(record_stmt).scalars().one()
         assert record.status == "pending"
         # The final payload should correspond to one of the attempted updates.
-        assert record.payload["payload"]["value"] in range(8)
+        assert record.payload["payload"]["value"] in range(concurrency)
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary
- align the enqueue concurrency payload assertion with the configured concurrency value so it accepts all possible winners

## Testing
- ⚠️ `pytest tests/workers/test_enqueue_concurrency.py::test_enqueue_idempotent_concurrency_creates_single_row` *(hangs when waiting for external database in this environment; interrupted)*

No ToDo changes required.

------
https://chatgpt.com/codex/tasks/task_e_68e3c58b4f1c8321aba17a36d44311d6