### PR TITLE
CODX-P1-ART-502: Restore watchlist timer and sync force handling

### DIFF
--- a/app/orchestrator/handlers_artist.py
+++ b/app/orchestrator/handlers_artist.py
@@ -614,6 +614,12 @@ async def handle_artist_sync(
     else:
         inactivated_count = 0
 
+    release_mutations = added_count + updated_count + inactivated_count
+    if release_mutations > 0:
+        refreshed_row = await asyncio.to_thread(deps.dao.refresh_artist_version, artist_key)
+        if refreshed_row is not None:
+            artist_row = refreshed_row
+
     existing_ids = {snapshot.id for snapshot in local_state.releases}
     persisted_by_id = {row.id: row for row in persisted_rows}
     new_rows = [row for row in persisted_rows if row.id not in existing_ids]

--- a/app/schemas/artists.py
+++ b/app/schemas/artists.py
@@ -96,9 +96,16 @@ class EnqueueResponse(BaseModel):
     already_enqueued: bool
 
 
+class EnqueueSyncRequest(BaseModel):
+    """Request payload for triggering an artist sync."""
+
+    force: bool = False
+
+
 __all__ = [
     "ArtistOut",
     "EnqueueResponse",
+    "EnqueueSyncRequest",
     "ReleaseOut",
     "WatchlistItemIn",
     "WatchlistItemOut",

--- a/app/services/artist_workflow_dao.py
+++ b/app/services/artist_workflow_dao.py
@@ -18,6 +18,15 @@ from app.services.artist_delta import ArtistKnownRelease
 _UNSET = object()
 
 
+def _normalize_hash(value: str | None) -> str | None:
+    """Return ``None`` when the provided hash is empty or whitespace."""
+
+    if value is None:
+        return None
+    trimmed = value.strip()
+    return trimmed or None
+
+
 @dataclass(slots=True)
 class ArtistWorkflowArtistRow:
     """Lightweight representation of an artist monitored by the workflow."""
@@ -27,7 +36,10 @@ class ArtistWorkflowArtistRow:
     name: str
     last_checked: datetime | None
     retry_block_until: datetime | None
-    last_hash: str | None
+    last_hash: str | None = None
+
+    def __post_init__(self) -> None:
+        self.last_hash = _normalize_hash(self.last_hash)
 
 
 class ArtistWorkflowDAO:
@@ -155,7 +167,7 @@ class ArtistWorkflowDAO:
                     return
                 record.last_checked = timestamp
                 record.last_scan_at = timestamp
-                record.last_hash = content_hash
+                record.last_hash = _normalize_hash(content_hash)
                 record.retry_block_until = None
                 record.updated_at = self._now_factory()
                 session.add(record)

--- a/tests/orchestrator/test_timer.py
+++ b/tests/orchestrator/test_timer.py
@@ -24,6 +24,31 @@ class RecordingDAO:
         return self.rows[:limit]
 
 
+def test_artist_row_defaults_last_hash_to_none() -> None:
+    row = ArtistWorkflowArtistRow(
+        id=42,
+        spotify_artist_id="artist-42",
+        name="Artist",
+        last_checked=None,
+        retry_block_until=None,
+    )
+
+    assert row.last_hash is None
+
+
+def test_artist_row_normalizes_blank_last_hash() -> None:
+    row = ArtistWorkflowArtistRow(
+        id=7,
+        spotify_artist_id="artist-7",
+        name="Artist",
+        last_checked=None,
+        retry_block_until=None,
+        last_hash="   ",
+    )
+
+    assert row.last_hash is None
+
+
 def _build_config(**overrides) -> WatchlistWorkerConfig:
     params = {
         "max_concurrency": 3,

--- a/tests/snapshots/openapi.json
+++ b/tests/snapshots/openapi.json
@@ -1195,6 +1195,18 @@
         "title": "EnqueueRequest",
         "type": "object"
       },
+      "EnqueueSyncRequest": {
+        "description": "Request payload for triggering an artist sync.",
+        "properties": {
+          "force": {
+            "default": false,
+            "title": "Force",
+            "type": "boolean"
+          }
+        },
+        "title": "EnqueueSyncRequest",
+        "type": "object"
+      },
       "ErrorObject": {
         "properties": {
           "code": {
@@ -4818,6 +4830,23 @@
             }
           }
         ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "anyOf": [
+                  {
+                    "$ref": "#/components/schemas/EnqueueSyncRequest"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "title": "Payload"
+              }
+            }
+          }
+        },
         "responses": {
           "202": {
             "content": {


### PR DESCRIPTION
## Summary
- normalize watchlist workflow rows so `last_hash` defaults to `None` and add a DAO hook that refreshes artist versions when release data changes
- let the artist sync API accept an optional `force` payload, wiring it through the service and updating the OpenAPI snapshot
- update the test harness and suites (timer, DAO, API, E2E) to exercise blank hash handling and forced sync retries while keeping existing logging assertions satisfied

## Testing
- pytest tests/orchestrator/test_timer.py -q
- pytest tests/services/test_artist_workflow_dao.py -q
- pytest tests/api/test_artists_api.py -q
- pytest tests/e2e/test_artist_flow.py -q

No ToDo changes required.

------
https://chatgpt.com/codex/tasks/task_e_68e5e71c62c883219dcb5773a124455f