### PR TITLE
feat: add provider album and top-track support

### DIFF
--- a/app/core/spotify_client.py
+++ b/app/core/spotify_client.py
@@ -486,6 +486,14 @@ class SpotifyClient:
             album_type="album,single,compilation",
         )
 
+    def get_artist_top_tracks(
+        self, artist_id: str, *, market: Optional[str] = None
+    ) -> Dict[str, Any]:
+        params: Dict[str, Any] = {}
+        if market:
+            params["market"] = market
+        return self._execute(self._client.artist_top_tracks, artist_id, **params)
+
     def get_album_tracks(  # noqa: F811
         self, album_id: str, *, market: Optional[str] = None
     ) -> Dict[str, Any]:

--- a/app/integrations/contracts.py
+++ b/app/integrations/contracts.py
@@ -43,6 +43,19 @@ class ProviderAlbum:
     id: str | None = None
     artists: tuple[ProviderArtist, ...] = ()
     metadata: Mapping[str, object] = field(default_factory=dict)
+    release_date: str | None = None
+    total_tracks: int | None = None
+    images: tuple[str, ...] = ()
+
+
+@dataclass(slots=True, frozen=True)
+class ProviderAlbumDetails:
+    """Detailed album metadata including the canonical track listing."""
+
+    source: str
+    album: ProviderAlbum
+    tracks: tuple["ProviderTrack", ...] = ()
+    metadata: Mapping[str, object] = field(default_factory=dict)
 
 
 @dataclass(slots=True, frozen=True)
@@ -165,9 +178,18 @@ class TrackProvider(Protocol):
     ) -> list[ProviderRelease]:
         """Return releases associated with the supplied artist."""
 
+    async def fetch_album(self, album_source_id: str) -> ProviderAlbumDetails | None:
+        """Return detailed album metadata for the supplied identifier."""
+
+    async def fetch_artist_top_tracks(
+        self, artist_source_id: str, *, limit: int | None = None
+    ) -> list[ProviderTrack]:
+        """Return the provider's notion of an artist's top tracks."""
+
 
 __all__ = [
     "ProviderAlbum",
+    "ProviderAlbumDetails",
     "ProviderArtist",
     "ProviderDependencyError",
     "ProviderError",

--- a/app/integrations/provider_gateway.py
+++ b/app/integrations/provider_gateway.py
@@ -9,6 +9,7 @@ from typing import Awaitable, Callable, Mapping, Sequence, TypeVar
 
 from app.config import ExternalCallPolicy, ProviderProfile, settings
 from app.integrations.contracts import (
+    ProviderAlbumDetails,
     ProviderArtist,
     ProviderDependencyError,
     ProviderError,
@@ -347,6 +348,23 @@ class ProviderGateway:
             lambda adapter: adapter.fetch_artist_releases(artist_source_id, limit=limit),
         )
         return list(releases)
+
+    async def fetch_album(self, provider: str, album_source_id: str) -> ProviderAlbumDetails | None:
+        return await self._execute_provider_call(
+            provider,
+            "fetch_album",
+            lambda adapter: adapter.fetch_album(album_source_id),
+        )
+
+    async def fetch_artist_top_tracks(
+        self, provider: str, artist_source_id: str, *, limit: int | None = None
+    ) -> list[ProviderTrack]:
+        tracks = await self._execute_provider_call(
+            provider,
+            "fetch_artist_top_tracks",
+            lambda adapter: adapter.fetch_artist_top_tracks(artist_source_id, limit=limit),
+        )
+        return list(tracks)
 
     @staticmethod
     def _jitter_pct(policy: ProviderRetryPolicy) -> int:

--- a/tests/integrations/test_provider_gateway_artist_flow.py
+++ b/tests/integrations/test_provider_gateway_artist_flow.py
@@ -2,7 +2,14 @@ from __future__ import annotations
 
 import pytest
 
-from app.integrations.contracts import ProviderArtist, ProviderRelease, ProviderTrack, SearchQuery
+from app.integrations.contracts import (
+    ProviderAlbum,
+    ProviderAlbumDetails,
+    ProviderArtist,
+    ProviderRelease,
+    ProviderTrack,
+    SearchQuery,
+)
 from app.integrations.provider_gateway import (
     ProviderGateway,
     ProviderGatewayConfig,
@@ -15,6 +22,8 @@ class DummyProvider:
         self.name = name
         self.artist_calls: list[tuple[str | None, str | None]] = []
         self.release_calls: list[tuple[str, int | None]] = []
+        self.album_calls: list[str] = []
+        self.top_calls: list[tuple[str, int | None]] = []
 
     async def search_tracks(self, query: SearchQuery) -> list[ProviderTrack]:
         return []
@@ -44,6 +53,23 @@ class DummyProvider:
             )
         ]
 
+    async def fetch_album(self, album_source_id: str) -> ProviderAlbumDetails:
+        self.album_calls.append(album_source_id)
+        album = ProviderAlbum(name=f"{self.name.title()} Album", id=album_source_id)
+        return ProviderAlbumDetails(
+            source=self.name,
+            album=album,
+            tracks=(
+                ProviderTrack(name="Top Song", provider=self.name),
+            ),
+        )
+
+    async def fetch_artist_top_tracks(
+        self, artist_source_id: str, *, limit: int | None = None
+    ) -> list[ProviderTrack]:
+        self.top_calls.append((artist_source_id, limit))
+        return [ProviderTrack(name=f"{self.name.title()} Hit", provider=self.name)]
+
 
 @pytest.mark.asyncio
 async def test_gateway_returns_uniform_dtos_for_all_providers() -> None:
