### PR TITLE
feat(orchestrator): add artist refresh and delta workflow

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -203,7 +203,8 @@ class OrchestratorConfig:
     pool_sync: int
     pool_matching: int
     pool_retry: int
-    pool_watchlist: int
+    pool_artist_refresh: int
+    pool_artist_delta: int
     priority_map: dict[str, int]
     visibility_timeout_s: int
     heartbeat_s: int
@@ -215,7 +216,10 @@ class OrchestratorConfig:
             "sync": max(1, self.pool_sync or self.global_concurrency),
             "matching": max(1, self.pool_matching or self.global_concurrency),
             "retry": max(1, self.pool_retry or self.global_concurrency),
-            "watchlist": max(1, self.pool_watchlist or self.global_concurrency),
+            "artist_refresh": max(
+                1, self.pool_artist_refresh or self.global_concurrency
+            ),
+            "artist_delta": max(1, self.pool_artist_delta or self.global_concurrency),
         }
 
     @classmethod
@@ -244,9 +248,14 @@ class OrchestratorConfig:
             default=DEFAULT_ORCH_POOL_RETRY,
             minimum=1,
         )
-        pool_watchlist = _bounded_int(
-            env.get("ORCH_POOL_WATCHLIST"),
-            default=DEFAULT_ORCH_POOL_WATCHLIST,
+        pool_artist_refresh = _bounded_int(
+            env.get("ORCH_POOL_ARTIST_REFRESH"),
+            default=DEFAULT_ORCH_POOL_ARTIST_REFRESH,
+            minimum=1,
+        )
+        pool_artist_delta = _bounded_int(
+            env.get("ORCH_POOL_ARTIST_DELTA"),
+            default=DEFAULT_ORCH_POOL_ARTIST_DELTA,
             minimum=1,
         )
         visibility_timeout = _bounded_int(
@@ -276,7 +285,8 @@ class OrchestratorConfig:
             pool_sync=pool_sync,
             pool_matching=pool_matching,
             pool_retry=pool_retry,
-            pool_watchlist=pool_watchlist,
+            pool_artist_refresh=pool_artist_refresh,
+            pool_artist_delta=pool_artist_delta,
             priority_map=priority_map,
             visibility_timeout_s=visibility_timeout,
             heartbeat_s=heartbeat_s,
@@ -588,12 +598,14 @@ DEFAULT_ORCH_GLOBAL_CONCURRENCY = 8
 DEFAULT_ORCH_POOL_SYNC = 4
 DEFAULT_ORCH_POOL_MATCHING = 4
 DEFAULT_ORCH_POOL_RETRY = 2
-DEFAULT_ORCH_POOL_WATCHLIST = 2
+DEFAULT_ORCH_POOL_ARTIST_REFRESH = 2
+DEFAULT_ORCH_POOL_ARTIST_DELTA = 2
 DEFAULT_ORCH_PRIORITY_MAP = {
     "sync": 100,
     "matching": 90,
     "retry": 80,
-    "watchlist": 50,
+    "artist_refresh": 50,
+    "artist_delta": 45,
 }
 DEFAULT_ORCH_VISIBILITY_TIMEOUT_S = 60
 DEFAULT_ORCH_HEARTBEAT_S = 20

--- a/app/main.py
+++ b/app/main.py
@@ -104,7 +104,16 @@ def _orchestrator_component_probe(component: str) -> Callable[[], DependencyStat
 
 
 def _build_orchestrator_dependency_probes() -> Mapping[str, Callable[[], DependencyStatus]]:
-    jobs = ("sync", "matching", "retry", "watchlist", "artwork", "lyrics")
+    jobs = (
+        "sync",
+        "matching",
+        "retry",
+        "artist_refresh",
+        "artist_delta",
+        "watchlist",
+        "artwork",
+        "lyrics",
+    )
     probes: dict[str, Callable[[], DependencyStatus]] = {
         "orchestrator:scheduler": _orchestrator_component_probe("scheduler"),
         "orchestrator:dispatcher": _orchestrator_component_probe("dispatcher"),

--- a/app/orchestrator/dispatcher.py
+++ b/app/orchestrator/dispatcher.py
@@ -22,6 +22,8 @@ from app.workers import persistence
 
 if TYPE_CHECKING:  # pragma: no cover - import for typing only
     from app.orchestrator.handlers import (
+        ArtistDeltaHandlerDeps,
+        ArtistRefreshHandlerDeps,
         MatchingHandlerDeps,
         RetryHandlerDeps,
         SyncHandlerDeps,
@@ -38,10 +40,14 @@ def default_handlers(
     matching_deps: "MatchingHandlerDeps" | None = None,
     retry_deps: "RetryHandlerDeps" | None = None,
     watchlist_deps: "WatchlistHandlerDeps" | None = None,
+    artist_refresh_deps: "ArtistRefreshHandlerDeps" | None = None,
+    artist_delta_deps: "ArtistDeltaHandlerDeps" | None = None,
 ) -> dict[str, JobHandler]:
     """Return the default orchestrator handler mapping."""
 
     from app.orchestrator.handlers import (
+        build_artist_delta_handler,
+        build_artist_refresh_handler,
         build_matching_handler,
         build_retry_handler,
         build_sync_handler,
@@ -55,6 +61,10 @@ def default_handlers(
         handlers["retry"] = build_retry_handler(retry_deps)
     if watchlist_deps is not None:
         handlers["watchlist"] = build_watchlist_handler(watchlist_deps)
+    if artist_refresh_deps is not None:
+        handlers["artist_refresh"] = build_artist_refresh_handler(artist_refresh_deps)
+    if artist_delta_deps is not None:
+        handlers["artist_delta"] = build_artist_delta_handler(artist_delta_deps)
     return handlers
 
 

--- a/app/orchestrator/providers.py
+++ b/app/orchestrator/providers.py
@@ -18,6 +18,8 @@ from app.dependencies import (
     get_spotify_client,
 )
 from app.orchestrator.handlers import (
+    ArtistDeltaHandlerDeps,
+    ArtistRefreshHandlerDeps,
     ArtworkService,
     MatchingHandlerDeps,
     LyricsService,
@@ -102,9 +104,46 @@ def build_watchlist_handler_deps(
     )
 
 
+def build_artist_refresh_handler_deps(
+    *,
+    config: WatchlistWorkerConfig | None = None,
+    submit_delta_job: SyncJobSubmitter | None = None,
+) -> ArtistRefreshHandlerDeps:
+    """Construct handler dependencies for artist refresh jobs."""
+
+    resolved_config = config or get_app_config().watchlist
+    kwargs: dict[str, object] = {}
+    if submit_delta_job is not None:
+        kwargs["submit_delta_job"] = submit_delta_job
+    return ArtistRefreshHandlerDeps(config=resolved_config, **kwargs)
+
+
+def build_artist_delta_handler_deps(
+    *,
+    spotify_client: SpotifyClient | None = None,
+    soulseek_client: SoulseekClient | None = None,
+    config: WatchlistWorkerConfig | None = None,
+    submit_sync_job: SyncJobSubmitter | None = None,
+) -> ArtistDeltaHandlerDeps:
+    """Construct handler dependencies for artist delta jobs."""
+
+    resolved_config = config or get_app_config().watchlist
+    kwargs: dict[str, object] = {}
+    if submit_sync_job is not None:
+        kwargs["submit_sync_job"] = submit_sync_job
+    return ArtistDeltaHandlerDeps(
+        spotify_client=spotify_client or get_spotify_client(),
+        soulseek_client=soulseek_client or get_soulseek_client(),
+        config=resolved_config,
+        **kwargs,
+    )
+
+
 __all__ = [
     "build_sync_handler_deps",
     "build_matching_handler_deps",
     "build_retry_handler_deps",
     "build_watchlist_handler_deps",
+    "build_artist_refresh_handler_deps",
+    "build_artist_delta_handler_deps",
 ]

--- a/tests/config/test_orchestrator_config.py
+++ b/tests/config/test_orchestrator_config.py
@@ -14,10 +14,10 @@ def test_priority_json_and_csv_fallback() -> None:
 
     csv_env = {
         "ORCH_PRIORITY_JSON": "not-json",
-        "ORCH_PRIORITY_CSV": "matching:40,watchlist:10",
+        "ORCH_PRIORITY_CSV": "matching:40,artist_refresh:10",
     }
     csv_config = OrchestratorConfig.from_env(csv_env)
-    assert csv_config.priority_map == {"matching": 40, "watchlist": 10}
+    assert csv_config.priority_map == {"matching": 40, "artist_refresh": 10}
 
     default_config = OrchestratorConfig.from_env({})
     assert default_config.priority_map == DEFAULT_ORCH_PRIORITY_MAP
@@ -29,7 +29,8 @@ def test_bounds_and_defaults_applied() -> None:
         "ORCH_POOL_SYNC": "0",
         "ORCH_POOL_MATCHING": "-5",
         "ORCH_POOL_RETRY": "-1",
-        "ORCH_POOL_WATCHLIST": "3",
+        "ORCH_POOL_ARTIST_REFRESH": "3",
+        "ORCH_POOL_ARTIST_DELTA": "4",
         "ORCH_VISIBILITY_TIMEOUT_S": "2",
         "ORCH_HEARTBEAT_S": "-10",
         "ORCH_POLL_INTERVAL_MS": "5",
@@ -40,7 +41,8 @@ def test_bounds_and_defaults_applied() -> None:
     assert config.pool_sync == 1
     assert config.pool_matching == 1
     assert config.pool_retry == 1
-    assert config.pool_watchlist == 3
+    assert config.pool_artist_refresh == 3
+    assert config.pool_artist_delta == 4
     assert config.visibility_timeout_s == 5
     assert config.heartbeat_s == 1
     assert config.poll_interval_ms == 10

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -79,7 +79,10 @@ class RecordingScheduler:
         persistence_module=persistence,
     ) -> None:
         self._persistence = persistence_module
-        self._job_types = tuple(job_types or ("sync", "matching", "retry", "watchlist"))
+        self._job_types = tuple(
+            job_types
+            or ("sync", "matching", "retry", "artist_refresh", "artist_delta", "watchlist")
+        )
         self.poll_interval = 0.01
         self.started = asyncio.Event()
         self.stopped = asyncio.Event()

--- a/tests/workers/test_graceful_shutdown.py
+++ b/tests/workers/test_graceful_shutdown.py
@@ -10,11 +10,11 @@ from app.workers.persistence import enqueue, lease, release_active_leases
 
 
 def test_release_active_leases_resets_all_jobs() -> None:
-    active_job = enqueue("watchlist", {"idempotency_key": "active"})
-    expired_job = enqueue("watchlist", {"idempotency_key": "expired"})
+    active_job = enqueue("artist_refresh", {"idempotency_key": "active"})
+    expired_job = enqueue("artist_refresh", {"idempotency_key": "expired"})
 
-    assert lease(active_job.id, job_type="watchlist", lease_seconds=30) is not None
-    assert lease(expired_job.id, job_type="watchlist", lease_seconds=5) is not None
+    assert lease(active_job.id, job_type="artist_refresh", lease_seconds=30) is not None
+    assert lease(expired_job.id, job_type="artist_refresh", lease_seconds=5) is not None
 
     with session_scope() as session:
         db_job = session.get(QueueJob, expired_job.id)
@@ -22,7 +22,7 @@ def test_release_active_leases_resets_all_jobs() -> None:
         db_job.lease_expires_at = datetime.utcnow() - timedelta(seconds=1)
         session.add(db_job)
 
-    release_active_leases("watchlist")
+    release_active_leases("artist_refresh")
 
     with session_scope() as session:
         active = session.get(QueueJob, active_job.id)

--- a/tests/workers/test_orch_visibility.py
+++ b/tests/workers/test_orch_visibility.py
@@ -37,7 +37,7 @@ def test_scheduler_orders_jobs_by_priority_and_time(
     )
     job_watchlist = queue_job_factory(
         job_id=4,
-        job_type="watchlist",
+        job_type="artist_refresh",
         priority=50,
         available_at=base + timedelta(seconds=2),
     )
@@ -45,7 +45,7 @@ def test_scheduler_orders_jobs_by_priority_and_time(
     for job in (job_retry, job_sync_early, job_sync_late, job_watchlist):
         stub_queue_persistence.add_ready(job)
 
-    config = PriorityConfig(priorities={"retry": 90, "sync": 60, "watchlist": 30})
+    config = PriorityConfig(priorities={"retry": 90, "sync": 60, "artist_refresh": 30})
     scheduler = Scheduler(
         priority_config=config,
         poll_interval_ms=10,

--- a/tests/workers/test_watchlist_defaults.py
+++ b/tests/workers/test_watchlist_defaults.py
@@ -62,7 +62,11 @@ async def test_worker_enqueues_due_artists() -> None:
     assert all(outcome.enqueued for outcome in outcomes)
 
     with session_scope() as session:
-        jobs = session.execute(select(QueueJob).where(QueueJob.type == "watchlist")).scalars().all()
+        jobs = (
+            session.execute(select(QueueJob).where(QueueJob.type == "artist_refresh"))
+            .scalars()
+            .all()
+        )
         assert len(jobs) == 3
         keys = {job.idempotency_key for job in jobs}
         assert len(keys) == 3
@@ -90,7 +94,11 @@ async def test_worker_idempotency_prevents_duplicates() -> None:
     assert second_run[0].enqueued
 
     with session_scope() as session:
-        jobs = session.execute(select(QueueJob).where(QueueJob.type == "watchlist")).scalars().all()
+        jobs = (
+            session.execute(select(QueueJob).where(QueueJob.type == "artist_refresh"))
+            .scalars()
+            .all()
+        )
         assert len(jobs) == 1
         job = jobs[0]
         assert job.idempotency_key is not None

--- a/tests/workers/test_watchlist_timer.py
+++ b/tests/workers/test_watchlist_timer.py
@@ -85,7 +85,7 @@ async def test_watchlist_timer_enqueues_idempotently(monkeypatch: pytest.MonkeyP
     assert dao.calls == 2
 
     with session_scope() as session:
-        jobs = session.query(QueueJob).filter(QueueJob.type == "watchlist").all()
+        jobs = session.query(QueueJob).filter(QueueJob.type == "artist_refresh").all()
         assert len(jobs) == 1
 
 


### PR DESCRIPTION
## Summary
- introduce artist_refresh and artist_delta handler dependencies, register them in the dispatcher, and wire the bootstrap/runtime to expose the new queues alongside updated pool and priority defaults
- refactor the watchlist timer and worker so they enqueue artist_refresh jobs with explicit delta idempotency keys and priority, delegating artist processing to the new handlers
- align orchestrator configuration and tests with the refreshed job types, keeping legacy watchlist handling as a thin alias while covering the new flow

## Testing
- pytest tests/config/test_orchestrator_config.py tests/orchestrator/test_timer.py tests/workers/test_watchlist_timer.py tests/workers/test_watchlist_defaults.py tests/workers/test_graceful_shutdown.py tests/workers/test_orch_visibility.py

------
https://chatgpt.com/codex/tasks/task_e_68e3f785e5a48321ac9b1766449d0a30