### PR TITLE
feat: add artist gateway for provider release lookups

### DIFF
--- a/app/integrations/__init__.py
+++ b/app/integrations/__init__.py
@@ -1,10 +1,22 @@
 """Music provider adapters for Harmony integrations."""
 
+from .artist_gateway import (
+    ArtistDTO,
+    ArtistGateway,
+    ArtistGatewayResponse,
+    ArtistGatewayResult,
+    ArtistReleaseDTO,
+)
 from .base import Album, Artist, MusicProvider, Playlist, Track
 
 __all__ = [
     "Album",
     "Artist",
+    "ArtistDTO",
+    "ArtistGateway",
+    "ArtistGatewayResponse",
+    "ArtistGatewayResult",
+    "ArtistReleaseDTO",
     "MusicProvider",
     "Playlist",
     "Track",

--- a/app/integrations/artist_gateway.py
+++ b/app/integrations/artist_gateway.py
@@ -1,0 +1,267 @@
+"""Gateway orchestrating artist metadata calls via :mod:`ProviderGateway`."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Mapping, Sequence
+
+from app.integrations.contracts import SearchQuery
+from app.integrations.provider_gateway import (
+    ProviderGateway,
+    ProviderGatewayDependencyError,
+    ProviderGatewayError,
+    ProviderGatewayRateLimitedError,
+    ProviderGatewaySearchResult,
+    ProviderGatewayTimeoutError,
+)
+
+
+@dataclass(slots=True, frozen=True)
+class ArtistReleaseDTO:
+    """Normalised representation of a provider release payload."""
+
+    id: str
+    etag: str | None = None
+    fetched_at: datetime | None = None
+    provider_cursor: str | None = None
+    metadata: Mapping[str, object] = field(default_factory=dict)
+
+
+@dataclass(slots=True, frozen=True)
+class ArtistDTO:
+    """Normalised representation of an artist with release information."""
+
+    id: str
+    etag: str | None = None
+    fetched_at: datetime | None = None
+    provider_cursor: str | None = None
+    metadata: Mapping[str, object] = field(default_factory=dict)
+    releases: tuple[ArtistReleaseDTO, ...] = ()
+
+
+@dataclass(slots=True, frozen=True)
+class ArtistGatewayResult:
+    """Container describing the outcome of a provider specific fetch."""
+
+    provider: str
+    artist: ArtistDTO | None
+    releases: tuple[ArtistReleaseDTO, ...]
+    error: ProviderGatewayError | None = None
+    retryable: bool = False
+
+
+@dataclass(slots=True, frozen=True)
+class ArtistGatewayResponse:
+    """Aggregated response for multi-provider artist fetch operations."""
+
+    artist_id: str
+    results: tuple[ArtistGatewayResult, ...]
+
+    @property
+    def releases(self) -> tuple[ArtistReleaseDTO, ...]:
+        """Return the deduplicated set of releases across providers."""
+
+        seen: dict[str, ArtistReleaseDTO] = {}
+        for result in self.results:
+            for release in result.releases:
+                seen[release.id] = release
+        return tuple(seen.values())
+
+    @property
+    def errors(self) -> Mapping[str, ProviderGatewayError]:
+        return {
+            result.provider: result.error
+            for result in self.results
+            if result.error is not None
+        }
+
+    @property
+    def retryable(self) -> bool:
+        return any(result.retryable for result in self.results if result.error)
+
+
+class ArtistGateway:
+    """Facade providing release lookups while reusing provider gateway policies."""
+
+    def __init__(self, *, provider_gateway: ProviderGateway) -> None:
+        self._provider_gateway = provider_gateway
+
+    async def fetch_artist(
+        self,
+        artist_id: str,
+        *,
+        providers: Sequence[str],
+        limit: int = 50,
+    ) -> ArtistGatewayResponse:
+        """Fetch artist releases from the configured providers."""
+
+        effective_limit = max(1, int(limit))
+        query = SearchQuery(text=artist_id, artist=artist_id, limit=effective_limit)
+        response = await self._provider_gateway.search_many(providers, query)
+        results = tuple(self._normalise_result(entry) for entry in response.results)
+        return ArtistGatewayResponse(artist_id=artist_id, results=results)
+
+    def _normalise_result(self, result: ProviderGatewaySearchResult) -> ArtistGatewayResult:
+        artist, releases = self._extract_payload(result)
+        error = result.error
+        retryable = self._is_retryable(error)
+        return ArtistGatewayResult(
+            provider=result.provider,
+            artist=artist,
+            releases=releases,
+            error=error,
+            retryable=retryable,
+        )
+
+    def _extract_payload(
+        self, result: ProviderGatewaySearchResult
+    ) -> tuple[ArtistDTO | None, tuple[ArtistReleaseDTO, ...]]:
+        artist: ArtistDTO | None = None
+        releases: list[ArtistReleaseDTO] = []
+        for track in result.tracks:
+            metadata = getattr(track, "metadata", None)
+            if not isinstance(metadata, Mapping):
+                continue
+            artist_payload = metadata.get("artist")
+            if artist is None and isinstance(artist_payload, Mapping):
+                try:
+                    artist = self._normalise_artist(artist_payload)
+                except ValueError:
+                    artist = None
+            releases_payload = metadata.get("releases")
+            if isinstance(releases_payload, Mapping):
+                releases_payload = [releases_payload]
+            if isinstance(releases_payload, Sequence) and not isinstance(
+                releases_payload, (str, bytes)
+            ):
+                for entry in releases_payload:
+                    if isinstance(entry, Mapping):
+                        normalized = self._normalise_release(entry)
+                        if normalized is not None:
+                            releases.append(normalized)
+            release_payload = metadata.get("release")
+            if isinstance(release_payload, Mapping):
+                normalized = self._normalise_release(release_payload)
+                if normalized is not None:
+                    releases.append(normalized)
+        deduped: dict[str, ArtistReleaseDTO] = {}
+        for release in releases:
+            deduped[release.id] = release
+        if artist is not None and not artist.releases and deduped:
+            artist = ArtistDTO(
+                id=artist.id,
+                etag=artist.etag,
+                fetched_at=artist.fetched_at,
+                provider_cursor=artist.provider_cursor,
+                metadata=artist.metadata,
+                releases=tuple(deduped.values()),
+            )
+        return artist, tuple(deduped.values())
+
+    def _normalise_artist(self, payload: Mapping[str, object]) -> ArtistDTO:
+        raw_id = payload.get("id")
+        if raw_id is None or raw_id == "":
+            raise ValueError("artist payload missing 'id'")
+        artist_id = str(raw_id)
+        etag = self._optional_str(payload.get("etag"))
+        fetched_at = self._coerce_datetime(payload.get("fetched_at"))
+        cursor = self._optional_str(payload.get("provider_cursor") or payload.get("cursor"))
+        metadata = self._extract_metadata(payload, {"id", "etag", "fetched_at", "provider_cursor", "cursor", "releases"})
+        releases_payload = payload.get("releases")
+        releases: tuple[ArtistReleaseDTO, ...] = ()
+        if isinstance(releases_payload, Mapping):
+            releases_payload = [releases_payload]
+        if isinstance(releases_payload, Sequence) and not isinstance(
+            releases_payload, (str, bytes)
+        ):
+            releases = tuple(
+                normalized
+                for entry in releases_payload
+                if isinstance(entry, Mapping)
+                for normalized in [self._normalise_release(entry)]
+                if normalized is not None
+            )
+        return ArtistDTO(
+            id=artist_id,
+            etag=etag,
+            fetched_at=fetched_at,
+            provider_cursor=cursor,
+            metadata=metadata,
+            releases=releases,
+        )
+
+    def _normalise_release(self, payload: Mapping[str, object]) -> ArtistReleaseDTO | None:
+        release_id = payload.get("id")
+        if release_id is None or release_id == "":
+            return None
+        etag = self._optional_str(payload.get("etag"))
+        fetched_at = self._coerce_datetime(payload.get("fetched_at"))
+        cursor = self._optional_str(payload.get("provider_cursor") or payload.get("cursor"))
+        metadata = self._extract_metadata(
+            payload,
+            {"id", "etag", "fetched_at", "provider_cursor", "cursor"},
+        )
+        return ArtistReleaseDTO(
+            id=str(release_id),
+            etag=etag,
+            fetched_at=fetched_at,
+            provider_cursor=cursor,
+            metadata=metadata,
+        )
+
+    @staticmethod
+    def _optional_str(value: object) -> str | None:
+        if value is None:
+            return None
+        return str(value)
+
+    @staticmethod
+    def _extract_metadata(
+        payload: Mapping[str, object], keys: set[str]
+    ) -> Mapping[str, object]:
+        metadata = payload.get("metadata")
+        if isinstance(metadata, Mapping):
+            return dict(metadata)
+        extracted: dict[str, object] = {}
+        for key, value in payload.items():
+            if key in keys:
+                continue
+            extracted[key] = value
+        return extracted
+
+    @staticmethod
+    def _coerce_datetime(value: object) -> datetime | None:
+        if isinstance(value, datetime):
+            return value
+        if isinstance(value, str) and value:
+            try:
+                if value.endswith("Z"):
+                    value = value[:-1] + "+00:00"
+                return datetime.fromisoformat(value)
+            except ValueError:
+                return None
+        return None
+
+    @staticmethod
+    def _is_retryable(error: ProviderGatewayError | None) -> bool:
+        if error is None:
+            return False
+        return isinstance(
+            error,
+            (
+                ProviderGatewayTimeoutError,
+                ProviderGatewayRateLimitedError,
+                ProviderGatewayDependencyError,
+            ),
+        )
+
+
+__all__ = [
+    "ArtistGateway",
+    "ArtistGatewayResponse",
+    "ArtistGatewayResult",
+    "ArtistDTO",
+    "ArtistReleaseDTO",
+]
+

--- a/tests/integrations/test_artist_gateway.py
+++ b/tests/integrations/test_artist_gateway.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.integrations.artist_gateway import ArtistGateway
+from app.integrations.contracts import ProviderTrack, SearchQuery
+from app.integrations.provider_gateway import (
+    ProviderGateway,
+    ProviderGatewaySearchResponse,
+    ProviderGatewaySearchResult,
+    ProviderGatewayTimeoutError,
+)
+
+
+def _search_response(*results: ProviderGatewaySearchResult) -> ProviderGatewaySearchResponse:
+    return ProviderGatewaySearchResponse(results=results)
+
+
+@pytest.mark.asyncio
+async def test_fetch_artist_normalises_payload() -> None:
+    provider_gateway = AsyncMock(spec=ProviderGateway)
+    provider_gateway.search_many.return_value = _search_response(
+        ProviderGatewaySearchResult(
+            provider="spotify",
+            tracks=(
+                ProviderTrack(
+                    name="Test Track",
+                    provider="spotify",
+                    metadata={
+                        "artist": {
+                            "id": "artist-1",
+                            "etag": "artist-etag",
+                            "fetched_at": "2024-01-01T12:00:00Z",
+                            "provider_cursor": "artist-cursor",
+                            "metadata": {"name": "Test Artist"},
+                        },
+                        "releases": [
+                            {
+                                "id": "release-1",
+                                "etag": "release-etag",
+                                "fetched_at": "2024-01-02T08:30:00Z",
+                                "provider_cursor": "release-cursor",
+                                "metadata": {"name": "Test Release"},
+                            }
+                        ],
+                    },
+                ),
+            ),
+        ),
+    )
+
+    gateway = ArtistGateway(provider_gateway=provider_gateway)
+    response = await gateway.fetch_artist("artist-1", providers=("spotify",), limit=20)
+
+    provider_gateway.search_many.assert_awaited_once()
+    args, _ = provider_gateway.search_many.call_args
+    assert args[0] == ("spotify",)
+    assert isinstance(args[1], SearchQuery)
+    assert args[1].text == "artist-1"
+    assert args[1].limit == 20
+
+    assert response.artist_id == "artist-1"
+    assert len(response.results) == 1
+
+    result = response.results[0]
+    assert result.provider == "spotify"
+    assert result.error is None
+    assert result.retryable is False
+    assert result.artist is not None
+    assert result.artist.id == "artist-1"
+    assert result.artist.etag == "artist-etag"
+    assert result.artist.provider_cursor == "artist-cursor"
+    assert result.artist.fetched_at == datetime(2024, 1, 1, 12, 0, tzinfo=timezone.utc)
+    assert result.artist.metadata == {"name": "Test Artist"}
+    assert len(result.releases) == 1
+
+    release = result.releases[0]
+    assert release.id == "release-1"
+    assert release.etag == "release-etag"
+    assert release.provider_cursor == "release-cursor"
+    assert release.fetched_at == datetime(2024, 1, 2, 8, 30, tzinfo=timezone.utc)
+    assert release.metadata == {"name": "Test Release"}
+    assert response.releases == result.releases
+
+
+@pytest.mark.asyncio
+async def test_fetch_artist_records_retryable_error() -> None:
+    error = ProviderGatewayTimeoutError("spotify", timeout_ms=5000)
+    provider_gateway = AsyncMock(spec=ProviderGateway)
+    provider_gateway.search_many.return_value = _search_response(
+        ProviderGatewaySearchResult(
+            provider="spotify",
+            tracks=tuple(),
+            error=error,
+        )
+    )
+
+    gateway = ArtistGateway(provider_gateway=provider_gateway)
+    response = await gateway.fetch_artist("artist-1", providers=("spotify",), limit=5)
+
+    result = response.results[0]
+    assert result.error is error
+    assert result.retryable is True
+    assert result.artist is None
+    assert result.releases == ()
+    assert response.errors == {"spotify": error}
+    assert response.retryable is True
+    assert response.releases == ()
+
+
+@pytest.mark.asyncio
+async def test_fetch_artist_deduplicates_releases() -> None:
+    provider_gateway = AsyncMock(spec=ProviderGateway)
+    provider_gateway.search_many.return_value = _search_response(
+        ProviderGatewaySearchResult(
+            provider="spotify",
+            tracks=(
+                ProviderTrack(
+                    name="",
+                    provider="spotify",
+                    metadata={
+                        "release": {
+                            "id": "release-1",
+                            "etag": "etag-1",
+                            "metadata": {"name": "First"},
+                        }
+                    },
+                ),
+            ),
+        ),
+        ProviderGatewaySearchResult(
+            provider="slskd",
+            tracks=(
+                ProviderTrack(
+                    name="",
+                    provider="slskd",
+                    metadata={
+                        "releases": [
+                            {
+                                "id": "release-1",
+                                "etag": "etag-override",
+                                "metadata": {"name": "Override"},
+                            },
+                            {
+                                "id": "release-2",
+                                "etag": "etag-2",
+                                "metadata": {"name": "Second"},
+                            },
+                        ]
+                    },
+                ),
+            ),
+        ),
+    )
+
+    gateway = ArtistGateway(provider_gateway=provider_gateway)
+    response = await gateway.fetch_artist("artist-1", providers=("spotify", "slskd"), limit=10)
+
+    assert len(response.results) == 2
+    aggregated = response.releases
+    assert {release.id for release in aggregated} == {"release-1", "release-2"}
+
+    release_map = {release.id: release for release in aggregated}
+    assert release_map["release-1"].etag == "etag-override"
+    assert release_map["release-1"].metadata == {"name": "Override"}
+    assert release_map["release-2"].metadata == {"name": "Second"}
+    assert response.retryable is False


### PR DESCRIPTION
## Summary
- add artist and release DTOs plus an ArtistGateway wrapper over the ProviderGateway
- expose the gateway objects from the integrations package and cover them with unit tests

## Testing
- pytest tests/integrations/test_artist_gateway.py

No ToDo changes required

------
https://chatgpt.com/codex/tasks/task_e_68e4000f7ce48321849c2fe634f7b9ab