### PR TITLE
feat: artist watchlist and detail ui [CODX-P1-ART-FE-501]

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Harmony setzt auf ein geschichtetes Kernsystem (Router → Services → Domain �
 ## Features
 
 - **Harmony Web UI (React + Vite)** mit Dashboard, Service-Tabs, Tabellen, Karten und Dark-/Light-Mode.
+- **Artist Watchlist & Detail UI** unter `/artists` mit Prioritäts-Management, Match-Kuration und Queue-Aktionen (siehe [docs/frontend/artists-ui.md](docs/frontend/artists-ui.md)).
 - **Vollständige Spotify-Integration** für Suche, Playlists, Audio-Features, Empfehlungen und Benutzerbibliotheken.
 - **Spotify FREE-Modus** für parserbasierte Imports ohne OAuth inklusive Free-Ingest-Pipeline: Text- oder Datei-Eingaben sowie bis zu 100 Playlist-Links werden normalisiert, dedupliziert und als Soulseek-Downloads in Batches eingeplant.
 - **Spotify PRO Backfill** reichert bestehende FREE-Ingest-Daten nach OAuth-Setup automatisch mit Spotify-IDs, ISRCs und Laufzeiten an und expandiert gemeldete Playlist-Links zu vollständigen Tracklisten.

--- a/docs/frontend/artists-ui.md
+++ b/docs/frontend/artists-ui.md
@@ -1,0 +1,26 @@
+# Artist Watchlist & Detail UI
+
+Die neue Artist-Oberfläche ist unter `/artists` erreichbar und bündelt Watchlist, Detailansicht, Match-Kuration sowie Sync-Aktionen in einem konsistenten Workflow.
+
+## Watchlist (`/artists`)
+
+- Reaktive Tabelle mit Suchfeld und Filtern für Priorität und Gesundheitsstatus.
+- Inline-Aktionen pro Artist: Priorität, Sync-Intervall, Details, Entfernen.
+- Hinzufügen-Formular für Spotify-Artist-ID + Name mit Validierung und Toast-Feedback.
+- Badge-Highlights für offene Matches; Navigation zur Detailseite mit einem Klick.
+
+## Detailansicht (`/artists/:id`)
+
+- Header mit externen IDs, letztem Sync und direktem Zugriff auf Resync/Invalidate.
+- Tabs: **Overview** (Health & Watchlist), **Releases** (filterbar nach Typ), **Matches** (Accept/Reject mit Status-Badges), **Activity** (chronologisches Log mit ScrollArea).
+- Queue-Panel mit Status, Versuchen, ETA und Triggern (Bestätigung via Dialog).
+- Regelmäßiges Polling (20 s) für den Sync-/Queue-Status.
+
+## UX & Technik
+
+- Shadcn/Radix-Komponenten (Tabs, Select, ScrollArea, Toast) und Tailwind-Theme (Dark/Light).
+- React-Query-ähnlicher Client für Caching/Refetch (`src/lib/query`).
+- API-Services: `listArtists`, `getArtistDetail`, `updateWatchlistEntry`, `updateArtistMatchStatus`, `enqueueArtistResync`, `invalidateArtistCache`.
+- Tests (Jest + RTL): Routing, Watchlist-Interaktionen, Match-Aktionen, Queue-Polling, A11y-Rollen.
+
+Siehe Implementierung in `frontend/src/pages/Artists/` und `frontend/src/api/services/artists.ts` für Details zu Komponenten und Parsing.

--- a/frontend/src/__tests__/ArtistDetailPage.test.tsx
+++ b/frontend/src/__tests__/ArtistDetailPage.test.tsx
@@ -1,0 +1,138 @@
+import userEvent from '@testing-library/user-event';
+import { screen, waitFor } from '@testing-library/react';
+
+import ArtistDetailPage from '../pages/Artists/ArtistDetailPage';
+import { renderWithProviders } from '../test-utils';
+import {
+  enqueueArtistResync,
+  getArtistDetail,
+  invalidateArtistCache,
+  updateArtistMatchStatus
+} from '../api/services/artists';
+
+jest.mock('../api/services/artists', () => ({
+  ...jest.requireActual('../api/services/artists'),
+  getArtistDetail: jest.fn(),
+  enqueueArtistResync: jest.fn(),
+  invalidateArtistCache: jest.fn(),
+  updateArtistMatchStatus: jest.fn()
+}));
+
+const mockedGetArtistDetail = getArtistDetail as jest.MockedFunction<typeof getArtistDetail>;
+const mockedEnqueueResync = enqueueArtistResync as jest.MockedFunction<typeof enqueueArtistResync>;
+const mockedInvalidateCache = invalidateArtistCache as jest.MockedFunction<typeof invalidateArtistCache>;
+const mockedUpdateMatchStatus = updateArtistMatchStatus as jest.MockedFunction<typeof updateArtistMatchStatus>;
+
+const createDetailResponse = () => ({
+  artist: {
+    id: 'artist-1',
+    name: 'First Artist',
+    external_ids: { spotify: 'spotify:artist:1' },
+    watchlist: {
+      id: 'watch-1',
+      enabled: true,
+      priority: 'medium',
+      interval_days: 7,
+      last_synced_at: '2024-05-01T10:00:00Z',
+      next_sync_at: '2024-05-08T10:00:00Z'
+    },
+    health_status: 'ok',
+    releases_total: 2,
+    matches_pending: 1,
+    updated_at: '2024-05-02T10:00:00Z'
+  },
+  releases: [
+    {
+      id: 'rel-1',
+      title: 'Album A',
+      type: 'album',
+      released_at: '2024-01-10T00:00:00Z',
+      spotify_url: 'https://example.com'
+    }
+  ],
+  matches: [
+    {
+      id: 'match-1',
+      title: 'Track X',
+      confidence: 0.82,
+      release_title: 'Album A',
+      provider: 'Spotify',
+      status: 'pending',
+      badges: [{ label: 'Neu', tone: 'info' }],
+      submitted_at: '2024-05-03T12:00:00Z'
+    }
+  ],
+  activity: [
+    {
+      id: 'act-1',
+      created_at: '2024-05-02T11:00:00Z',
+      message: 'Sync abgeschlossen',
+      category: 'sync',
+      meta: null
+    }
+  ],
+  queue: {
+    status: 'running',
+    attempts: 1,
+    eta: '2024-05-06T12:00:00Z'
+  }
+});
+
+describe('ArtistDetailPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedGetArtistDetail.mockResolvedValue(createDetailResponse());
+    mockedEnqueueResync.mockResolvedValue();
+    mockedInvalidateCache.mockResolvedValue();
+    mockedUpdateMatchStatus.mockResolvedValue();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('zeigt Artist-Details und Tabs an', async () => {
+    renderWithProviders(<ArtistDetailPage />, { route: '/artists/artist-1' });
+
+    expect(await screen.findByText('Sync-Aktionen')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'First Artist', level: 1 })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'Overview' })).toHaveAttribute('data-state', 'active');
+    expect(mockedGetArtistDetail).toHaveBeenCalledWith('artist-1');
+  });
+
+  it('ermöglicht Match-Aktionen sowie Resync und Cache-Invalidierung', async () => {
+    const toastSpy = jest.fn();
+    const resyncConfirm = jest.spyOn(window, 'confirm').mockReturnValue(true);
+
+    renderWithProviders(<ArtistDetailPage />, { route: '/artists/artist-1', toastFn: toastSpy });
+
+    await screen.findByText('Track X');
+
+    await userEvent.click(screen.getByRole('button', { name: /Accept/i }));
+    await waitFor(() =>
+      expect(mockedUpdateMatchStatus).toHaveBeenCalledWith('artist-1', 'match-1', 'accept')
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: 'Resync' }));
+    await waitFor(() => expect(mockedEnqueueResync).toHaveBeenCalledWith('artist-1'));
+
+    await userEvent.click(screen.getByRole('button', { name: 'Invalidate Cache' }));
+    await waitFor(() => expect(mockedInvalidateCache).toHaveBeenCalledWith('artist-1'));
+
+    expect(toastSpy).toHaveBeenCalled();
+    resyncConfirm.mockRestore();
+  });
+
+  it('pollt den Queue-Status in Intervallen', async () => {
+    jest.useFakeTimers();
+    renderWithProviders(<ArtistDetailPage />, { route: '/artists/artist-1' });
+
+    await screen.findByText('Track X');
+    mockedGetArtistDetail.mockClear();
+
+    jest.advanceTimersByTime(20000);
+
+    await waitFor(() => expect(mockedGetArtistDetail).toHaveBeenCalled());
+    jest.useRealTimers();
+  });
+});

