### PR TITLE
feat: hash artist releases during scan

### DIFF
--- a/app/services/artist_workflow_dao.py
+++ b/app/services/artist_workflow_dao.py
@@ -27,6 +27,7 @@ class ArtistWorkflowArtistRow:
     name: str
     last_checked: datetime | None
     retry_block_until: datetime | None
+    last_hash: str | None
 
 
 class ArtistWorkflowDAO:
@@ -55,6 +56,7 @@ class ArtistWorkflowDAO:
                     name=record.name,
                     last_checked=record.last_checked,
                     retry_block_until=record.retry_block_until,
+                    last_hash=record.last_hash,
                 )
 
         return _query()
@@ -104,6 +106,7 @@ class ArtistWorkflowDAO:
                         name=record.name,
                         last_checked=record.last_checked,
                         retry_block_until=record.retry_block_until,
+                        last_hash=record.last_hash,
                     )
                     for record in records
                 ]
@@ -139,6 +142,7 @@ class ArtistWorkflowDAO:
         *,
         checked_at: datetime | None = None,
         known_releases: Sequence[ArtistKnownRelease] | None = None,
+        content_hash: str | None = None,
     ) -> None:
         """Record a successful run and optionally persist known releases."""
 
@@ -151,6 +155,7 @@ class ArtistWorkflowDAO:
                     return
                 record.last_checked = timestamp
                 record.last_scan_at = timestamp
+                record.last_hash = content_hash
                 record.retry_block_until = None
                 record.updated_at = self._now_factory()
                 session.add(record)
@@ -221,6 +226,7 @@ class ArtistWorkflowDAO:
                 name=row.name,
                 last_checked=row.last_scan_at,
                 retry_block_until=row.retry_block_until,
+                last_hash=row.last_hash,
             )
             for row in rows
         ]

--- a/tests/services/test_artist_workflow_dao.py
+++ b/tests/services/test_artist_workflow_dao.py
@@ -37,13 +37,19 @@ def test_mark_success_updates_state_and_known_releases() -> None:
     checked_at = datetime(2024, 1, 1, 12, 0, 0)
     release = ArtistKnownRelease(track_id="track-1", etag="etag-1", fetched_at=checked_at)
 
-    dao.mark_success(artist_id, checked_at=checked_at, known_releases=[release])
+    dao.mark_success(
+        artist_id,
+        checked_at=checked_at,
+        known_releases=[release],
+        content_hash="hash-123",
+    )
 
     with session_scope() as session:
         artist = session.get(WatchlistArtist, artist_id)
         assert artist is not None
         assert artist.last_checked == checked_at
         assert artist.retry_block_until is None
+        assert artist.last_hash == "hash-123"
         rows = (
             session.execute(
                 select(ArtistKnownReleaseRecord).where(


### PR DESCRIPTION
## Summary
* add canonical serialization and hashing helpers to the library service for deterministic content fingerprints【F:app/services/library_service.py†L83-L178】
* capture artist release state in the orchestrator, short-circuit on unchanged hashes, and evict caches only when data changes【F:app/orchestrator/handlers.py†L892-L1096】【F:app/orchestrator/handlers.py†L1691-L1829】
* persist the last scan hash on watchlist artists and extend tests to cover unchanged hashes, hash-driven refreshes, and cache eviction behaviour【F:app/services/artist_workflow_dao.py†L22-L170】【F:tests/orchestrator/test_artist_handlers.py†L277-L462】【F:tests/services/test_library_service_dto_contract.py†L72-L105】

## Testing
* `pytest tests/services/test_library_service_dto_contract.py`【a1a9fb†L1-L16】
* `pytest tests/orchestrator/test_artist_handlers.py`【84887f†L1-L15】

------
https://chatgpt.com/codex/tasks/task_e_68e504fdf45c8321b046fb8774e931b6