### PR TITLE
chore: capture bandit scan evidence

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,4 +113,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install bandit==1.7.9
       - name: Security scan (Bandit)
-        run: bandit -c .bandit -r app
+        run: |
+          mkdir -p reports/analysis/_evidence
+          set -o pipefail
+          bandit -c .bandit -r app | tee reports/analysis/_evidence/bandit_app.txt

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,8 @@ security:
 ifeq ($(OFF),true)
 	@echo "⚠️ CI_OFFLINE=true → skipping security tools (bandit, pip-audit)."
 else
-	bandit -c .bandit -r app
+	@mkdir -p reports/analysis/_evidence
+	@bash -c "set -o pipefail; bandit -c .bandit -r app | tee reports/analysis/_evidence/bandit_app.txt"
 	pip-audit -r requirements.txt || true
 endif
 

--- a/README.md
+++ b/README.md
@@ -364,6 +364,9 @@ Der Security-Scan blockt unsichere Muster frühzeitig. `bandit -c .bandit -r app
 Severity/Confidence) und entspricht dem verpflichtenden CI-Gate. Führe den Scan vor jedem Commit lokal aus, damit Findings
 gar nicht erst im Pull Request landen.
 
+Die Ausgabe landet zusätzlich in `reports/analysis/_evidence/bandit_app.txt`, sodass Sicherheitsnachweise versioniert werden
+können. `make security` erzeugt die Datei automatisch und aktualisiert sie bei jeder Ausführung.
+
 ## Datenbank-Migrationen
 
 - `make db.upgrade` führt `alembic upgrade head` aus und wendet alle offenen Migrationen auf die konfigurierte Datenbank an.

--- a/ToDo.md
+++ b/ToDo.md
@@ -151,12 +151,12 @@
   - [x] CODX-P2-TOOL-318 — Apply isort formatting and wire checks into CI.
 
 ## TD-20251008-009 Reinstate bandit security scanning
-- **Status:** todo
+- **Status:** in-progress
 - **Priority:** P2
 - **Scope:** backend
 - **Owner:** codex
 - **Created_at (UTC):** 2025-10-08T06:52:42Z
-- **Updated_at (UTC):** 2025-10-08T06:52:42Z
+- **Updated_at (UTC):** 2025-10-08T09:45:00Z
 - **Tags:** security, tooling
 - **Description:** `bandit` is not installed in the tooling environment, so security scans silently skip the backend. 【F:reports/analysis/backend_deep_scan.md†L72-L76】【2a7069†L1-L1】
 - **Acceptance Criteria:**
@@ -167,4 +167,5 @@
 - **Dependencies:** TD-20251008-008 (align tooling updates).
 - **References:** CODX-P0-ANLY-500; `reports/analysis/backend_deep_scan.md`; `reports/analysis/_evidence/bandit_app.txt`. 【F:reports/analysis/backend_deep_scan.md†L72-L76】【F:reports/analysis/_evidence/bandit_app.txt†L1-L1】
 - **Subtasks:**
-  - [ ] CODX-P2-SEC-319 — Add bandit dependency, configure baseline, and integrate with CI.
+  - [x] CODX-P2-SEC-319 — Add bandit dependency, configure baseline, and integrate with CI (Makefile + CI tee output to `reports/analysis/_evidence/bandit_app.txt`).
+  - [ ] CODX-P1-SEC-401 — Provide offline Bandit wheel and capture first-run findings so high-severity issues can be triaged.

--- a/docs/code_health_report.md
+++ b/docs/code_health_report.md
@@ -12,7 +12,7 @@
 | `black --check .` | ✅ | No formatting drift detected. |
 | `mypy app` | ✅ | Strict settings honoured; no untyped defs in `app/**`. |
 | `pytest -q` | ✅ | Full suite passes; FastAPI lifespan migration eliminates prior `on_event` warnings. |
-| `bandit -q -r app` | ⚠️ | Tool not installed and cannot be fetched because the execution environment blocks outbound package downloads. |
+| `bandit -q -r app` | ⚠️ | Pinned in `requirements-dev.txt` and wired into CI/`make security`; offline environments still need a vendored wheel before the scan can run. Evidence is written to `reports/analysis/_evidence/bandit_app.txt`. |
 | `vulture app tests --exclude .venv` | ⚠️ | Binary unavailable in the offline environment; cannot verify dead-code findings without vendored wheel. |
 | `radon cc -s -a app` | ⚠️ | CLI missing and pip installation is blocked; recommend bundling radon for deterministic local runs. |
 | `pip-audit` | ⚠️ | Not installable offline; dependency audit deferred. |

--- a/reports/analysis/_evidence/bandit_app.txt
+++ b/reports/analysis/_evidence/bandit_app.txt
@@ -1,1 +1,1 @@
-bash: command not found: bandit
+Bandit scan pending: install dependencies from requirements-dev.txt and rerun `make security` to refresh this evidence file.

--- a/reports/analysis/project_completion_status.md
+++ b/reports/analysis/project_completion_status.md
@@ -17,5 +17,5 @@
 - **Coverage:** Execute `pytest --cov=app/schemas/common.py --cov-report=term-missing` to regenerate the coverage artefact for the
   updated schema helpers.
 - **Lint/Type/Bandit:** All gates run as dedicated steps in the `backend` job (`ruff check .`, `black --check .`, `mypy app`,
-  `bandit -r app`).
+  `bandit -r app`). Bandit output is archived at `reports/analysis/_evidence/bandit_app.txt` via CI and `make security`.
 - **OpenAPI drift:** The `openapi` job compares the generated schema gegen `tests/snapshots/openapi.json` and fails on drift.


### PR DESCRIPTION
## Summary
- persist Bandit output in both the Makefile security target and the CI workflow under reports/analysis/_evidence/bandit_app.txt
- document the evidence location in the README and analysis docs and update the ToDo entry with the follow-up for an offline Bandit wheel

## Testing
- ⚠️ `pip install -r requirements-dev.txt` *(fails: environment blocks outbound package downloads, so Bandit is not yet runnable locally)*

------
https://chatgpt.com/codex/tasks/task_e_68e62e502770832181b0220db7fff80a