--- a/frontend/src/__tests__/ArtistsPage.test.tsx
+++ b/frontend/src/__tests__/ArtistsPage.test.tsx
@@ -1,0 +1,128 @@
+import userEvent from '@testing-library/user-event';
+import { screen, waitFor } from '@testing-library/react';
+
+import ArtistsPage from '../pages/Artists/ArtistsPage';
+import { renderWithProviders } from '../test-utils';
+import {
+  addArtistToWatchlist,
+  listArtists,
+  removeWatchlistEntry,
+  updateWatchlistEntry
+} from '../api/services/artists';
+
+jest.mock('../api/services/artists', () => ({
+  ...jest.requireActual('../api/services/artists'),
+  listArtists: jest.fn(),
+  addArtistToWatchlist: jest.fn(),
+  updateWatchlistEntry: jest.fn(),
+  removeWatchlistEntry: jest.fn()
+}));
+
+const mockedListArtists = listArtists as jest.MockedFunction<typeof listArtists>;
+const mockedAddArtist = addArtistToWatchlist as jest.MockedFunction<typeof addArtistToWatchlist>;
+const mockedUpdateWatchlist = updateWatchlistEntry as jest.MockedFunction<typeof updateWatchlistEntry>;
+const mockedRemoveWatchlist = removeWatchlistEntry as jest.MockedFunction<typeof removeWatchlistEntry>;
+
+const createListResponse = () => ({
+  items: [
+    {
+      id: 'artist-1',
+      name: 'First Artist',
+      external_ids: { spotify: 'spotify:artist:1' },
+      watchlist: {
+        id: 'watch-1',
+        enabled: true,
+        priority: 'medium',
+        interval_days: 7,
+        last_synced_at: '2024-05-01T10:00:00Z',
+        next_sync_at: '2024-05-08T10:00:00Z'
+      },
+      health_status: 'ok',
+      matches_pending: 2,
+      releases_total: 5,
+      updated_at: '2024-05-02T10:00:00Z'
+    }
+  ],
+  total: 1,
+  page: 1,
+  per_page: 25
+});
+
+describe('ArtistsPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedListArtists.mockResolvedValue(createListResponse());
+    mockedAddArtist.mockResolvedValue(createListResponse().items[0] ?? null);
+    mockedUpdateWatchlist.mockResolvedValue({
+      id: 'watch-1',
+      enabled: true,
+      priority: 'high',
+      interval_days: 7,
+      last_synced_at: '2024-05-01T10:00:00Z',
+      next_sync_at: '2024-05-08T10:00:00Z'
+    });
+    mockedRemoveWatchlist.mockResolvedValue();
+  });
+
+  it('lädt und zeigt die Watchlist', async () => {
+    renderWithProviders(<ArtistsPage />, { route: '/artists' });
+
+    expect(await screen.findByRole('heading', { name: 'Artist Watchlist' })).toBeInTheDocument();
+    await waitFor(() => expect(mockedListArtists).toHaveBeenCalled());
+    expect(await screen.findByText('First Artist')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Details' })).toBeInTheDocument();
+  });
+
+  it('passt Priorität, Intervall und Filter an und entfernt Artists', async () => {
+    const toastSpy = jest.fn();
+    const confirmSpy = jest.spyOn(window, 'confirm').mockReturnValue(true);
+
+    renderWithProviders(<ArtistsPage />, { route: '/artists', toastFn: toastSpy });
+
+    await screen.findByText('First Artist');
+
+    await userEvent.click(screen.getByRole('combobox', { name: 'Priorität für First Artist' }));
+    await userEvent.click(await screen.findByRole('option', { name: 'Hoch' }));
+
+    await waitFor(() =>
+      expect(mockedUpdateWatchlist).toHaveBeenCalledWith('watch-1', { priority: 'high' })
+    );
+
+    await userEvent.click(screen.getByRole('combobox', { name: 'Sync-Intervall für First Artist' }));
+    await userEvent.click(await screen.findByRole('option', { name: 'Alle 14 Tage' }));
+
+    await waitFor(() =>
+      expect(mockedUpdateWatchlist).toHaveBeenCalledWith('watch-1', { interval_days: 14 })
+    );
+
+    await userEvent.click(screen.getByRole('combobox', { name: 'Gesundheitsstatus filtern' }));
+    await userEvent.click(await screen.findByRole('option', { name: 'Warnung' }));
+
+    await waitFor(() => {
+      const lastCall = mockedListArtists.mock.calls[mockedListArtists.mock.calls.length - 1]?.[0];
+      expect(lastCall).toMatchObject({ health: 'warning', watchlistOnly: true });
+    });
+
+    await userEvent.click(screen.getByRole('button', { name: 'Entfernen' }));
+
+    await waitFor(() => expect(mockedRemoveWatchlist).toHaveBeenCalledWith('watch-1'));
+    expect(confirmSpy).toHaveBeenCalled();
+    expect(toastSpy).toHaveBeenCalled();
+
+    confirmSpy.mockRestore();
+  });
+
+  it('fügt einen Artist über das Formular hinzu', async () => {
+    renderWithProviders(<ArtistsPage />, { route: '/artists' });
+
+    await screen.findByText('First Artist');
+
+    await userEvent.type(screen.getByLabelText('Name'), 'Neuer Artist');
+    await userEvent.type(screen.getByLabelText('Spotify-Artist-ID'), 'new-artist');
+    await userEvent.click(screen.getByRole('button', { name: /Zur Watchlist hinzufügen/i }));
+
+    await waitFor(() =>
+      expect(mockedAddArtist).toHaveBeenCalledWith({ name: 'Neuer Artist', spotify_artist_id: 'new-artist' })
+    );
+  });
+});

