### PR TITLE
fix(orchestrator): deterministic leasing and isolation [CODX-ORCH-501]

### DIFF
--- a/tests/orchestrator/test_scheduler.py
+++ b/tests/orchestrator/test_scheduler.py
@@ -4,8 +4,11 @@ import asyncio
 from datetime import datetime, timedelta
 from typing import Mapping
 
+from dataclasses import replace
+
 import pytest
 
+from app.config import settings
 from app.models import QueueJobStatus
 from app.orchestrator.scheduler import PriorityConfig, Scheduler
 from app.workers.persistence import QueueJobDTO
@@ -173,3 +176,28 @@ def test_scheduler_backpressure_resets_after_work() -> None:
 
     scheduler.lease_ready_jobs()
     assert scheduler.poll_interval > 0.01
+
+
+def test_priority_state_isolated_between_runs(
+    stub_queue_persistence: "StubQueuePersistence",
+) -> None:
+    base_config = replace(
+        settings.orchestrator,
+        priority_map={"sync": 10},
+    )
+    scheduler_one = Scheduler(
+        config=base_config,
+        poll_interval_ms=5,
+        persistence_module=stub_queue_persistence,
+    )
+
+    base_config.priority_map["sync"] = 99
+    scheduler_two = Scheduler(
+        config=base_config,
+        poll_interval_ms=5,
+        persistence_module=stub_queue_persistence,
+    )
+
+    assert scheduler_one._priority.get("sync") == 10
+    assert scheduler_two._priority.get("sync") == 99
+    assert settings.orchestrator.priority_map.get("sync") != 99

--- a/tests/workers/test_orch_visibility.py
+++ b/tests/workers/test_orch_visibility.py
@@ -6,7 +6,7 @@ from datetime import datetime, timedelta
 
 import pytest
 
-from app.db import session_scope
+from app.db import reset_engine_for_tests, session_scope
 from app.models import QueueJob, QueueJobStatus
 from app.orchestrator.scheduler import PriorityConfig, Scheduler
 from app.workers import persistence
@@ -99,3 +99,76 @@ async def test_heartbeat_failure_releases_job_for_redelivery(
         db_job = session.get(QueueJob, job.id)
         assert db_job is not None
         assert db_job.status == QueueJobStatus.LEASED.value
+
+
+def test_lease_and_redelivery_after_visibility_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    reset_engine_for_tests()
+    current = datetime(2024, 1, 1, 9, 0, 0)
+
+    def fake_now() -> datetime:
+        return current
+
+    monkeypatch.setattr("app.workers.persistence._utcnow", fake_now)
+    scheduler = Scheduler(
+        priority_config=PriorityConfig(priorities={"sync": 100}),
+        poll_interval_ms=0,
+        visibility_timeout=15,
+    )
+
+    job = persistence.enqueue("sync", {"priority": 5, "visibility_timeout": 15})
+
+    first_lease = scheduler.lease_ready_jobs()
+    assert [item.id for item in first_lease] == [job.id]
+    first_deadline = first_lease[0].lease_expires_at
+
+    with session_scope() as session:
+        db_job = session.get(QueueJob, job.id)
+        assert db_job is not None
+        assert db_job.status == QueueJobStatus.LEASED.value
+        assert db_job.attempts == 1
+
+    current = current + timedelta(seconds=30)
+    second_lease = scheduler.lease_ready_jobs()
+    assert [item.id for item in second_lease] == [job.id]
+
+    with session_scope() as session:
+        db_job = session.get(QueueJob, job.id)
+        assert db_job is not None
+        assert db_job.status == QueueJobStatus.LEASED.value
+        assert db_job.attempts == 2
+        assert db_job.lease_expires_at is not None
+        assert first_deadline is not None and db_job.lease_expires_at > first_deadline
+
+
+def test_heartbeat_extends_lease_in_long_running_handler(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    reset_engine_for_tests()
+    current = datetime(2024, 1, 1, 10, 0, 0)
+
+    def fake_now() -> datetime:
+        return current
+
+    monkeypatch.setattr("app.workers.persistence._utcnow", fake_now)
+    scheduler = Scheduler(
+        priority_config=PriorityConfig(priorities={"sync": 100}),
+        poll_interval_ms=0,
+        visibility_timeout=20,
+    )
+
+    job = persistence.enqueue("sync", {"priority": 1, "visibility_timeout": 20})
+    leased = scheduler.lease_ready_jobs()
+    assert leased and leased[0].id == job.id
+    first_deadline = leased[0].lease_expires_at
+
+    current = current + timedelta(seconds=10)
+    assert persistence.heartbeat(job.id, job_type="sync", lease_seconds=20) is True
+
+    with session_scope() as session:
+        db_job = session.get(QueueJob, job.id)
+        assert db_job is not None
+        assert db_job.status == QueueJobStatus.LEASED.value
+        assert db_job.lease_expires_at is not None
+        assert first_deadline is not None and db_job.lease_expires_at > first_deadline


### PR DESCRIPTION
## Summary
- freeze scheduler priority configuration to isolate per-run state and maintain deterministic job ordering
- add guard-based persistence updates to release expired leases and atomically lease jobs
- cover orchestration flows with new scheduler, dispatcher, and lease/heartbeat regression tests

## Testing
- pytest tests/orchestrator/test_scheduler.py -q
- pytest tests/workers/test_orch_visibility.py -q
- pytest tests/orchestrator/test_dispatcher.py::test_dispatcher_drains_queue_under_mixed_load -q

No ToDo changes required.

------
https://chatgpt.com/codex/tasks/task_e_68e55d0ea1708321b31c0475e0f4e11a