### PR TITLE
feat: expose artist workflow configuration controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -480,9 +480,10 @@ try-Zugriffs im CI bewusst ausgelassen.
 | `WATCHLIST_TICK_BUDGET_MS` | int | `8000` | Budget pro Verarbeitungsschritt. | — |
 | `WATCHLIST_BACKOFF_BASE_MS` | int | `250` | Basiswert für den Backoff bei Fehlern. | — |
 | `WATCHLIST_RETRY_MAX` | int | `3` | Retries pro Tick vor Eskalation. | — |
-| `WATCHLIST_RETRY_BUDGET_PER_ARTIST` | int | `6` | Gesamtretry-Budget pro Artist innerhalb des Cooldowns. | — |
+| `WATCHLIST_RETRY_BUDGET_PER_ARTIST` | int | `6` | Gesamtretry-Budget pro Artist innerhalb des Cooldowns (Fallback, wenn kein Artist-Override gesetzt ist). | — |
+| `ARTIST_MAX_RETRY_PER_ARTIST` | int | `6` | Override für das Retry-Budget einzelner Artists; ersetzt den Watchlist-Wert und wird auf `[1, 20]` begrenzt. | — |
 | `WATCHLIST_COOLDOWN_MINUTES` | int | `15` | Pause nach fehlerhaften Läufen. | — |
-| `WATCHLIST_COOLDOWN_S` | int | `300` | Alternative Sekundenangabe für den Artist-Cooldown (überschreibt Minutenwert). | — |
+| `ARTIST_COOLDOWN_S` | int | `900` | Sekundenbasierter Cooldown pro Artist; wird auf Minuten gerundet und überschreibt den Minutenwert. | — |
 | `WATCHLIST_DB_IO_MODE` | string | `thread` | Datenbankmodus (`thread` oder `async`). | — |
 | `WATCHLIST_JITTER_PCT` | float | `0.2` | Zufallsjitter für Backoff-Delays. | — |
 | `WATCHLIST_SHUTDOWN_GRACE_MS` | int | `2000` | Grace-Periode beim Shutdown. | — |
@@ -552,6 +553,9 @@ Harmony bündelt alle Hintergrundjobs in einem Orchestrator, der die Queue prior
 | `ORCH_GLOBAL_CONCURRENCY` | int | `8` | Globale Obergrenze paralleler Dispatcher-Tasks. | — |
 | `ORCH_HEARTBEAT_S` | int | `20` | Zielintervall für Dispatcher-Heartbeats (greift zusätzlich zur 50%-Lease-Regel). | — |
 | `ORCH_POOL_<JOB>` | int | `sync=4`, `matching=4`, `retry=2`, `watchlist=2` | Optionale per-Job-Limits (z. B. `ORCH_POOL_SYNC=3`). Fällt ohne Wert auf das globale Limit zurück. | — |
+| `ARTIST_POOL_CONCURRENCY` | int | `2` | Gemeinsames Limit für `artist_refresh`- und `artist_delta`-Pools; überschreibt die Einzelwerte. | — |
+| `ARTIST_PRIORITY` | int | `50` | Setzt eine einheitliche Priorität für Artist-Jobs und überschreibt `ORCH_PRIORITY_*`. | — |
+| `ARTIST_CACHE_INVALIDATE` | bool | `false` | Aktiviert Cache-Hints & Invalidierung für Artist-Workflows im Orchestrator. | — |
 
 ### Background Workers
 

--- a/app/main.py
+++ b/app/main.py
@@ -45,6 +45,8 @@ def _initial_orchestrator_status(*, artwork_enabled: bool, lyrics_enabled: bool)
             "matching": True,
             "retry": True,
             "watchlist": True,
+            "artist_refresh": True,
+            "artist_delta": True,
             "artwork": artwork_enabled,
             "lyrics": lyrics_enabled,
         },
@@ -433,6 +435,8 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
             "matching": True,
             "retry": True,
             "watchlist": True,
+            "artist_refresh": True,
+            "artist_delta": True,
             "artwork": enable_artwork,
             "lyrics": enable_lyrics,
         }

--- a/app/orchestrator/handlers.py
+++ b/app/orchestrator/handlers.py
@@ -34,6 +34,7 @@ from app.core.matching_engine import MusicMatchingEngine
 from app.core.soulseek_client import SoulseekClient
 from app.core.spotify_client import SpotifyClient
 from app.db import run_session, session_scope
+from app.dependencies import get_app_config
 from app.integrations.normalizers import normalize_slskd_candidate, normalize_spotify_track
 from app.logging import get_logger
 from app.logging_events import log_event
@@ -644,6 +645,8 @@ class ArtistRefreshHandlerDeps:
         self.refresh_priority = _coerce_priority(self.refresh_priority)
         self.retry_budget = max(1, int(self.config.retry_budget_per_artist))
         self.cooldown_minutes = max(0, int(self.config.cooldown_minutes))
+        if not get_app_config().features.enable_artist_cache_invalidation:
+            self.cache_service = None
 
 
 @dataclass(slots=True)
@@ -681,6 +684,8 @@ class ArtistDeltaHandlerDeps:
         self.backoff_base_ms = max(0, int(self.config.backoff_base_ms))
         self.jitter_pct = max(0.0, float(self.config.jitter_pct))
         self.retry_max = max(1, int(self.config.retry_max))