--- a/frontend/src/api/services/artists.ts
+++ b/frontend/src/api/services/artists.ts
@@ -1,0 +1,411 @@
+import { apiUrl, request } from '../client';
+import type {
+  ArtistActivityEntry,
+  ArtistDetailResponse,
+  ArtistListResponse,
+  ArtistMatch,
+  ArtistMatchBadge,
+  ArtistMatchStatus,
+  ArtistPriority,
+  ArtistQueueStatus,
+  ArtistRelease,
+  ArtistSummary,
+  ArtistWatchlistSettings,
+  WatchlistArtistPayload
+} from '../types';
+
+const asString = (value: unknown): string => (typeof value === 'string' ? value : '');
+
+const asNullableString = (value: unknown): string | null => {
+  if (value === undefined || value === null) {
+    return null;
+  }
+  const str = asString(value);
+  return str.length > 0 ? str : null;
+};
+
+const asNumber = (value: unknown): number | null => {
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : null;
+  }
+  if (typeof value === 'string' && value.trim().length > 0) {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+};
+
+const parsePriority = (value: unknown): ArtistPriority => {
+  if (value === 'low' || value === 'medium' || value === 'high') {
+    return value;
+  }
+  if (typeof value === 'string' && value.trim().length > 0) {
+    return value as ArtistPriority;
+  }
+  return 'medium';
+};
+
+const parseWatchlistSettings = (value: unknown): ArtistWatchlistSettings | null => {
+  if (!value || typeof value !== 'object') {
+    return null;
+  }
+  const record = value as Record<string, unknown>;
+  const enabled = typeof record.enabled === 'boolean' ? record.enabled : true;
+  const priority = parsePriority(record.priority);
+  const interval = asNumber(record.interval_days);
+  return {
+    id: asNullableString(record.id ?? record.watchlist_id),
+    enabled,
+    priority,
+    interval_days: interval,
+    last_synced_at: asNullableString(record.last_synced_at),
+    next_sync_at: asNullableString(record.next_sync_at)
+  };
+};
+
+const parseExternalIds = (value: unknown): Record<string, string> | undefined => {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return undefined;
+  }
+  return Object.entries(value).reduce<Record<string, string>>((acc, [key, val]) => {
+    const normalized = asString(val);
+    if (normalized) {
+      acc[key] = normalized;
+    }
+    return acc;
+  }, {});
+};
+
+const parseArtistSummary = (value: unknown): ArtistSummary | null => {
+  if (!value || typeof value !== 'object') {
+    return null;
+  }
+  const record = value as Record<string, unknown>;
+  const id = asString(record.id ?? record.artist_id);
+  const name = asString(record.name ?? record.artist_name);
+  if (!id || !name) {
+    return null;
+  }
+  return {
+    id,
+    name,
+    image_url: asNullableString(record.image_url ?? record.image),
+    external_ids: parseExternalIds(record.external_ids ?? record.ids),
+    watchlist: parseWatchlistSettings(record.watchlist ?? record.watchlist_settings),
+    health_status: asNullableString(record.health_status ?? record.status ?? record.health),
+    releases_total: asNumber(record.releases_total ?? record.release_count),
+    matches_pending: asNumber(record.matches_pending ?? record.pending_matches),
+    updated_at: asNullableString(record.updated_at ?? record.synced_at ?? record.modified_at)
+  };
+};
+
+const parseRelease = (value: unknown): ArtistRelease | null => {
+  if (!value || typeof value !== 'object') {
+    return null;
+  }
+  const record = value as Record<string, unknown>;
+  const id = asString(record.id ?? record.release_id);
+  const title = asString(record.title ?? record.name);
+  if (!id || !title) {
+    return null;
+  }
+  return {
+    id,
+    title,
+    type: asNullableString(record.type ?? record.category),
+    released_at: asNullableString(record.released_at ?? record.release_date),
+    spotify_url: asNullableString(record.spotify_url ?? record.url),
+    metadata: typeof record.metadata === 'object' && record.metadata !== null ? (record.metadata as Record<string, unknown>) :
+    undefined
+  };
+};
+
+const parseMatchStatus = (value: unknown): ArtistMatchStatus => {
+  if (value === 'pending' || value === 'accepted' || value === 'rejected') {
+    return value;
+  }
+  if (typeof value === 'string' && value.trim().length > 0) {
+    return value as ArtistMatchStatus;
+  }
+  return 'pending';
+};
+
+const parseMatchBadges = (value: unknown): ArtistMatchBadge[] | undefined => {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+  const normalized = value
+    .map((entry) => {
+      if (!entry || typeof entry !== 'object') {
+        return null;
+      }
+      const record = entry as Record<string, unknown>;
+      const label = asString(record.label ?? record.text);
+      if (!label) {
+        return null;
+      }
+      const tone = asString(record.tone ?? record.variant);
+      return {
+        label,
+        tone: tone === '' ? undefined : (tone as ArtistMatchBadge['tone'])
+      };
+    })
+    .filter((badge): badge is NonNullable<typeof badge> => badge !== null);
+  return normalized.length ? normalized : undefined;
+};
+
+const parseMatch = (value: unknown): ArtistMatch | null => {
+  if (!value || typeof value !== 'object') {
+    return null;
+  }
+  const record = value as Record<string, unknown>;
+  const id = asString(record.id ?? record.match_id);
+  const title = asString(record.title ?? record.track ?? record.release_title);
+  if (!id || !title) {
+    return null;
+  }
+  return {
+    id,
+    title,
+    confidence: asNumber(record.confidence),
+    release_title: asNullableString(record.release_title ?? record.release),
+    provider: asNullableString(record.provider ?? record.source),
+    status: parseMatchStatus(record.status),
+    badges: parseMatchBadges(record.badges),
+    submitted_at: asNullableString(record.submitted_at ?? record.created_at)
+  };
+};
+
+const parseActivity = (value: unknown): ArtistActivityEntry | null => {
+  if (!value || typeof value !== 'object') {
+    return null;
+  }
+  const record = value as Record<string, unknown>;
+  const id = asString(record.id ?? record.activity_id ?? record.created_at ?? Math.random().toString(16));
+  const message = asString(record.message ?? record.summary ?? record.description);
+  const createdAt = asString(record.created_at ?? record.timestamp ?? record.time);
+  if (!message || !createdAt) {
+    return null;
+  }
+  return {
+    id,
+    created_at: createdAt,
+    message,
+    category: asNullableString(record.category ?? record.type),
+    meta:
+      typeof record.meta === 'object' && record.meta !== null
+        ? (record.meta as Record<string, unknown>)
+        : undefined
+  };
+};
+
+const parseQueueStatus = (value: unknown): ArtistQueueStatus | null => {
+  if (!value || typeof value !== 'object') {
+    return null;
+  }
+  const record = value as Record<string, unknown>;
+  return {
+    job_id: asNullableString(record.job_id ?? record.id),
+    status: asNullableString(record.status),
+    attempts: asNumber(record.attempts),
+    eta: asNullableString(record.eta ?? record.next_run_at),
+    queued_at: asNullableString(record.queued_at),
+    started_at: asNullableString(record.started_at),
+    updated_at: asNullableString(record.updated_at)
+  };
+};
+
+const normalizeListResponse = (value: unknown): ArtistListResponse => {
+  const itemsSource =
+    value && typeof value === 'object' && !Array.isArray(value)
+      ? (value as { items?: unknown[]; results?: unknown[]; total?: unknown; page?: unknown; per_page?: unknown })
+      : undefined;
+  const itemsRaw =
+    Array.isArray(value)
+      ? value
+      : Array.isArray(itemsSource?.items)
+        ? itemsSource?.items
+        : Array.isArray(itemsSource?.results)
+          ? itemsSource?.results
+          : [];
+
+  const items = itemsRaw
+    .map((entry) => parseArtistSummary(entry))
+    .filter((entry): entry is ArtistSummary => entry !== null);
+
+  return {
+    items,
+    total: asNumber(itemsSource?.total) ?? items.length,
+    page: asNumber(itemsSource?.page) ?? 1,
+    per_page: asNumber(itemsSource?.per_page ?? (itemsSource as { perPage?: unknown })?.perPage) ?? items.length || 1
+  };
+};
+
+const normalizeDetailResponse = (value: unknown): ArtistDetailResponse => {
+  const container = value && typeof value === 'object' ? (value as Record<string, unknown>) : {};
+  const artist = parseArtistSummary(container.artist ?? value) ?? {
+    id: 'unknown',
+    name: 'Unbekannter Artist',
+    watchlist: null
+  };
+  const releasesSource = Array.isArray(container.releases)
+    ? container.releases
+    : Array.isArray((container.releases as { items?: unknown[] } | undefined)?.items)
+      ? ((container.releases as { items?: unknown[] }).items as unknown[])
+      : [];
+  const matchesSource = Array.isArray(container.matches)
+    ? container.matches
+    : Array.isArray((container.matches as { items?: unknown[] } | undefined)?.items)
+      ? ((container.matches as { items?: unknown[] }).items as unknown[])
+      : [];
+  const activitySource = Array.isArray(container.activity)
+    ? container.activity
+    : Array.isArray((container.activity as { items?: unknown[] } | undefined)?.items)
+      ? ((container.activity as { items?: unknown[] }).items as unknown[])
+      : [];
+
+  return {
+    artist,
+    releases: releasesSource
+      .map((entry) => parseRelease(entry))
+      .filter((entry): entry is ArtistRelease => entry !== null),
+    matches: matchesSource
+      .map((entry) => parseMatch(entry))
+      .filter((entry): entry is ArtistMatch => entry !== null),
+    activity: activitySource
+      .map((entry) => parseActivity(entry))
+      .filter((entry): entry is ArtistActivityEntry => entry !== null),
+    queue: parseQueueStatus(container.queue ?? container.sync)
+  };
+};
+
+export interface ListArtistsParams {
+  search?: string;
+  priority?: ArtistPriority | 'all';
+  health?: string | 'all';
+  page?: number;
+  perPage?: number;
+  watchlistOnly?: boolean;
+}
+
+const serializeListParams = (params: ListArtistsParams = {}) => {
+  const result: Record<string, unknown> = {};
+  if (params.search) {
+    result.search = params.search;
+  }
+  if (params.priority && params.priority !== 'all') {
+    result.priority = params.priority;
+  }
+  if (params.health && params.health !== 'all') {
+    result.health = params.health;
+  }
+  if (typeof params.page === 'number') {
+    result.page = params.page;
+  }
+  if (typeof params.perPage === 'number') {
+    result.per_page = params.perPage;
+  }
+  if (params.watchlistOnly) {
+    result.watchlist = true;
+  }
+  return result;
+};
+
+export const listArtists = async (params: ListArtistsParams = {}): Promise<ArtistListResponse> => {
+  const payload = await request<unknown>({
+    method: 'GET',
+    url: apiUrl('/api/v1/artists'),
+    params: serializeListParams(params)
+  });
+  return normalizeListResponse(payload);
+};
+
+export const getArtistDetail = async (artistId: string): Promise<ArtistDetailResponse> => {
+  const payload = await request<unknown>({
+    method: 'GET',
+    url: apiUrl(`/api/v1/artists/${encodeURIComponent(artistId)}`)
+  });
+  return normalizeDetailResponse(payload);
+};
+
+export interface UpdateWatchlistPayload {
+  enabled?: boolean;
+  priority?: ArtistPriority;
+  interval_days?: number | null;
+}
+
+export const updateWatchlistEntry = async (
+  watchlistId: string,
+  payload: UpdateWatchlistPayload
+): Promise<ArtistWatchlistSettings | null> => {
+  const response = await request<unknown>({
+    method: 'PATCH',
+    url: apiUrl(`/api/v1/watchlist/${encodeURIComponent(watchlistId)}`),
+    data: payload
+  });
+  return parseWatchlistSettings(response);
+};
+
+export const addArtistToWatchlist = async (
+  payload: WatchlistArtistPayload
+): Promise<ArtistSummary | null> => {
+  const response = await request<unknown>({
+    method: 'POST',
+    url: apiUrl('/api/v1/watchlist'),
+    data: payload
+  });
+  if (response && typeof response === 'object' && !Array.isArray(response) && 'artist' in (response as object)) {
+    const candidate = (response as { artist?: unknown }).artist;
+    const summary = parseArtistSummary(candidate);
+    if (summary) {
+      return summary;
+    }
+  }
+  return parseArtistSummary(response);
+};
+
+export const removeWatchlistEntry = async (watchlistId: string): Promise<void> => {
+  await request<void>({
+    method: 'DELETE',
+    url: apiUrl(`/api/v1/watchlist/${encodeURIComponent(watchlistId)}`),
+    responseType: 'void'
+  });
+};
+
+export const enqueueArtistResync = async (artistId: string): Promise<void> => {
+  await request<void>({
+    method: 'POST',
+    url: apiUrl(`/api/v1/artists/${encodeURIComponent(artistId)}:resync`),
+    responseType: 'void'
+  });
+};
+
+export const invalidateArtistCache = async (artistId: string): Promise<void> => {
+  await request<void>({
+    method: 'POST',
+    url: apiUrl(`/api/v1/artists/${encodeURIComponent(artistId)}:invalidate`),
+    responseType: 'void'
+  });
+};
+
+export type ArtistMatchAction = 'accept' | 'reject';
+
+export const updateArtistMatchStatus = async (
+  artistId: string,
+  matchId: string,
+  action: ArtistMatchAction
+): Promise<void> => {
+  await request<void>({
+    method: 'POST',
+    url: apiUrl(`/api/v1/artists/${encodeURIComponent(artistId)}/matches/${encodeURIComponent(matchId)}:${action}`),
+    responseType: 'void'
+  });
+};
+
+export type {
+  ArtistSummary,
+  ArtistRelease,
+  ArtistMatch,
+  ArtistActivityEntry,
+  ArtistQueueStatus
+};

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -422,3 +422,86 @@ export interface DownloadExportFilters {
   from?: string;
   to?: string;
 }