@@ -63,16 +89,30 @@ async def test_gateway_returns_uniform_dtos_for_all_providers() -> None:
 
     spotify_artist = await gateway.fetch_artist("spotify", artist_id="artist-1")
     spotify_releases = await gateway.fetch_artist_releases("spotify", "artist-1", limit=5)
+    spotify_album = await gateway.fetch_album("spotify", "album-1")
+    spotify_top_tracks = await gateway.fetch_artist_top_tracks("spotify", "artist-1", limit=3)
     slskd_artist = await gateway.fetch_artist("slskd", artist_id="artist-1")
     slskd_releases = await gateway.fetch_artist_releases("slskd", "artist-1")
+    slskd_album = await gateway.fetch_album("slskd", "album-2")
+    slskd_top_tracks = await gateway.fetch_artist_top_tracks("slskd", "artist-1")
 
     assert spotify_artist.source == "spotify"
     assert spotify_artist.name == "Spotify Artist"
     assert spotify_releases[0].source == "spotify"
+    assert spotify_album.source == "spotify"
+    assert spotify_album.album.name == "Spotify Album"
+    assert spotify_top_tracks[0].provider == "spotify"
     assert slskd_artist.source == "slskd"
     assert slskd_releases[0].source == "slskd"
+    assert slskd_album.source == "slskd"
+    assert slskd_album.album.name == "Slskd Album"
+    assert slskd_top_tracks[0].provider == "slskd"
 
     assert spotify.artist_calls == [("artist-1", None)]
     assert slskd.artist_calls == [("artist-1", None)]
     assert spotify.release_calls == [("artist-1", 5)]
     assert slskd.release_calls == [("artist-1", None)]
+    assert spotify.album_calls == ["album-1"]
+    assert slskd.album_calls == ["album-2"]
+    assert spotify.top_calls == [("artist-1", 3)]
+    assert slskd.top_calls == [("artist-1", None)]

--- a/tests/integrations/test_provider_gateway_new_endpoints.py
+++ b/tests/integrations/test_provider_gateway_new_endpoints.py
@@ -1,0 +1,75 @@
+import pytest
+
+from app.integrations.contracts import (
+    ProviderAlbumDetails,
+    ProviderArtist,
+    ProviderNotFoundError,
+    ProviderRelease,
+    ProviderTimeoutError,
+    ProviderTrack,
+    SearchQuery,
+)
+from app.integrations.provider_gateway import (
+    ProviderGateway,
+    ProviderGatewayConfig,
+    ProviderGatewayNotFoundError,
+    ProviderGatewayTimeoutError,
+    ProviderRetryPolicy,
+)
+
+
+class _StubProvider:
+    def __init__(self) -> None:
+        self.name = "stub"
+
+    async def search_tracks(self, query: SearchQuery) -> list[ProviderTrack]:
+        return []
+
+    async def fetch_artist(
+        self, *, artist_id: str | None = None, name: str | None = None
+    ) -> ProviderArtist | None:
+        return None
+
+    async def fetch_artist_releases(
+        self, artist_source_id: str, *, limit: int | None = None
+    ) -> list[ProviderRelease]:
+        return []
+
+    async def fetch_album(self, album_source_id: str) -> ProviderAlbumDetails:
+        raise ProviderTimeoutError(self.name, 1000)
+
+    async def fetch_artist_top_tracks(
+        self, artist_source_id: str, *, limit: int | None = None
+    ) -> list[ProviderTrack]:
+        raise ProviderNotFoundError(self.name, "missing", status_code=404)
+
+
+def _gateway(provider: _StubProvider) -> ProviderGateway:
+    policy = ProviderRetryPolicy(
+        timeout_ms=10,
+        retry_max=0,
+        backoff_base_ms=10,
+        jitter_pct=0.0,
+    )
+    config = ProviderGatewayConfig(
+        max_concurrency=1,
+        default_policy=policy,
+        provider_policies={"stub": policy},
+    )
+    return ProviderGateway(providers={"stub": provider}, config=config)
+
+
+@pytest.mark.asyncio
+async def test_fetch_album_timeout_maps_to_gateway_error() -> None:
+    gateway = _gateway(_StubProvider())
+
+    with pytest.raises(ProviderGatewayTimeoutError):
+        await gateway.fetch_album("stub", "album-1")
+
+
+@pytest.mark.asyncio
+async def test_fetch_artist_top_tracks_maps_not_found() -> None:
+    gateway = _gateway(_StubProvider())
+
+    with pytest.raises(ProviderGatewayNotFoundError):
+        await gateway.fetch_artist_top_tracks("stub", "artist-1")


### PR DESCRIPTION
## Summary
- add ProviderAlbumDetails and extend the provider gateway with album and top-track fetch operations
- update Spotify and slskd adapters plus normalizers to normalize album metadata consistently
- add integration tests for normalization coverage, gateway error mapping, and adapter helpers

## Testing
- pytest tests/integrations

No ToDo changes required

------
https://chatgpt.com/codex/tasks/task_e_68e50168fa98832182ffa04d9d90236b