### PR TITLE
fix: ensure Spotify playlist cache invalidation stays fresh [CODX-P1-PLCACHE-504]

### DIFF
--- a/app/api/spotify.py
+++ b/app/api/spotify.py
@@ -48,6 +48,7 @@ from app.schemas import (
     TrackDetailResponse,
     UserProfileResponse,
 )
+from app.services.cache import playlist_filters_hash
 from app.services.free_ingest_service import IngestSubmission, PlaylistValidationError
 from app.services.backfill_service import BackfillJobStatus
 from app.services.spotify_domain_service import (
@@ -176,7 +177,8 @@ def list_playlists(
     service: SpotifyDomainService = Depends(_get_spotify_service),
 ) -> PlaylistResponse | Response:
     playlists = list(service.list_playlists(db))
-    metadata = compute_playlist_collection_metadata(playlists)
+    filters_hash = playlist_filters_hash(request.url.query)
+    metadata = compute_playlist_collection_metadata(playlists, filters_hash=filters_hash)
 
     if is_request_not_modified(
         request,

--- a/app/routers/sync_router.py
+++ b/app/routers/sync_router.py
@@ -117,12 +117,10 @@ def _get_playlist_worker(request: Request) -> PlaylistSyncWorker | None:
         logger.error("Unable to initialise Spotify client for playlist sync: %s", exc)
         return None
     response_cache = getattr(request.app.state, "response_cache", None)
-    api_base_path = getattr(request.app.state, "api_base_path", "") or ""
     worker = PlaylistSyncWorker(
         spotify_client,
         interval_seconds=900.0,
         response_cache=response_cache,
-        api_base_path=api_base_path,
     )
     request.app.state.playlist_worker = worker
     return worker

--- a/app/services/cache.py
+++ b/app/services/cache.py
@@ -357,6 +357,30 @@ def resolve_auth_variant(authorization_header: str | None) -> str:
     return digest.hexdigest()
 
 
+PLAYLIST_LIST_CACHE_PREFIX = "cache:playlists:list"
+PLAYLIST_DETAIL_CACHE_PREFIX = "cache:playlists:detail"
+
+
+def playlist_filters_hash(query_string: str) -> str:
+    """Return a stable hash for playlist listing filters."""
+
+    return build_query_hash(query_string)
+
+
+def playlist_list_cache_key(*, query_string: str = "", filters_hash: str | None = None) -> str:
+    """Construct the canonical cache key for playlist collection responses."""
+
+    resolved_hash = filters_hash if filters_hash is not None else playlist_filters_hash(query_string)
+    return f"{PLAYLIST_LIST_CACHE_PREFIX}:{resolved_hash}"
+
+
+def playlist_detail_cache_key(playlist_id: str) -> str:
+    """Construct the canonical cache key for a playlist detail response."""
+
+    normalized = playlist_id.strip()
+    return f"{PLAYLIST_DETAIL_CACHE_PREFIX}:{normalized}" if normalized else f"{PLAYLIST_DETAIL_CACHE_PREFIX}:"
+
+
 def artist_cache_templates(base_path: str | None) -> tuple[str, ...]:
     """Return canonical cache templates for artist resources."""
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1522,7 +1522,6 @@ def client(
             stub_spotify,
             interval_seconds=0.1,
             response_cache=getattr(test_client.app.state, "response_cache", None),
-            api_base_path=getattr(test_client.app.state, "api_base_path", "") or "",
         )
         test_client.app.state.provider_gateway_stub = stub_gateway
         test_client.app.state.artist_gateway_stub = artist_gateway_stub

--- a/tests/spotify/test_playlist_cache_invalidation.py
+++ b/tests/spotify/test_playlist_cache_invalidation.py
@@ -4,7 +4,12 @@ from datetime import datetime, timezone
 import pytest
 
 from app.models import Playlist
-from app.services.cache import CacheEntry, ResponseCache, build_path_param_hash
+from app.services.cache import (
+    CacheEntry,
+    ResponseCache,
+    playlist_detail_cache_key,
+    playlist_list_cache_key,
+)
 from app.utils.http_cache import compute_playlist_collection_metadata
 from app.workers.playlist_sync_worker import PlaylistCacheInvalidator
 from tests.simple_client import SimpleTestClient
@@ -42,41 +47,47 @@ def _build_entry(
     )
 
 
-def test_etag_changes_when_playlist_updates() -> None:
+def test_etag_last_modified_reflect_max_updated_at() -> None:
     base = datetime(2024, 1, 1, tzinfo=timezone.utc)
-    playlist = Playlist(id="playlist-1", name="Focus", track_count=10)
-    playlist.updated_at = base
-    initial = compute_playlist_collection_metadata([playlist])
+    newer = base.replace(day=2)
+    playlist_a = Playlist(id="playlist-1", name="Focus", track_count=10)
+    playlist_a.updated_at = newer
+    playlist_b = Playlist(id="playlist-2", name="Calm", track_count=5)
+    playlist_b.updated_at = base
 
-    playlist.name = "Focus Updated"
-    playlist.track_count = 12
-    playlist.updated_at = base.replace(day=2)
-    refreshed = compute_playlist_collection_metadata([playlist])
+    initial = compute_playlist_collection_metadata(
+        [playlist_a, playlist_b], filters_hash="filters:v1"
+    )
+    assert initial.last_modified == newer
+
+    playlist_a.updated_at = newer.replace(day=3)
+    refreshed = compute_playlist_collection_metadata(
+        [playlist_a, playlist_b], filters_hash="filters:v1"
+    )
 
     assert initial.etag != refreshed.etag
-    assert refreshed.last_modified > initial.last_modified
+    assert refreshed.last_modified == playlist_a.updated_at
+
+    filters_changed = compute_playlist_collection_metadata(
+        [playlist_a, playlist_b], filters_hash="filters:v2"
+    )
+    assert filters_changed.etag != refreshed.etag
 
 
 @pytest.mark.asyncio
-async def test_cache_eviction_on_playlist_persist() -> None:
+async def test_playlist_list_busts_cache_on_update() -> None:
     cache = ResponseCache(max_items=20, default_ttl=60.0)
     loop = asyncio.get_running_loop()
-    invalidator = PlaylistCacheInvalidator(
-        cache,
-        loop=loop,
-        list_paths=("/spotify/playlists",),
-        detail_templates=("/spotify/playlists/{playlist_id}/tracks",),
-    )
+    invalidator = PlaylistCacheInvalidator(cache, loop=loop)
 
     now = datetime(2024, 1, 1, tzinfo=timezone.utc)
-    list_key = "GET:/spotify/playlists:0:0:anon"
+    list_key = playlist_list_cache_key(filters_hash="0")
     await cache.set(
         list_key,
         _build_entry(path_template="/spotify/playlists", etag='"list"', last_modified=now),
     )
 
-    path_hash = build_path_param_hash({"playlist_id": "playlist-1"})
-    detail_key = f"GET:/spotify/playlists/{{playlist_id}}/tracks:{path_hash}:0:anon"
+    detail_key = playlist_detail_cache_key("playlist-1")
     await cache.set(
         detail_key,
         _build_entry(
@@ -95,7 +106,40 @@ async def test_cache_eviction_on_playlist_persist() -> None:
     assert await cache.get(detail_key) is None
 
 
-def test_conditional_get_304_when_unchanged(client: SimpleTestClient) -> None:
+@pytest.mark.asyncio
+async def test_playlist_detail_busts_cache_on_update() -> None:
+    cache = ResponseCache(max_items=20, default_ttl=60.0)
+    loop = asyncio.get_running_loop()
+    invalidator = PlaylistCacheInvalidator(cache, loop=loop)
+
+    now = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    target_key = playlist_detail_cache_key("playlist-1")
+    other_key = playlist_detail_cache_key("playlist-2")
+
+    await cache.set(
+        target_key,
+        _build_entry(
+            path_template="/spotify/playlists/{playlist_id}/tracks",
+            etag='"target"',
+            last_modified=now,
+        ),
+    )
+    await cache.set(
+        other_key,
+        _build_entry(
+            path_template="/spotify/playlists/{playlist_id}/tracks",
+            etag='"other"',
+            last_modified=now,
+        ),
+    )
+
+    await asyncio.to_thread(invalidator.invalidate, ["playlist-1"])
+
+    assert await cache.get(target_key) is None
+    assert await cache.get(other_key) is not None
+
+
+def test_playlist_list_returns_304_when_unchanged(client: SimpleTestClient) -> None:
     stub = client.app.state.spotify_stub
     stub.playlists = [
         {"id": "playlist-1", "name": "Focus", "tracks": {"total": 10}},
@@ -114,7 +158,7 @@ def test_conditional_get_304_when_unchanged(client: SimpleTestClient) -> None:
     assert conditional.text == ""
 
 
-def test_listing_endpoint_evicted_if_impacted(client: SimpleTestClient) -> None:
+def test_playlist_list_busts_cache_on_update_response(client: SimpleTestClient) -> None:
     stub = client.app.state.spotify_stub
     stub.playlists = [
         {"id": "playlist-1", "name": "Focus", "tracks": {"total": 10}},


### PR DESCRIPTION
## Summary
- unify playlist list/detail cache keys between middleware and worker invalidator using deterministic namespaces and filter hashes
- derive playlist collection validators from max(updated_at) timestamps and filters to keep ETag/Last-Modified fresh
- adjust playlist sync worker wiring to bust caches consistently across API base paths

## Testing
- ruff check
- mypy app
- pytest tests/spotify/test_playlist_cache_invalidation.py -q


------
https://chatgpt.com/codex/tasks/task_e_68e5f8c503dc8321ae30f62be55ac93f