+
+export type ArtistPriority = 'low' | 'medium' | 'high' | (string & {});
+
+export interface ArtistWatchlistSettings {
+  id?: string | null;
+  enabled: boolean;
+  priority: ArtistPriority;
+  interval_days: number | null;
+  last_synced_at: string | null;
+  next_sync_at: string | null;
+}
+
+export interface ArtistSummary {
+  id: string;
+  name: string;
+  image_url?: string | null;
+  external_ids?: Record<string, string>;
+  watchlist: ArtistWatchlistSettings | null;
+  health_status?: string | null;
+  releases_total?: number | null;
+  matches_pending?: number | null;
+  updated_at?: string | null;
+}
+
+export interface ArtistRelease {
+  id: string;
+  title: string;
+  type?: string | null;
+  released_at?: string | null;
+  spotify_url?: string | null;
+  metadata?: Record<string, unknown>;
+}
+
+export type ArtistMatchStatus = 'pending' | 'accepted' | 'rejected' | (string & {});
+
+export interface ArtistMatchBadge {
+  label: string;
+  tone?: 'default' | 'info' | 'success' | 'warning' | 'destructive';
+}
+
+export interface ArtistMatch {
+  id: string;
+  title: string;
+  confidence: number | null;
+  release_title?: string | null;
+  provider?: string | null;
+  status: ArtistMatchStatus;
+  badges?: ArtistMatchBadge[];
+  submitted_at?: string | null;
+}
+
+export interface ArtistActivityEntry {
+  id: string;
+  created_at: string;
+  message: string;
+  category?: string | null;
+  meta?: Record<string, unknown> | null;
+}
+
+export interface ArtistQueueStatus {
+  job_id?: string | null;
+  status?: string | null;
+  attempts?: number | null;
+  eta?: string | null;
+  queued_at?: string | null;
+  started_at?: string | null;
+  updated_at?: string | null;
+}
+
+export interface ArtistDetailResponse {
+  artist: ArtistSummary;
+  releases: ArtistRelease[];
+  matches: ArtistMatch[];
+  activity: ArtistActivityEntry[];
+  queue?: ArtistQueueStatus | null;
+}
+
+export interface ArtistListResponse {
+  items: ArtistSummary[];
+  total: number;
+  page: number;
+  per_page: number;
+}

--- a/frontend/src/components/ui/badge.tsx
+++ b/frontend/src/components/ui/badge.tsx
@@ -1,0 +1,40 @@
+import * as React from 'react';
+import { Slot } from '@radix-ui/react-slot';
+import { cva, type VariantProps } from 'class-variance-authority';
+
+import { cn } from '../../lib/utils';
+
+const badgeVariants = cva(
+  'inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2',
+  {
+    variants: {
+      variant: {
+        default: 'border-transparent bg-primary text-primary-foreground shadow',
+        secondary: 'border-transparent bg-secondary text-secondary-foreground',
+        destructive: 'border-transparent bg-destructive text-destructive-foreground shadow',
+        outline: 'text-foreground',
+        info: 'border-transparent bg-sky-500/10 text-sky-600 dark:text-sky-300',
+        success: 'border-transparent bg-emerald-500/10 text-emerald-600 dark:text-emerald-300',
+        warning: 'border-transparent bg-amber-500/10 text-amber-600 dark:text-amber-300'
+      }
+    },
+    defaultVariants: {
+      variant: 'default'
+    }
+  }
+);
+
+export interface BadgeProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof badgeVariants> {
+  asChild?: boolean;
+}
+
+const Badge = React.forwardRef<HTMLDivElement, BadgeProps>(({ className, variant, asChild, ...props }, ref) => {
+  const Comp = asChild ? Slot : 'div';
+  return <Comp ref={ref} className={cn(badgeVariants({ variant }), className)} {...props} />;
+});
+
+Badge.displayName = 'Badge';
+
+export { Badge, badgeVariants };

--- a/frontend/src/components/ui/shadcn.ts
+++ b/frontend/src/components/ui/shadcn.ts
@@ -8,5 +8,6 @@ export {
   CardTitle
 } from './card';
 export { Input, type InputProps } from './input';
+export { Badge, type BadgeProps } from './badge';
 export { Tabs, TabsList, TabsTrigger, TabsContent } from './tabs';
 export { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from './tooltip';

--- a/frontend/src/hooks/useDebouncedValue.ts
+++ b/frontend/src/hooks/useDebouncedValue.ts
@@ -1,0 +1,16 @@
+import { useEffect, useState } from 'react';
+
+const useDebouncedValue = <T>(value: T, delay = 250): T => {
+  const [debounced, setDebounced] = useState(value);
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => {
+      setDebounced(value);
+    }, delay);
+    return () => window.clearTimeout(timer);
+  }, [value, delay]);
+
+  return debounced;
+};
+
+export default useDebouncedValue;

