### PR TITLE
Add activity events table migration

### DIFF
--- a/app/db.py
+++ b/app/db.py
@@ -92,7 +92,7 @@ def _ensure_engine(*, auto_init: bool = True) -> None:
     )
     _configured_database_url = database_url
 
-    if auto_init and not _initializing_db and sqlite_path is not None and not sqlite_path.exists():
+    if auto_init and not _initializing_db:
         init_db()
 
 

--- a/app/migrations/versions/202411181200_create_activity_events_table.py
+++ b/app/migrations/versions/202411181200_create_activity_events_table.py
@@ -1,0 +1,59 @@
+"""Create activity_events table for storing activity audit records."""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.engine import Connection
+
+revision = "202411181200"
+down_revision = "202411151200"
+branch_labels = None
+depends_on = None
+
+
+_TABLE = "activity_events"
+_INDEX = "ix_activity_events_type_status_timestamp"
+_JSON_TYPE = sa.JSON().with_variant(sa.Text(), "sqlite")
+
+
+def _has_table(connection: Connection, table_name: str) -> bool:
+    return connection.dialect.has_table(connection, table_name)
+
+
+def _index_names(connection: Connection, table_name: str) -> set[str]:
+    inspector = sa.inspect(connection)
+    return {index["name"] for index in inspector.get_indexes(table_name)}
+
+
+def upgrade() -> None:
+    connection = op.get_bind()
+
+    if not _has_table(connection, _TABLE):
+        op.create_table(
+            _TABLE,
+            sa.Column("id", sa.Integer(), primary_key=True),
+            sa.Column(
+                "timestamp",
+                sa.DateTime(),
+                nullable=False,
+                server_default=sa.func.now(),
+            ),
+            sa.Column("type", sa.String(length=128), nullable=False),
+            sa.Column("status", sa.String(length=128), nullable=False),
+            sa.Column("details", _JSON_TYPE, nullable=True),
+        )
+
+    existing_indexes = _index_names(connection, _TABLE) if _has_table(connection, _TABLE) else set()
+    if _INDEX not in existing_indexes:
+        op.create_index(_INDEX, _TABLE, ["type", "status", "timestamp"])
+
+
+def downgrade() -> None:
+    connection = op.get_bind()
+
+    if _has_table(connection, _TABLE):
+        existing_indexes = _index_names(connection, _TABLE)
+        if _INDEX in existing_indexes:
+            op.drop_index(_INDEX, table_name=_TABLE)
+        op.drop_table(_TABLE)


### PR DESCRIPTION
## Summary
- add an Alembic revision that creates the activity_events table with its composite index
- make session initialization always run migrations so fresh SQLite files include new tables

## Testing
- pytest tests/api/test_admin_artists.py
- pytest tests/migrations/test_upgrade_downgrade_postgres.py

No ToDo changes required.

------
https://chatgpt.com/codex/tasks/task_e_68e618c11c448321b31a3e2a6f4a9058