### PR TITLE
TASK_ID CODX-ORCH-000: Refresh sync retry policy snapshots at runtime

### DIFF
--- a/app/workers/sync_worker.py
+++ b/app/workers/sync_worker.py
@@ -263,7 +263,8 @@ class SyncWorker:
             artwork_service=self._artwork,
             lyrics_service=self._lyrics,
             music_dir=self._music_dir,
-            retry_policy=self._retry_config,
+            retry_policy_provider=self._retry_provider,
+            retry_policy_override=self._retry_config,
             rng=self._retry_rng,
         )
 

--- a/tests/orchestrator/test_dispatcher.py
+++ b/tests/orchestrator/test_dispatcher.py
@@ -405,7 +405,9 @@ async def test_default_handlers_bind_sync_job(tmp_path: Path) -> None:
     soulseek = InlineSoulseekClient()
     deps = SyncHandlerDeps(
         soulseek_client=soulseek,
-        retry_policy=SyncRetryPolicy(max_attempts=3, base_seconds=1.0, jitter_pct=0.0),
+        retry_policy_override=SyncRetryPolicy(
+            max_attempts=3, base_seconds=1.0, jitter_pct=0.0
+        ),
         rng=random.Random(0),
         music_dir=tmp_path,
     )
@@ -457,7 +459,9 @@ async def test_default_handlers_bind_matching_job(tmp_path: Path) -> None:
     soulseek = InlineSoulseekClient()
     deps = SyncHandlerDeps(
         soulseek_client=soulseek,  # type: ignore[arg-type]
-        retry_policy=SyncRetryPolicy(max_attempts=3, base_seconds=1.0, jitter_pct=0.0),
+        retry_policy_override=SyncRetryPolicy(
+            max_attempts=3, base_seconds=1.0, jitter_pct=0.0
+        ),
         rng=random.Random(0),
         music_dir=tmp_path,
     )

--- a/tests/orchestrator/test_sync_handler.py
+++ b/tests/orchestrator/test_sync_handler.py
@@ -101,7 +101,9 @@ async def test_process_sync_payload_marks_downloads_downloading(tmp_path: Path) 
     client = StubSoulseekClient()
     deps = SyncHandlerDeps(
         soulseek_client=client,
-        retry_policy=SyncRetryPolicy(max_attempts=3, base_seconds=1.0, jitter_pct=0.0),
+        retry_policy_override=SyncRetryPolicy(
+            max_attempts=3, base_seconds=1.0, jitter_pct=0.0
+        ),
         rng=random.Random(0),
         music_dir=tmp_path,
     )
@@ -145,7 +147,9 @@ async def test_process_sync_payload_handles_failure(tmp_path: Path) -> None:
     client = StubSoulseekClient(error=RuntimeError("boom"))
     deps = SyncHandlerDeps(
         soulseek_client=client,
-        retry_policy=SyncRetryPolicy(max_attempts=5, base_seconds=1.0, jitter_pct=0.0),
+        retry_policy_override=SyncRetryPolicy(
+            max_attempts=5, base_seconds=1.0, jitter_pct=0.0
+        ),
         rng=random.Random(0),
         music_dir=tmp_path,
     )
@@ -191,7 +195,9 @@ async def test_process_sync_payload_dead_letters_on_limit(tmp_path: Path) -> Non
     client = StubSoulseekClient(error=RuntimeError("boom"))
     deps = SyncHandlerDeps(
         soulseek_client=client,
-        retry_policy=SyncRetryPolicy(max_attempts=1, base_seconds=1.0, jitter_pct=0.0),
+        retry_policy_override=SyncRetryPolicy(
+            max_attempts=1, base_seconds=1.0, jitter_pct=0.0
+        ),
         rng=random.Random(0),
         music_dir=tmp_path,
     )
@@ -269,7 +275,9 @@ async def test_fanout_download_completion_invokes_services(
         artwork_service=artwork_service,
         lyrics_service=lyrics_service,
         music_dir=tmp_path,
-        retry_policy=SyncRetryPolicy(max_attempts=3, base_seconds=1.0, jitter_pct=0.0),
+        retry_policy_override=SyncRetryPolicy(
+            max_attempts=3, base_seconds=1.0, jitter_pct=0.0
+        ),
         rng=random.Random(0),
     )
 

--- a/tests/services/test_retry_policy_provider.py
+++ b/tests/services/test_retry_policy_provider.py
@@ -160,7 +160,6 @@ def test_dlq_after_max_attempts_update(monkeypatch: pytest.MonkeyPatch) -> None:
     # Tighten policy and wait for TTL so the next load observes the new value.
     env["RETRY_MAX_ATTEMPTS"] = "1"
     now[0] += 0.2
-    deps = SyncHandlerDeps(soulseek_client=_StubSoulseekClient(), rng=random.Random(0))
 
     asyncio.run(handle_sync_download_failure(job, files, deps, "boom again"))
 


### PR DESCRIPTION
## Summary
- ensure `SyncHandlerDeps` pulls retry policy snapshots from the shared provider so TTL-driven updates apply without restarting the orchestrator
- refresh retry handling paths to read a per-call policy snapshot and log current metadata
- feed the shared provider through the sync worker and adjust tests to cover live reload behaviour

## Testing
- pytest tests/services/test_retry_policy_provider.py
- pytest tests/orchestrator/test_sync_handler.py tests/orchestrator/test_dispatcher.py

No ToDo changes required.


------
https://chatgpt.com/codex/tasks/task_e_68e3c568fcd08321bd2683bf9a9f6d44