--- a/frontend/src/pages/Artists/ArtistDetailPage.tsx
+++ b/frontend/src/pages/Artists/ArtistDetailPage.tsx
@@ -1,0 +1,532 @@
+import { useMemo, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { ArrowLeft, Check, Loader2, RefreshCw, ShieldAlert, ShieldCheck, X } from 'lucide-react';
+
+import {
+  enqueueArtistResync,
+  getArtistDetail,
+  invalidateArtistCache,
+  updateArtistMatchStatus,
+  type ArtistMatch
+} from '../../api/services/artists';
+import type { ArtistDetailResponse, ArtistMatchStatus, ArtistRelease } from '../../api/types';
+import { ApiError } from '../../api/client';
+import { Button } from '../../components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../../components/ui/card';
+import { Badge } from '../../components/ui/shadcn';
+import { ScrollArea } from '../../components/ui/scroll-area';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '../../components/ui/shadcn';
+import { useToast } from '../../hooks/useToast';
+import { useMutation, useQuery, useQueryClient } from '../../lib/query';
+
+const MATCH_STATUS_ORDER: ArtistMatchStatus[] = ['pending', 'accepted', 'rejected'];
+
+const formatDateTime = (value?: string | null, fallback = '—') => {
+  if (!value) {
+    return fallback;
+  }
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return fallback;
+  }
+  return new Intl.DateTimeFormat('de-DE', {
+    dateStyle: 'medium',
+    timeStyle: 'short'
+  }).format(date);
+};
+
+const formatReleaseType = (release: ArtistRelease) => release.type?.toUpperCase() ?? 'UNKNOWN';
+
+const formatConfidence = (match: ArtistMatch) => {
+  if (match.confidence === null || match.confidence === undefined) {
+    return '—';
+  }
+  const pct = Math.round(match.confidence * 100);
+  return `${pct}%`;
+};
+
+const ArtistDetailPage = () => {
+  const params = useParams();
+  const artistId = params.id ?? '';
+  const { toast } = useToast();
+  const queryClient = useQueryClient();
+  const [activeTab, setActiveTab] = useState<'overview' | 'releases' | 'matches' | 'activity'>('overview');
+  const [releaseFilter, setReleaseFilter] = useState<'all' | 'album' | 'single' | 'ep'>('all');
+
+  const queryKey = useMemo(() => ['artist-detail', artistId], [artistId]);
+
+  const detailQuery = useQuery<ArtistDetailResponse>({
+    queryKey,
+    queryFn: () => getArtistDetail(artistId),
+    enabled: Boolean(artistId),
+    refetchInterval: 20000,
+    onError: (error) => {
+      if (error instanceof ApiError && error.handled) {
+        return;
+      }
+      toast({
+        title: 'Artist konnte nicht geladen werden',
+        description: 'Bitte erneut versuchen oder Backend prüfen.',
+        variant: 'destructive'
+      });
+    }
+  });
+
+  const resyncMutation = useMutation({
+    mutationFn: () => enqueueArtistResync(artistId),
+    onSuccess: () => {
+      toast({
+        title: 'Resync gestartet',
+        description: 'Der Artist wurde erneut in die Sync-Queue gestellt.'
+      });
+      queryClient.invalidateQueries({ queryKey });
+    },
+    onError: (error) => {
+      if (error instanceof ApiError && error.handled) {
+        return;
+      }
+      toast({
+        title: 'Resync fehlgeschlagen',
+        description: 'Bitte später erneut versuchen.',
+        variant: 'destructive'
+      });
+    }
+  });
+
+  const invalidateMutation = useMutation({
+    mutationFn: () => invalidateArtistCache(artistId),
+    onSuccess: () => {
+      toast({
+        title: 'Cache invalidiert',
+        description: 'Die Artist-Daten werden beim nächsten Abruf neu geladen.'
+      });
+      queryClient.invalidateQueries({ queryKey });
+    },
+    onError: (error) => {
+      if (error instanceof ApiError && error.handled) {
+        return;
+      }
+      toast({
+        title: 'Invalidate fehlgeschlagen',
+        description: 'Bitte später erneut versuchen.',
+        variant: 'destructive'
+      });
+    }
+  });
+
+  const matchMutation = useMutation({
+    mutationFn: ({ matchId, action }: { matchId: string; action: 'accept' | 'reject' }) =>
+      updateArtistMatchStatus(artistId, matchId, action),
+    onSuccess: (_, variables) => {
+      toast({
+        title: `Match ${variables.action === 'accept' ? 'akzeptiert' : 'abgelehnt'}`,
+        description: 'Die Auswahl wurde gespeichert.'
+      });
+      queryClient.invalidateQueries({ queryKey });
+    },
+    onError: (error) => {
+      if (error instanceof ApiError && error.handled) {
+        return;
+      }
+      toast({
+        title: 'Aktion fehlgeschlagen',
+        description: 'Bitte erneut versuchen.',
+        variant: 'destructive'
+      });
+    }
+  });
+
+  if (!artistId) {
+    return (
+      <div className="space-y-4">
+        <Button variant="ghost" disabled>
+          <ArrowLeft className="mr-2 h-4 w-4" aria-hidden /> Zurück
+        </Button>
+        <Card>
+          <CardHeader>
+            <CardTitle>Kein Artist gewählt</CardTitle>
+            <CardDescription>Bitte über die Watchlist einen Artist auswählen.</CardDescription>
+          </CardHeader>
+        </Card>
+      </div>
+    );
+  }
+
+  if (detailQuery.isLoading || !detailQuery.data) {
+    return (
+      <div className="space-y-6">
+        <Button variant="ghost" onClick={() => window.history.back()} className="inline-flex items-center gap-2">
+          <ArrowLeft className="h-4 w-4" aria-hidden /> Zurück
+        </Button>
+        <Card>
+          <CardHeader>
+            <CardTitle>Artist lädt…</CardTitle>
+            <CardDescription>Bitte einen Moment Geduld.</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="flex items-center gap-3 text-muted-foreground">
+              <Loader2 className="h-4 w-4 animate-spin" aria-hidden /> Daten werden geladen…
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  const detail = detailQuery.data;
+  const { artist, releases, matches, activity, queue } = detail;
+  const filteredReleases = releases.filter((release) => {
+    if (releaseFilter === 'all') {
+      return true;
+    }
+    return release.type?.toLowerCase() === releaseFilter;
+  });
+
+  const pendingMatches = matches.filter((match) => match.status === 'pending').length;
+
+  const handleMatchAction = (matchId: string, action: 'accept' | 'reject') => {
+    void matchMutation.mutate({ matchId, action });
+  };
+
+  const renderMatchActions = (match: ArtistMatch) => {
+    if (matchMutation.isPending) {
+      return <Loader2 className="h-4 w-4 animate-spin" aria-hidden />;
+    }
+    if (match.status === 'accepted') {
+      return (
+        <Badge variant="secondary" className="gap-1">
+          <Check className="h-3 w-3" aria-hidden /> Akzeptiert
+        </Badge>
+      );
+    }
+    if (match.status === 'rejected') {
+      return (
+        <Badge variant="destructive" className="gap-1">
+          <X className="h-3 w-3" aria-hidden /> Abgelehnt
+        </Badge>
+      );
+    }
+    return (
+      <div className="flex items-center gap-2">
+        <Button
+          type="button"
+          size="sm"
+          variant="outline"
+          onClick={() => handleMatchAction(match.id, 'accept')}
+        >
+          <Check className="mr-1 h-3 w-3" aria-hidden /> Accept
+        </Button>
+        <Button type="button" size="sm" variant="ghost" onClick={() => handleMatchAction(match.id, 'reject')}>
+          <X className="mr-1 h-3 w-3" aria-hidden /> Reject
+        </Button>
+      </div>
+    );
+  };
+
+  const renderMatchBadges = (match: ArtistMatch) => {
+    if (!match.badges?.length) {
+      return null;
+    }
+    return (
+      <div className="flex flex-wrap gap-2">
+        {match.badges.map((badge) => (
+          <Badge key={`${match.id}-${badge.label}`} variant={badge.tone ?? 'secondary'}>
+            {badge.label}
+          </Badge>
+        ))}
+      </div>
+    );
+  };
+
+  const queueStatus = queue ?? null;
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-wrap items-start justify-between gap-4">
+        <div className="space-y-2">
+          <Button
+            type="button"
+            variant="ghost"
+            onClick={() => window.history.back()}
+            className="inline-flex items-center gap-2"
+          >
+            <ArrowLeft className="h-4 w-4" aria-hidden /> Zurück
+          </Button>
+          <div>
+            <h1 className="text-3xl font-semibold tracking-tight">{artist.name}</h1>
+            <p className="text-sm text-muted-foreground">Artist-ID: {artist.id}</p>
+          </div>
+          {artist.external_ids ? (
+            <div className="flex flex-wrap gap-2 text-xs text-muted-foreground">
+              {Object.entries(artist.external_ids).map(([key, value]) => (
+                <span key={key} className="rounded bg-muted px-2 py-1">
+                  {key}: {value}
+                </span>
+              ))}
+            </div>
+          ) : null}
+        </div>
+
+        <Card className="min-w-[260px]">
+          <CardHeader>
+            <CardTitle>Sync-Aktionen</CardTitle>
+            <CardDescription>Queue-Status & Trigger.</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="space-y-1 text-sm">
+              <div>
+                <span className="font-medium">Status:</span>{' '}
+                <span className="capitalize">{queueStatus?.status ?? 'unbekannt'}</span>
+              </div>
+              <div>
+                <span className="font-medium">Versuche:</span>{' '}
+                {queueStatus?.attempts ?? '—'}
+              </div>
+              <div>
+                <span className="font-medium">ETA:</span> {formatDateTime(queueStatus?.eta)}
+              </div>
+            </div>
+            <div className="flex flex-col gap-2">
+              <Button
+                type="button"
+                className="inline-flex items-center gap-2"
+                onClick={() => {
+                  if (!window.confirm('Resync jetzt starten?')) {
+                    return;
+                  }
+                  void resyncMutation.mutate();
+                }}
+                disabled={resyncMutation.isPending}
+              >
+                {resyncMutation.isPending ? (
+                  <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
+                ) : (
+                  <RefreshCw className="h-4 w-4" aria-hidden />
+                )}
+                Resync
+              </Button>
+              <Button
+                type="button"
+                variant="outline"
+                className="inline-flex items-center gap-2"
+                onClick={() => {
+                  if (!window.confirm('Cache für diesen Artist invalidieren?')) {
+                    return;
+                  }
+                  void invalidateMutation.mutate();
+                }}
+                disabled={invalidateMutation.isPending}
+              >
+                {invalidateMutation.isPending ? (
+                  <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
+                ) : (
+                  <ShieldAlert className="h-4 w-4" aria-hidden />
+                )}
+                Invalidate Cache
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+
+      <Tabs value={activeTab} onValueChange={(value) => setActiveTab(value as typeof activeTab)}>
+        <TabsList>
+          <TabsTrigger value="overview">Overview</TabsTrigger>
+          <TabsTrigger value="releases">Releases</TabsTrigger>
+          <TabsTrigger value="matches">Matches</TabsTrigger>
+          <TabsTrigger value="activity">Activity</TabsTrigger>
+        </TabsList>
+        <TabsContent value="overview" className="space-y-4">
+          <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+            <Card>
+              <CardHeader>
+                <CardTitle>Health</CardTitle>
+                <CardDescription>Letzter Sync & Zustand</CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-2 text-sm">
+                <div className="flex items-center gap-2">
+                  {artist.health_status === 'ok' ? (
+                    <ShieldCheck className="h-4 w-4 text-emerald-500" aria-hidden />
+                  ) : (
+                    <ShieldAlert className="h-4 w-4 text-amber-500" aria-hidden />
+                  )}
+                  <span className="capitalize">{artist.health_status ?? 'unbekannt'}</span>
+                </div>
+                <div>
+                  <span className="font-medium">Zuletzt synchronisiert:</span> {formatDateTime(artist.watchlist?.last_synced_at)}
+                </div>
+                <div>
+                  <span className="font-medium">Nächster Sync:</span> {formatDateTime(artist.watchlist?.next_sync_at)}
+                </div>
+              </CardContent>
+            </Card>
+            <Card>
+              <CardHeader>
+                <CardTitle>Watchlist</CardTitle>
+                <CardDescription>Priorität & Intervall</CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-2 text-sm">
+                <div>
+                  <span className="font-medium">Priorität:</span> {artist.watchlist?.priority ?? '—'}
+                </div>
+                <div>
+                  <span className="font-medium">Intervall:</span>{' '}
+                  {artist.watchlist?.interval_days ? `${artist.watchlist.interval_days} Tage` : 'Automatisch'}
+                </div>
+                <div>
+                  <span className="font-medium">Matches offen:</span> {pendingMatches}
+                </div>
+              </CardContent>
+            </Card>
+            <Card>
+              <CardHeader>
+                <CardTitle>Releases</CardTitle>
+                <CardDescription>Gesamtbestand</CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-2 text-sm">
+                <div>
+                  <span className="font-medium">Gesamt:</span> {artist.releases_total ?? releases.length}
+                </div>
+                <div>
+                  <span className="font-medium">Letzte Aktualisierung:</span> {formatDateTime(artist.updated_at)}
+                </div>
+              </CardContent>
+            </Card>
+          </div>
+        </TabsContent>
+        <TabsContent value="releases">
+          <Card>
+            <CardHeader className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+              <div>
+                <CardTitle>Releases</CardTitle>
+                <CardDescription>Gefundene Veröffentlichungen nach Typ filtern.</CardDescription>
+              </div>
+              <div className="flex items-center gap-2 text-sm">
+                <label htmlFor="release-filter" className="text-muted-foreground">
+                  Filter
+                </label>
+                <select
+                  id="release-filter"
+                  className="rounded border bg-background px-2 py-1"
+                  value={releaseFilter}
+                  onChange={(event) => setReleaseFilter(event.target.value as typeof releaseFilter)}
+                >
+                  <option value="all">Alle</option>
+                  <option value="album">Album</option>
+                  <option value="single">Single</option>
+                  <option value="ep">EP</option>
+                </select>
+              </div>
+            </CardHeader>
+            <CardContent>
+              {filteredReleases.length ? (
+                <ScrollArea className="h-[360px] pr-4">
+                  <ul className="space-y-4">
+                    {filteredReleases.map((release) => (
+                      <li key={release.id} className="rounded border p-4">
+                        <div className="flex flex-wrap items-center justify-between gap-3">
+                          <div>
+                            <h3 className="text-base font-medium">{release.title}</h3>
+                            <p className="text-sm text-muted-foreground">{formatReleaseType(release)}</p>
+                          </div>
+                          <div className="text-sm text-muted-foreground">{formatDateTime(release.released_at)}</div>
+                        </div>
+                        {release.spotify_url ? (
+                          <a
+                            className="mt-2 inline-flex text-sm text-primary hover:underline"
+                            href={release.spotify_url}
+                            target="_blank"
+                            rel="noreferrer"
+                          >
+                            Spotify öffnen
+                          </a>
+                        ) : null}
+                      </li>
+                    ))}
+                  </ul>
+                </ScrollArea>
+              ) : (
+                <div className="py-10 text-center text-sm text-muted-foreground">Keine Releases gefunden.</div>
+              )}
+            </CardContent>
+          </Card>
+        </TabsContent>
+        <TabsContent value="matches">
+          <Card>
+            <CardHeader>
+              <CardTitle>Matches</CardTitle>
+              <CardDescription>Treffer kuratieren und Entscheidungen treffen.</CardDescription>
+            </CardHeader>
+            <CardContent>
+              {matches.length ? (
+                <div className="space-y-4">
+                  {matches
+                    .slice()
+                    .sort((a, b) => MATCH_STATUS_ORDER.indexOf(a.status) - MATCH_STATUS_ORDER.indexOf(b.status))
+                    .map((match) => (
+                      <div key={match.id} className="rounded border p-4">
+                        <div className="flex flex-wrap items-start justify-between gap-3">
+                          <div className="space-y-1">
+                            <div className="text-sm text-muted-foreground">{match.provider ?? 'Unbekannte Quelle'}</div>
+                            <h3 className="text-lg font-semibold">{match.title}</h3>
+                            <p className="text-sm text-muted-foreground">
+                              Release: {match.release_title ?? 'n/a'} · Confidence {formatConfidence(match)}
+                            </p>
+                            {renderMatchBadges(match)}
+                          </div>
+                          <div className="text-right text-xs text-muted-foreground">
+                            Eingereicht: {formatDateTime(match.submitted_at)}
+                          </div>
+                        </div>
+                        <div className="mt-4 flex flex-wrap items-center justify-between gap-3">
+                          <Badge variant="outline" className="capitalize">
+                            Status: {match.status}
+                          </Badge>
+                          {renderMatchActions(match)}
+                        </div>
+                      </div>
+                    ))}
+                </div>
+              ) : (
+                <div className="py-10 text-center text-sm text-muted-foreground">
+                  Keine Matches gefunden.
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        </TabsContent>
+        <TabsContent value="activity">
+          <Card>
+            <CardHeader>
+              <CardTitle>Aktivität</CardTitle>
+              <CardDescription>Chronologisches Log der letzten Ereignisse.</CardDescription>
+            </CardHeader>
+            <CardContent>
+              {activity.length ? (
+                <ScrollArea className="h-[360px] pr-4" aria-label="Aktivitätenliste">
+                  <ol className="space-y-4 text-sm">
+                    {activity.map((item) => (
+                      <li key={item.id} className="flex gap-3">
+                        <div className="mt-1 h-2 w-2 flex-none rounded-full bg-primary" aria-hidden />
+                        <div className="space-y-1">
+                          <div className="font-medium">{item.message}</div>
+                          <div className="text-xs text-muted-foreground">
+                            {formatDateTime(item.created_at)} · {item.category ?? 'Event'}
+                          </div>
+                        </div>
+                      </li>
+                    ))}
+                  </ol>
+                </ScrollArea>
+              ) : (
+                <div className="py-10 text-center text-sm text-muted-foreground">Noch keine Aktivitäten vorhanden.</div>
+              )}
+            </CardContent>
+          </Card>
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+};
+
+export default ArtistDetailPage;

--- a/frontend/src/pages/Artists/ArtistsPage.tsx
+++ b/frontend/src/pages/Artists/ArtistsPage.tsx
@@ -1,0 +1,527 @@
+import { FormEvent, useMemo, useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { AlertCircle, CheckCircle, Loader2, Plus, RefreshCw, Search, XCircle } from 'lucide-react';
+
+import {
+  addArtistToWatchlist,
+  listArtists,
+  removeWatchlistEntry,
+  updateWatchlistEntry,
+  type ArtistSummary
+} from '../../api/services/artists';
+import type { ArtistPriority } from '../../api/types';
+import { ApiError } from '../../api/client';
+import { Button } from '../../components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../../components/ui/card';
+import { Input } from '../../components/ui/input';
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectTrigger,
+  SelectValue
+} from '../../components/ui/select';
+import { Badge } from '../../components/ui/shadcn';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../../components/ui/table';
+import { useToast } from '../../hooks/useToast';
+import useDebouncedValue from '../../hooks/useDebouncedValue';
+import { useMutation, useQuery, useQueryClient } from '../../lib/query';
+
+const HEALTH_FILTERS = [
+  { value: 'all', label: 'Alle Zustände' },
+  { value: 'ok', label: 'Gesund' },
+  { value: 'warning', label: 'Warnung' },
+  { value: 'error', label: 'Fehler' }
+] as const;
+
+const PRIORITY_OPTIONS: { value: ArtistPriority; label: string }[] = [
+  { value: 'high', label: 'Hoch' },
+  { value: 'medium', label: 'Mittel' },
+  { value: 'low', label: 'Niedrig' }
+];
+
+const INTERVAL_OPTIONS = [1, 3, 7, 14, 30, 60] as const;
+
+const getHealthIcon = (health?: string | null) => {
+  if (health === 'ok' || health === 'healthy') {
+    return <CheckCircle className="h-4 w-4 text-emerald-500" aria-hidden />;
+  }
+  if (health === 'warning' || health === 'degraded') {
+    return <AlertCircle className="h-4 w-4 text-amber-500" aria-hidden />;
+  }
+  if (!health) {
+    return <AlertCircle className="h-4 w-4 text-muted-foreground" aria-hidden />;
+  }
+  return <XCircle className="h-4 w-4 text-destructive" aria-hidden />;
+};
+
+const formatDate = (value?: string | null) => {
+  if (!value) {
+    return '—';
+  }
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return '—';
+  }
+  return new Intl.DateTimeFormat('de-DE', {
+    dateStyle: 'medium',
+    timeStyle: 'short'
+  }).format(date);
+};
+
+const ArtistsPage = () => {
+  const { toast } = useToast();
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const [search, setSearch] = useState('');
+  const [priorityFilter, setPriorityFilter] = useState<'all' | ArtistPriority>('all');
+  const [healthFilter, setHealthFilter] = useState<(typeof HEALTH_FILTERS)[number]['value']>('all');
+  const [spotifyArtistId, setSpotifyArtistId] = useState('');
+  const [artistName, setArtistName] = useState('');
+  const [isRemoving, setIsRemoving] = useState<string | null>(null);
+
+  const debouncedSearch = useDebouncedValue(search, 300);
+
+  const queryKey = useMemo(
+    () => ['artists', { search: debouncedSearch, priority: priorityFilter, health: healthFilter }],
+    [debouncedSearch, priorityFilter, healthFilter]
+  );
+
+  const artistsQuery = useQuery({
+    queryKey,
+    queryFn: () =>
+      listArtists({
+        search: debouncedSearch || undefined,
+        priority: priorityFilter,
+        health: healthFilter,
+        watchlistOnly: true
+      }),
+    onError: (error) => {
+      if (error instanceof ApiError && error.handled) {
+        return;
+      }
+      toast({
+        title: 'Artists konnten nicht geladen werden',
+        description: 'Bitte Verbindung prüfen und erneut versuchen.',
+        variant: 'destructive'
+      });
+    }
+  });
+
+  const addMutation = useMutation({
+    mutationFn: addArtistToWatchlist,
+    onSuccess: (artist) => {
+      toast({
+        title: 'Artist zur Watchlist hinzugefügt',
+        description: artist?.name ? `${artist.name} wird künftig überwacht.` : undefined
+      });
+      setArtistName('');
+      setSpotifyArtistId('');
+      queryClient.invalidateQueries({ queryKey });
+    },
+    onError: (error) => {
+      if (error instanceof ApiError) {
+        if (error.status === 409) {
+          toast({
+            title: 'Artist bereits vorhanden',
+            description: 'Dieser Artist ist schon Teil der Watchlist.',
+            variant: 'destructive'
+          });
+          return;
+        }
+        if (error.handled) {
+          return;
+        }
+        error.markHandled();
+      }
+      toast({
+        title: 'Watchlist konnte nicht aktualisiert werden',
+        description: 'Bitte Eingaben prüfen und erneut versuchen.',
+        variant: 'destructive'
+      });
+    }
+  });
+
+  const priorityMutation = useMutation({
+    mutationFn: async ({ artist, priority }: { artist: ArtistSummary; priority: ArtistPriority }) => {
+      const watchlistId = artist.watchlist?.id ?? artist.id;
+      await updateWatchlistEntry(watchlistId, { priority });
+    },
+    onSuccess: (_data, { priority }) => {
+      toast({
+        title: 'Priorität aktualisiert',
+        description: `Neue Priorität: ${priority.toUpperCase()}`
+      });
+      queryClient.invalidateQueries({ queryKey });
+    },
+    onError: (error) => {
+      if (error instanceof ApiError && error.handled) {
+        return;
+      }
+      toast({
+        title: 'Priorität konnte nicht aktualisiert werden',
+        description: 'Bitte erneut versuchen.',
+        variant: 'destructive'
+      });
+    }
+  });
+
+  const intervalMutation = useMutation({
+    mutationFn: async ({ artist, intervalDays }: { artist: ArtistSummary; intervalDays: number }) => {
+      const watchlistId = artist.watchlist?.id ?? artist.id;
+      await updateWatchlistEntry(watchlistId, { interval_days: intervalDays });
+    },
+    onSuccess: (_data, { intervalDays }) => {
+      toast({
+        title: 'Intervall angepasst',
+        description: `Nächster Sync alle ${intervalDays} Tage.`
+      });
+      queryClient.invalidateQueries({ queryKey });
+    },
+    onError: (error) => {
+      if (error instanceof ApiError && error.handled) {
+        return;
+      }
+      toast({
+        title: 'Intervall konnte nicht geändert werden',
+        description: 'Bitte erneut versuchen.',
+        variant: 'destructive'
+      });
+    }
+  });
+
+  const removeMutation = useMutation({
+    mutationFn: removeWatchlistEntry,
+    onSuccess: () => {
+      toast({
+        title: 'Artist entfernt',
+        description: 'Der Artist wird nicht mehr überwacht.'
+      });
+      setIsRemoving(null);
+      queryClient.invalidateQueries({ queryKey });
+    },
+    onError: (error) => {
+      setIsRemoving(null);
+      if (error instanceof ApiError && error.handled) {
+        return;
+      }
+      toast({
+        title: 'Artist konnte nicht entfernt werden',
+        description: 'Bitte erneut versuchen.',
+        variant: 'destructive'
+      });
+    }
+  });
+
+  const items = artistsQuery.data?.items ?? [];
+  const isLoading = artistsQuery.isLoading;
+
+  const handleAdd = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const normalizedId = spotifyArtistId.trim();
+    const normalizedName = artistName.trim();
+    if (!normalizedId || !normalizedName) {
+      toast({
+        title: 'Bitte alle Felder ausfüllen',
+        description: 'Spotify-Artist-ID und Name werden benötigt.',
+        variant: 'destructive'
+      });
+      return;
+    }
+    void addMutation.mutate({ spotify_artist_id: normalizedId, name: normalizedName });
+  };
+
+  const renderRows = () => {
+    if (isLoading) {
+      return (
+        <TableRow>
+          <TableCell colSpan={6} className="py-10 text-center text-muted-foreground">
+            <span className="inline-flex items-center gap-2"><Loader2 className="h-4 w-4 animate-spin" aria-hidden /> Lädt…</span>
+          </TableCell>
+        </TableRow>
+      );
+    }
+    if (!items.length) {
+      return (
+        <TableRow>
+          <TableCell colSpan={6} className="py-10 text-center text-muted-foreground">
+            Keine Artists in der Watchlist gefunden.
+          </TableCell>
+        </TableRow>
+      );
+    }
+    return items.map((artist) => {
+      const watchlist = artist.watchlist;
+      const intervalLabel = watchlist?.interval_days ? `${watchlist.interval_days} Tage` : 'Automatisch';
+      const pendingMatches = typeof artist.matches_pending === 'number' ? artist.matches_pending : 0;
+      const removalInProgress = isRemoving === (watchlist?.id ?? artist.id) && removeMutation.isPending;
+      return (
+        <TableRow key={artist.id}>
+          <TableCell className="w-[22%] font-medium">
+            <button
+              type="button"
+              className="text-left hover:underline"
+              onClick={() => navigate(`/artists/${encodeURIComponent(artist.id)}`)}
+            >
+              {artist.name}
+            </button>
+            <div className="mt-1 text-xs text-muted-foreground">{artist.external_ids?.spotify ?? artist.id}</div>
+          </TableCell>
+          <TableCell className="w-[12%]">
+            <div className="flex items-center gap-2">
+              {getHealthIcon(artist.health_status)}
+              <span className="text-sm capitalize">{artist.health_status ?? 'unbekannt'}</span>
+            </div>
+          </TableCell>
+          <TableCell className="w-[18%]">
+            <Select
+              value={watchlist?.priority ?? 'medium'}
+              onValueChange={(value) => {
+                const next = value as ArtistPriority;
+                void priorityMutation.mutate({ artist, priority: next });
+              }}
+            >
+              <SelectTrigger className="h-9" aria-label={`Priorität für ${artist.name}`}>
+                <SelectValue aria-label={watchlist?.priority ?? 'medium'} />
+              </SelectTrigger>
+              <SelectContent align="start">
+                <SelectGroup>
+                  <SelectLabel>Priorität</SelectLabel>
+                  {PRIORITY_OPTIONS.map((option) => (
+                    <SelectItem key={option.value} value={option.value}>
+                      {option.label}
+                    </SelectItem>
+                  ))}
+                </SelectGroup>
+              </SelectContent>
+            </Select>
+          </TableCell>
+          <TableCell className="w-[16%]">
+            <Select
+              value={String(watchlist?.interval_days ?? '')}
+              onValueChange={(value) => {
+                const parsed = Number(value);
+                if (!Number.isNaN(parsed)) {
+                  void intervalMutation.mutate({ artist, intervalDays: parsed });
+                }
+              }}
+            >
+              <SelectTrigger className="h-9" aria-label={`Sync-Intervall für ${artist.name}`}>
+                <SelectValue placeholder="Automatisch" aria-label={intervalLabel} />
+              </SelectTrigger>
+              <SelectContent align="start">
+                <SelectGroup>
+                  <SelectLabel>Sync-Intervall</SelectLabel>
+                  {INTERVAL_OPTIONS.map((days) => (
+                    <SelectItem key={days} value={String(days)}>
+                      Alle {days} Tage
+                    </SelectItem>
+                  ))}
+                </SelectGroup>
+              </SelectContent>
+            </Select>
+          </TableCell>
+          <TableCell className="w-[14%]">
+            <div className="space-y-1 text-sm">
+              <div>
+                <span className="font-medium">Zuletzt:</span> {formatDate(watchlist?.last_synced_at)}
+              </div>
+              <div className="text-xs text-muted-foreground">Nächster: {formatDate(watchlist?.next_sync_at)}</div>
+            </div>
+          </TableCell>
+          <TableCell className="w-[18%] text-right">
+            <div className="flex flex-col items-end gap-2">
+              {pendingMatches > 0 ? <Badge variant="secondary">{pendingMatches} offene Matches</Badge> : null}
+              <div className="flex items-center gap-2">
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => navigate(`/artists/${encodeURIComponent(artist.id)}`)}
+                >
+                  Details
+                </Button>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={() => {
+                    const watchlistId = artist.watchlist?.id ?? artist.id;
+                    if (!window.confirm(`Artist ${artist.name} wirklich entfernen?`)) {
+                      return;
+                    }
+                    setIsRemoving(watchlistId);
+                    void removeMutation.mutate(watchlistId);
+                  }}
+                  disabled={removeMutation.isPending && removalInProgress}
+                >
+                  {removalInProgress ? (
+                    <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
+                  ) : (
+                    'Entfernen'
+                  )}
+                </Button>
+              </div>
+            </div>
+          </TableCell>
+        </TableRow>
+      );
+    });
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold tracking-tight">Artist Watchlist</h1>
+          <p className="text-sm text-muted-foreground">Überblick über alle überwachten Artists und deren Sync-Status.</p>
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <div className="relative w-full min-w-[240px] lg:w-64">
+            <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" aria-hidden />
+            <Input
+              value={search}
+              onChange={(event) => setSearch(event.target.value)}
+              placeholder="Artist oder ID suchen"
+              className="pl-9"
+              aria-label="Watchlist durchsuchen"
+            />
+          </div>
+          <Select value={priorityFilter} onValueChange={(value) => setPriorityFilter(value as typeof priorityFilter)}>
+            <SelectTrigger className="w-[160px]" aria-label="Priorität filtern">
+              <SelectValue placeholder="Priorität" />
+            </SelectTrigger>
+            <SelectContent align="end">
+              <SelectGroup>
+                <SelectLabel>Priorität</SelectLabel>
+                <SelectItem value="all">Alle Prioritäten</SelectItem>
+                {PRIORITY_OPTIONS.map((option) => (
+                  <SelectItem key={option.value} value={option.value}>
+                    {option.label}
+                  </SelectItem>
+                ))}
+              </SelectGroup>
+            </SelectContent>
+          </Select>
+          <Select value={healthFilter} onValueChange={(value) => setHealthFilter(value as typeof healthFilter)}>
+            <SelectTrigger className="w-[160px]" aria-label="Gesundheitsstatus filtern">
+              <SelectValue placeholder="Status" />
+            </SelectTrigger>
+            <SelectContent align="end">
+              <SelectGroup>
+                <SelectLabel>Gesundheit</SelectLabel>
+                {HEALTH_FILTERS.map((option) => (
+                  <SelectItem key={option.value} value={option.value}>
+                    {option.label}
+                  </SelectItem>
+                ))}
+              </SelectGroup>
+            </SelectContent>
+          </Select>
+          <Button type="button" variant="outline" onClick={() => queryClient.invalidateQueries({ queryKey })}>
+            <RefreshCw className="mr-2 h-4 w-4" aria-hidden /> Neu laden
+          </Button>
+        </div>
+      </div>
+
+      <div className="grid gap-6 lg:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]">
+        <Card className="order-2 lg:order-1">
+          <CardHeader>
+            <CardTitle>Watchlist</CardTitle>
+            <CardDescription>Bestehende Artists überwachen, Priorität und Sync-Intervalle anpassen.</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="overflow-hidden rounded-xl border">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Artist</TableHead>
+                    <TableHead>Status</TableHead>
+                    <TableHead>Priorität</TableHead>
+                    <TableHead>Intervall</TableHead>
+                    <TableHead>Letzte / nächste Syncs</TableHead>
+                    <TableHead className="text-right">Aktionen</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>{renderRows()}</TableBody>
+              </Table>
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card className="order-1 lg:order-2">
+          <CardHeader>
+            <CardTitle>Artist hinzufügen</CardTitle>
+            <CardDescription>Neue Artists überwachen und automatische Syncs aktivieren.</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <form className="space-y-4" onSubmit={handleAdd}>
+              <div className="space-y-2">
+                <label htmlFor="artist-name" className="text-sm font-medium">
+                  Name
+                </label>
+                <Input
+                  id="artist-name"
+                  value={artistName}
+                  onChange={(event) => setArtistName(event.target.value)}
+                  placeholder="z. B. Moderat"
+                  aria-required
+                />
+              </div>
+              <div className="space-y-2">
+                <label htmlFor="spotify-artist-id" className="text-sm font-medium">
+                  Spotify-Artist-ID
+                </label>
+                <Input
+                  id="spotify-artist-id"
+                  value={spotifyArtistId}
+                  onChange={(event) => setSpotifyArtistId(event.target.value)}
+                  placeholder="z. B. 4tZwfgrHOc3mvqYlEYSvVi"
+                  aria-required
+                />
+              </div>
+              <div className="flex items-center justify-end">
+                <Button type="submit" disabled={addMutation.isPending} className="inline-flex items-center gap-2">
+                  {addMutation.isPending ? (
+                    <>
+                      <Loader2 className="h-4 w-4 animate-spin" aria-hidden /> Hinzufügen…
+                    </>
+                  ) : (
+                    <>
+                      <Plus className="h-4 w-4" aria-hidden /> Zur Watchlist hinzufügen
+                    </>
+                  )}
+                </Button>
+              </div>
+            </form>
+          </CardContent>
+        </Card>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Direkt zu einem Artist</CardTitle>
+          <CardDescription>Schnellnavigation zu einem bekannten Artist.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="flex flex-wrap items-center gap-3">
+            {items.slice(0, 6).map((artist) => (
+              <Badge key={artist.id} variant="outline" className="cursor-pointer" asChild>
+                <Link to={`/artists/${encodeURIComponent(artist.id)}`}>{artist.name}</Link>
+              </Badge>
+            ))}
+            {items.length === 0 ? (
+              <span className="text-sm text-muted-foreground">
+                Noch keine Artists verfügbar – zuerst zur Watchlist hinzufügen.
+              </span>
+            ) : null}
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export default ArtistsPage;

--- a/frontend/src/pages/ArtistsPage.tsx
+++ b/frontend/src/pages/ArtistsPage.tsx
@@ -1,5 +1,0 @@
-import { Navigate } from 'react-router-dom';
-
-const ArtistsPage = () => <Navigate to="/library?tab=artists" replace />;
-
-export default ArtistsPage;

--- a/frontend/src/pages/SpotifyPage.tsx
+++ b/frontend/src/pages/SpotifyPage.tsx
@@ -377,18 +377,18 @@ const SpotifyPage = () => {
                   <Button
                     type="button"
                     asChild
-                    variant={pendingDestination === '/library?tab=watchlist' ? 'default' : 'secondary'}
+                    variant={pendingDestination === '/artists' ? 'default' : 'secondary'}
                   >
-                    <Link to="/library?tab=watchlist" onClick={handleCloseSuccessDialog}>
+                    <Link to="/artists" onClick={handleCloseSuccessDialog}>
                       Watchlist öffnen
                     </Link>
                   </Button>
                   <Button
                     type="button"
                     asChild
-                    variant={pendingDestination === '/library?tab=artists' ? 'default' : 'secondary'}
+                    variant={pendingDestination === '/artists' ? 'default' : 'secondary'}
                   >
-                    <Link to="/library?tab=artists" onClick={handleCloseSuccessDialog}>
+                    <Link to="/artists" onClick={handleCloseSuccessDialog}>
                       Künstlerbibliothek
                     </Link>
                   </Button>
@@ -529,17 +529,13 @@ const SpotifyPage = () => {
               </p>
             ) : null}
             <div className="flex flex-wrap gap-2">
-              <Button
-                type="button"
-                onClick={() => handleProNavigate('/library?tab=watchlist')}
-                disabled={proDisabled}
-              >
+              <Button type="button" onClick={() => handleProNavigate('/artists')} disabled={proDisabled}>
                 {renderProButtonLabel('Watchlist öffnen')}
               </Button>
               <Button
                 type="button"
                 variant="secondary"
-                onClick={() => handleProNavigate('/library?tab=artists')}
+                onClick={() => handleProNavigate('/artists')}
                 disabled={proDisabled}
               >
                 {renderProButtonLabel('Künstlerbibliothek')}

--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -7,6 +7,8 @@ import SettingsPage from '../pages/SettingsPage';
 import SoulseekPage from '../pages/SoulseekPage';
 import SpotifyPage from '../pages/SpotifyPage';
 import SpotifyProOAuthCallbackPage from '../pages/SpotifyProOAuthCallback';
+import ArtistsPage from '../pages/Artists/ArtistsPage';
+import ArtistDetailPage from '../pages/Artists/ArtistDetailPage';
 
 const AppRoutes = () => (
   <Routes>
@@ -14,8 +16,9 @@ const AppRoutes = () => (
     <Route path="/dashboard" element={<DashboardPage />} />
     <Route path="/library" element={<LibraryPage />} />
     <Route path="/downloads" element={<Navigate to="/library?tab=downloads" replace />} />
-    <Route path="/artists" element={<Navigate to="/library?tab=artists" replace />} />
-    <Route path="/watchlist" element={<Navigate to="/library?tab=watchlist" replace />} />
+    <Route path="/artists" element={<ArtistsPage />} />
+    <Route path="/artists/:id" element={<ArtistDetailPage />} />
+    <Route path="/watchlist" element={<Navigate to="/artists" replace />} />
     <Route path="/spotify" element={<SpotifyPage />} />
     <Route path="/spotify/oauth/callback" element={<SpotifyProOAuthCallbackPage />} />
     <Route path="/soulseek" element={<SoulseekPage />} />


### PR DESCRIPTION
# Summary
- add dedicated artist routes and API service for list, detail, watchlist updates, resync, invalidate, and match status updates
- build `/artists` watchlist UI with filtering, inline controls, addition form, toast feedback, and navigation to the detail page
- implement `/artists/:id` detail tabs (overview, releases, matches, activity) including queue status panel and match curation actions
- introduce shared badge component, debounce hook, and update Spotify shortcuts; add documentation for the new frontend workflow
- cover routing, watchlist interactions, match actions, and queue polling with Jest + RTL

# Testing
- npm run lint *(fails: eslint 9 requires eslint.config.js; repo uses .eslintrc.cjs and npm install is blocked by registry 403)*
- npm test *(fails: jest binary missing because dependencies cannot be installed in the sandbox)*
- npm run typecheck *(fails: missing `vite/client` and `jest` typings due to dependency install restrictions)*
- npm run build *(fails: ts build stops on missing type definitions for the same reason)*


------
https://chatgpt.com/codex/tasks/task_e_68e54af240c08321aca4005d55160840