### PR TITLE
fix: respect psutil overrides in system stats

### DIFF
--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -5,6 +5,35 @@ from typing import Any
 from app.api import system as system_router_module
 
 
+class DummyStats:
+    def __init__(self, **values: Any) -> None:
+        self.__dict__.update(values)
+
+
+class DummyPsutil:
+    def __init__(self, cpu_percent_value: float) -> None:
+        self._cpu_percent_value = cpu_percent_value
+
+    def cpu_times_percent(self, interval=None, percpu=False):  # type: ignore[override]
+        return DummyStats(idle=70.0, user=20.0, system=10.0)
+
+    def virtual_memory(self):
+        return DummyStats(total=8, available=4, percent=50.0, used=3, free=1)
+
+    def disk_usage(self, path):
+        assert path == "/"
+        return DummyStats(total=100, used=40, free=60, percent=40.0)
+
+    def net_io_counters(self):
+        return DummyStats(bytes_sent=1, bytes_recv=2, packets_sent=3, packets_recv=4)
+
+    def cpu_percent(self, interval=None):  # type: ignore[override]
+        return self._cpu_percent_value
+
+    def cpu_count(self, logical=True):  # type: ignore[override]
+        return 8
+
+
 def test_status_endpoint_reports_workers(client) -> None:
     response = client.get("/status")
     assert response.status_code == 200
@@ -22,37 +51,9 @@ def test_status_endpoint_reports_workers(client) -> None:
 
 
 def test_system_stats_endpoint_uses_psutil(monkeypatch, client) -> None:
-    class DummyStats:
-        def __init__(self, **values: Any) -> None:
-            self.__dict__.update(values)
+    module_dummy = DummyPsutil(30.0)
 
-    class DummyPsutil:
-        @staticmethod
-        def cpu_times_percent(interval=None, percpu=False):  # type: ignore[override]
-            return DummyStats(idle=70.0, user=20.0, system=10.0)
-
-        @staticmethod
-        def virtual_memory():
-            return DummyStats(total=8, available=4, percent=50.0, used=3, free=1)
-
-        @staticmethod
-        def disk_usage(path):
-            assert path == "/"
-            return DummyStats(total=100, used=40, free=60, percent=40.0)
-
-        @staticmethod
-        def net_io_counters():
-            return DummyStats(bytes_sent=1, bytes_recv=2, packets_sent=3, packets_recv=4)
-
-        @staticmethod
-        def cpu_percent(interval=None):  # type: ignore[override]
-            return 30.0
-
-        @staticmethod
-        def cpu_count(logical=True):  # type: ignore[override]
-            return 8
-
-    monkeypatch.setattr(system_router_module, "psutil", DummyPsutil)
+    monkeypatch.setattr(system_router_module, "psutil", module_dummy)
 
     response = client.get("/system/stats")
     assert response.status_code == 200
@@ -62,3 +63,35 @@ def test_system_stats_endpoint_uses_psutil(monkeypatch, client) -> None:
     assert stats["memory"]["total"] == 8
     assert stats["disk"]["free"] == 60
     assert stats["network"]["bytes_recv"] == 2
+
+
+def test_system_stats_endpoint_uses_app_state_psutil_override(monkeypatch, client) -> None:
+    module_dummy = DummyPsutil(20.0)
+    state_dummy = DummyPsutil(45.0)
+
+    monkeypatch.setattr(system_router_module, "psutil", module_dummy)
+    monkeypatch.setattr(client.app.state, "psutil", state_dummy, raising=False)
+
+    response = client.get("/system/stats")
+    assert response.status_code == 200
+
+    stats = response.json()
+    assert stats["cpu"]["percent"] == 45.0
+
+
+def test_system_stats_endpoint_uses_dependency_override_psutil(monkeypatch, client) -> None:
+    module_dummy = DummyPsutil(10.0)
+    override_dummy = DummyPsutil(55.0)
+
+    monkeypatch.setattr(system_router_module, "psutil", module_dummy)
+    monkeypatch.setitem(
+        client.app.dependency_overrides,
+        system_router_module._resolve_psutil,
+        lambda request: override_dummy,
+    )
+
+    response = client.get("/system/stats")
+    assert response.status_code == 200
+
+    stats = response.json()
+    assert stats["cpu"]["percent"] == 55.0


### PR DESCRIPTION
## Summary
- allow the system stats endpoint to resolve psutil from dependency overrides or app state before falling back to the shim
- pass the incoming request to the psutil resolver so override sources are available
- extend the psutil-focused system tests to cover dependency override and state override scenarios

## Testing
- pytest tests/test_system.py -k psutil

No ToDo changes required.

------
https://chatgpt.com/codex/tasks/task_e_68e621d6f0e883219ed509d56ce7a964