### PR TITLE
CODX-P1-DEPR-508: eliminate internal deprecation warnings

### DIFF
--- a/alembic.ini
+++ b/alembic.ini
@@ -1,7 +1,8 @@
 [alembic]
 script_location = app/migrations
 prepend_sys_path = .
-sqlalchemy.url = 
+path_separator = os
+sqlalchemy.url =
 
 [loggers]
 keys = root,sqlalchemy,alembic

--- a/app/services/spotify_domain.py
+++ b/app/services/spotify_domain.py
@@ -2,14 +2,13 @@
 
 from __future__ import annotations
 
-from warnings import warn
+from app._legacy import warn_legacy_import
 
 from .spotify_domain_service import PlaylistItemsResult, SpotifyDomainService
 
-warn(
-    "app.services.spotify_domain is deprecated; import from app.services.spotify_domain_service instead.",
-    DeprecationWarning,
-    stacklevel=2,
+warn_legacy_import(
+    "app.services.spotify_domain",
+    "app.services.spotify_domain_service",
 )
 
 __all__ = ["SpotifyDomainService", "PlaylistItemsResult"]

--- a/tests/schemas/test_pydantic_no_deprecations.py
+++ b/tests/schemas/test_pydantic_no_deprecations.py
@@ -1,0 +1,50 @@
+"""Ensure representative Pydantic models do not emit deprecation warnings."""
+
+from __future__ import annotations
+
+import warnings
+from datetime import datetime, timezone
+
+from app.schemas import DownloadFileRequest
+from app.schemas.common import ID, URI, ISODateTime, ProblemDetail
+from app.schemas.watchlist import (
+    WatchlistEntryResponse,
+    WatchlistListResponse,
+    WatchlistPauseRequest,
+    WatchlistPriorityUpdate,
+)
+
+
+def test_pydantic_models_emit_no_deprecations() -> None:
+    """Instantiating key models should not trigger deprecated behaviours."""
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+
+        download = DownloadFileRequest(filename="  example.flac  ", priority=2)
+        assert download.resolved_filename == "example.flac"
+
+        detail = ProblemDetail(code="E001", message="something went wrong")
+        assert detail.code == "E001"
+        assert detail.timestamp.endswith("+00:00")
+
+        pause = WatchlistPauseRequest(reason="  hiatus  ")
+        assert pause.reason == "hiatus"
+
+        update = WatchlistPriorityUpdate(priority=3)
+        assert update.priority == 3
+
+        entry = WatchlistEntryResponse(
+            id=1,
+            artist_key="artist-key",
+            priority=update.priority,
+            paused=False,
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+        )
+        listing = WatchlistListResponse(items=[entry])
+        assert listing.items[0].artist_key == "artist-key"
+
+        assert isinstance(ID.validate("  abc  "), ID)
+        assert isinstance(URI.validate("https://example.com"), URI)
+        assert isinstance(ISODateTime.validate("2024-01-01T00:00:00Z"), ISODateTime)


### PR DESCRIPTION
## Summary
- add Alembic path_separator configuration to suppress the legacy prepend_sys_path warning
- route the spotify_domain shim through the shared legacy import helper for consistent messaging
- introduce a regression test covering representative Pydantic models to guard against deprecated patterns

## Testing
- pytest tests/core/test_imports.py -W error::DeprecationWarning
- pytest tests/routers/test_legacy_router_shims.py -W error::DeprecationWarning
- pytest tests/api/test_openapi_determinism.py -W error::DeprecationWarning
- pytest tests/schemas/test_common_schema_types.py -W error::DeprecationWarning
- pytest tests/schemas/test_pydantic_no_deprecations.py -W error::DeprecationWarning
- ruff check
- black --check tests/schemas/test_pydantic_no_deprecations.py
- mypy app
- isort tests/schemas/test_pydantic_no_deprecations.py

No ToDo changes required.

Change-Impact-Scan: Alembic config, spotify domain shim, and schema consumers validated via targeted pytest suites.


------
https://chatgpt.com/codex/tasks/task_e_68e60ba0573883219538ab7e211cf9a9