### PR TITLE
Fix router shim deprecation helper import cycle

### DIFF
--- a/app/_legacy.py
+++ b/app/_legacy.py
@@ -1,0 +1,18 @@
+"""Shared utilities for emitting deprecation warnings for legacy modules."""
+
+from __future__ import annotations
+
+from warnings import warn
+
+
+def warn_legacy_import(old: str, new: str) -> None:
+    """Emit a deprecation warning for a legacy import path."""
+
+    warn(
+        f"{old} is deprecated; use {new}",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+
+
+__all__ = ["warn_legacy_import"]

--- a/app/api/_deprecation.py
+++ b/app/api/_deprecation.py
@@ -1,18 +1,7 @@
-"""Shared utilities for emitting API deprecation warnings."""
+"""Compat re-export for legacy API deprecation helpers."""
 
 from __future__ import annotations
 
-from warnings import warn
-
-
-def warn_legacy_import(old: str, new: str) -> None:
-    """Emit a deprecation warning for a legacy import path."""
-
-    warn(
-        f"{old} is deprecated; use {new}",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-
+from app._legacy import warn_legacy_import
 
 __all__ = ["warn_legacy_import"]

--- a/app/routers/__init__.py
+++ b/app/routers/__init__.py
@@ -1,7 +1,7 @@
 from importlib import import_module
 from typing import Any
 
-from app.api._deprecation import warn_legacy_import
+from app._legacy import warn_legacy_import
 
 from .activity_router import router as activity_router
 from .dlq_router import router as dlq_router

--- a/app/routers/backfill_router.py
+++ b/app/routers/backfill_router.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from app.api._deprecation import warn_legacy_import
+from app._legacy import warn_legacy_import
 from app.api.routers.spotify import backfill_router as router
 
 warn_legacy_import(

--- a/app/routers/free_ingest_router.py
+++ b/app/routers/free_ingest_router.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from app.api._deprecation import warn_legacy_import
+from app._legacy import warn_legacy_import
 from app.api.routers.spotify import free_ingest_router as router
 
 warn_legacy_import(

--- a/app/routers/search_router.py
+++ b/app/routers/search_router.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from app.api._deprecation import warn_legacy_import
+from app._legacy import warn_legacy_import
 from app.api.routers.search import log_event, router
 
 warn_legacy_import(

--- a/app/routers/spotify_free_router.py
+++ b/app/routers/spotify_free_router.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from app.api._deprecation import warn_legacy_import
+from app._legacy import warn_legacy_import
 from app.api.routers.spotify import free_router as router
 
 warn_legacy_import(

--- a/app/routers/spotify_router.py
+++ b/app/routers/spotify_router.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from app.api._deprecation import warn_legacy_import
+from app._legacy import warn_legacy_import
 from app.api.routers.spotify import core_router as router
 
 warn_legacy_import(

--- a/app/routers/system_router.py
+++ b/app/routers/system_router.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from app.api._deprecation import warn_legacy_import
+from app._legacy import warn_legacy_import
 from app.api.routers.system import psutil, router
 
 warn_legacy_import(

--- a/app/routers/watchlist_router.py
+++ b/app/routers/watchlist_router.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from app.api._deprecation import warn_legacy_import
+from app._legacy import warn_legacy_import
 from app.api.routers.watchlist import router
 
 warn_legacy_import(


### PR DESCRIPTION
## Summary
- move warn_legacy_import helper into app._legacy so router imports no longer load app.api during initialization
- re-export warn_legacy_import from app.api._deprecation for compatibility and update router shims to use the new helper path

## Testing
- pytest -q tests/routers/test_legacy_router_shims.py

------
https://chatgpt.com/codex/tasks/task_e_68e606559948832188f2b790efecbefb