+        if not get_app_config().features.enable_artist_cache_invalidation:
+            self.cache_service = None
 
 
 WatchlistHandlerDeps = ArtistDeltaHandlerDeps

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -55,7 +55,8 @@ Der frühere Pfad `app/routers/*` stellt nur noch Legacy-Reexports bereit und da
 1. Timer löst gemäß `WATCHLIST_INTERVAL` aus, liest Artists mit fälligem `last_checked`.
 2. Service erstellt pro Artist einen Job (`watchlist.sync`) und setzt Idempotency-Key `watchlist:<artist-id>:<tick-start>`.
 3. Worker lädt Spotify-Releases, mappt auf Downloads und triggert Soulseek-Enqueue über den ProviderGateway.
-4. Erfolgreiche Läufe löschen Retry-Cooldowns (`event=watchlist.cooldown.clear`), Fehler loggen `event=watchlist.cooldown.skip` und respektieren Budget/Backoff.
+4. Erfolgreiche Läufe löschen Retry-Cooldowns (`event=watchlist.cooldown.clear`), Fehler loggen `event=watchlist.cooldown.skip` und respektieren Budget/Backoff. `ARTIST_MAX_RETRY_PER_ARTIST` und `ARTIST_COOLDOWN_S` überschreiben die Watchlist-Defaults für Budget und Cooldown sekundengenau.
+5. Ist `ARTIST_CACHE_INVALIDATE=true`, schreiben die Refresh-/Delta-Handler Cache-Hints (`event=artist.delta`) bzw. räumen Einträge via `cache.evict`.
 
 ## Fehler-, Retry- und Idempotenzverträge
 
@@ -68,7 +69,7 @@ Der frühere Pfad `app/routers/*` stellt nur noch Legacy-Reexports bereit und da
 ## Konfiguration & Feature-Flags
 
 - **Konfigurationsmatrix:** `docs/ops/runtime-config.md` listet relevante ENV-Variablen (Ingest, Watchlist, Provider, Orchestrator). Neue Parameter dort und in dieser Übersicht verlinken.
-- **Feature-Flags:** `ENABLE_LYRICS`, `ENABLE_ARTWORK`, `INGEST_MAX_PENDING_JOBS`, `WATCHLIST_MAX_CONCURRENCY` u. a. werden in Services geprüft und müssen hier dokumentiert bleiben.
+- **Feature-Flags:** `ENABLE_LYRICS`, `ENABLE_ARTWORK`, `ARTIST_CACHE_INVALIDATE`, `INGEST_MAX_PENDING_JOBS`, `WATCHLIST_MAX_CONCURRENCY` u. a. werden in Services geprüft und müssen hier dokumentiert bleiben.
 - **Observability:** Structured Logs sind primär, Metriken entfallen. Externe Systeme abonnieren `event=request`, `event=worker_job`, `event=integration_call`.
 - **Caching:** `CACHE_WRITE_THROUGH` sorgt für sofortige Invalidierung der Spotify-Playlist-Routen; `cache.evict`-Events dokumentieren gezielte Räumungen.
 

--- a/tests/config/test_orchestrator_config.py
+++ b/tests/config/test_orchestrator_config.py
@@ -48,6 +48,19 @@ def test_bounds_and_defaults_applied() -> None:
     assert config.poll_interval_ms == 10
 
 
+def test_artist_pool_and_priority_overrides() -> None:
+    env = {
+        "ARTIST_POOL_CONCURRENCY": "5",
+        "ARTIST_PRIORITY": "88",
+    }
+    config = OrchestratorConfig.from_env(env)
+
+    assert config.pool_artist_refresh == 5
+    assert config.pool_artist_delta == 5
+    assert config.priority_map["artist_refresh"] == 88
+    assert config.priority_map["artist_delta"] == 88
+
+
 def test_settings_retry_policy_from_env() -> None:
     env = {
         "RETRY_MAX_ATTEMPTS": "7",

--- a/tests/workers/test_watchlist_defaults.py
+++ b/tests/workers/test_watchlist_defaults.py
@@ -43,6 +43,19 @@ def test_defaults_loaded_and_clamped(monkeypatch: pytest.MonkeyPatch) -> None:
     assert config.jitter_pct == 1.0
 
 
+def test_watchlist_cooldown_and_retry_budget_enforced(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("DATABASE_URL", "sqlite:///:memory:")
+    monkeypatch.setenv("ARTIST_COOLDOWN_S", "59")
+    monkeypatch.setenv("ARTIST_MAX_RETRY_PER_ARTIST", "25")
+    monkeypatch.setenv("WATCHLIST_COOLDOWN_MINUTES", "5")
+    monkeypatch.setenv("WATCHLIST_RETRY_BUDGET_PER_ARTIST", "2")
+
+    config = load_config().watchlist
+
+    assert config.cooldown_minutes == 1
+    assert config.retry_budget_per_artist == 20
+
+
 @pytest.mark.asyncio
 async def test_worker_enqueues_due_artists() -> None:
     for index in range(3):


### PR DESCRIPTION
## Summary
- surface artist orchestrator configuration (cooldown, retry, pool, priority, cache invalidation) in app settings and feature flags
- update orchestrator handlers and FastAPI bootstrap to respect artist cache toggles and reflect artist job status in readiness data
- document the new environment variables and add regression coverage for artist handlers, delta detection, DAO versioning, and watchlist defaults

## Testing
- pytest tests/orchestrator/test_artist_handlers.py tests/orchestrator/test_dispatcher.py tests/services/test_artist_delta.py tests/services/test_artist_workflow_dao.py tests/config/test_orchestrator_config.py
- pytest tests/workers/test_watchlist_defaults.py -vv *(hangs locally; interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68e484f7b484832181f27cbddeae687c