### PR TITLE
feat: add direct Spotify FREE links ingestion endpoint [CODX-P1-SPOT-520]

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Imports ohne Spotify-Credentials. Der Modus wird per `GET/POST /spotify/mode` ve
 Im FREE-Modus stehen neben den Parser-Endpunkten (`/spotify/free/*`) auch die Free-Ingest-Schnittstellen zur Verfügung:
 
 - `POST /spotify/import/free` akzeptiert bis zu 100 Playlist-Links (`open.spotify.com`) sowie umfangreiche Tracklisten aus dem Request-Body, normalisiert Artist/Titel/Album/Dauer und legt persistente `ingest_jobs`/`ingest_items` an.
+- `POST /spotify/free/links` erlaubt die direkte Eingabe einzelner oder mehrerer Playlist-Links/URIs, extrahiert die Playlist-ID, dedupliziert bereits laufende Jobs und stößt denselben Free-Ingest-Flow an (Response mit `accepted`/`skipped`).
 - `POST /spotify/import/free/upload` nimmt `multipart/form-data` (CSV/TXT/JSON) entgegen, parst serverseitig in Tracks und ruft intern den Free-Ingest-Service auf.
 - `GET /spotify/import/jobs/{job_id}` liefert den Job-Status inklusive Zählern (`registered`, `normalized`, `queued`, `failed`, `completed`) sowie Skip-Gründen.
 

--- a/app/api/router_registry.py
+++ b/app/api/router_registry.py
@@ -180,7 +180,7 @@ def register_all(
 # Built-in router registrations
 # ---------------------------------------------------------------------------
 
-from app.api import artists, search, spotify, system, watchlist  # noqa: E402
+from app.api import artists, search, spotify, spotify_free_links, system, watchlist  # noqa: E402
 from app.routers import (activity_router, dlq_router,  # noqa: E402
                          download_router, health_router, imports_router,
                          integrations_router, matching_router, metadata_router,
@@ -198,6 +198,7 @@ register_router("sync", sync_router)
 register_domain("system", system.router, tags=())
 register_router("download", download_router)
 register_router("activity", activity_router)
+register_router("spotify_free_links", spotify_free_links.router)
 register_router("integrations", integrations_router)
 register_router("health", health_router, prefix="/health", tags=("Health",))
 register_domain("watchlist", watchlist.router, prefix="", tags=())

--- a/app/api/spotify_free_links.py
+++ b/app/api/spotify_free_links.py
@@ -1,0 +1,215 @@
+"""API router providing direct Spotify FREE playlist ingestion."""
+
+from __future__ import annotations
+
+from time import perf_counter
+from typing import Any
+from urllib.parse import urlparse
+
+from fastapi import APIRouter, Depends, Request, status
+
+from app.dependencies import (
+    SessionRunner,
+    get_app_config,
+    get_session_runner,
+    get_soulseek_client,
+)
+from app.errors import (
+    AppError,
+    InternalServerError,
+    RateLimitedError,
+    ValidationAppError,
+)
+from app.logging import get_logger
+from app.logging_events import log_event
+from app.schemas.spotify_free_links import (
+    AcceptedPlaylist,
+    FreeLinksRequest,
+    FreeLinksResponse,
+    SkippedPlaylist,
+)
+from app.services.free_ingest_service import FreeIngestService, PlaylistEnqueueResult
+from app.utils.spotify_url import parse_playlist_id
+
+router = APIRouter(prefix="/spotify/free", tags=["Spotify FREE Links"])
+_logger = get_logger(__name__)
+
+
+def get_free_ingest_service(
+    config=Depends(get_app_config),
+    soulseek_client=Depends(get_soulseek_client),
+    session_runner: SessionRunner = Depends(get_session_runner),
+) -> FreeIngestService:
+    return FreeIngestService(
+        config=config,
+        soulseek_client=soulseek_client,
+        sync_worker=None,
+        session_runner=session_runner,
+    )
+
+
+def _emit_api_event(
+    request: Request,
+    *,
+    status_code: int,
+    status_value: str,
+    duration_ms: float,
+    error: str | None = None,
+    meta: dict[str, Any] | None = None,
+) -> None:
+    payload: dict[str, Any] = {
+        "component": "api.spotify.free_links",
+        "status": status_value,
+        "method": request.method,
+        "path": request.url.path,
+        "status_code": status_code,
+        "duration_ms": round(duration_ms, 3),
+        "entity_id": getattr(request.state, "request_id", None),
+    }
+    if error:
+        payload["error"] = error
+    if meta:
+        payload["meta"] = meta
+    log_event(_logger, "api.request", **payload)
+
+
+def _classify_invalid_reason(raw_url: str) -> str:
+    text = (raw_url or "").strip()
+    if text.lower().startswith("spotify:"):
+        parts = text.split(":", 2)
+        if len(parts) >= 2 and parts[1].lower() != "playlist":
+            return "non_playlist"
+        return "invalid"
+
+    parsed = urlparse(text)
+    if parsed.scheme not in {"http", "https"}:
+        return "invalid"
+    if parsed.netloc.lower() != "open.spotify.com":
+        return "invalid"
+    segments = [segment for segment in parsed.path.split("/") if segment]
+    if segments and segments[0].lower().startswith("intl-"):
+        segments = segments[1:]
+    if not segments:
+        return "invalid"
+    if segments[0].lower() != "playlist":
+        return "non_playlist"
+    return "invalid"
+
+
+def _canonical_playlist_url(playlist_id: str) -> str:
+    return f"https://open.spotify.com/playlist/{playlist_id}"
+
+
+@router.post("/links", response_model=FreeLinksResponse)
+async def submit_playlist_links(
+    payload: FreeLinksRequest,
+    request: Request,
+    service: FreeIngestService = Depends(get_free_ingest_service),
+) -> FreeLinksResponse:
+    started = perf_counter()
+    raw_urls = list(payload.iter_urls())
+    if not raw_urls:
+        raise ValidationAppError("url or urls must be provided")
+
+    accepted: list[AcceptedPlaylist] = []
+    skipped: list[SkippedPlaylist] = []
+    unique_ids: list[str] = []
+    origin_map: dict[str, str] = {}
+    seen: set[str] = set()
+
+    for raw in raw_urls:
+        text = (raw or "").strip()
+        if not text:
+            skipped.append(SkippedPlaylist(url=raw, reason="invalid"))
+            continue
+        playlist_id = parse_playlist_id(text)
+        if playlist_id is None:
+            reason = _classify_invalid_reason(text)
+            skipped.append(SkippedPlaylist(url=raw, reason=reason))
+            continue
+        if playlist_id in seen:
+            skipped.append(SkippedPlaylist(url=raw, reason="duplicate"))
+            continue
+        seen.add(playlist_id)
+        origin_map[playlist_id] = raw
+        unique_ids.append(playlist_id)
+
+    if unique_ids:
+        try:
+            outcome = await service.enqueue_playlists(unique_ids)
+        except AppError as exc:
+            duration_ms = (perf_counter() - started) * 1000
+            _emit_api_event(
+                request,
+                status_code=exc.http_status,
+                status_value="error",
+                duration_ms=duration_ms,
+                error=exc.code,
+                meta={"accepted": 0, "skipped": len(skipped)},
+            )
+            raise
+        except Exception as exc:  # pragma: no cover - defensive guard
+            duration_ms = (perf_counter() - started) * 1000
+            _emit_api_event(
+                request,
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                status_value="error",
+                duration_ms=duration_ms,
+                error="unexpected_error",
+                meta={"accepted": 0, "skipped": len(skipped)},
+            )
+            raise InternalServerError("Failed to enqueue playlists.") from exc
+    else:
+        outcome = PlaylistEnqueueResult(accepted_ids=[], duplicate_ids=[])
+
+    if outcome.error == "backpressure":
+        duration_ms = (perf_counter() - started) * 1000
+        rate_error = RateLimitedError("Too many ingest jobs in progress.")
+        _emit_api_event(
+            request,
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            status_value="error",
+            duration_ms=duration_ms,
+            error=rate_error.code,
+            meta={"accepted": 0, "skipped": len(skipped)},
+        )
+        raise rate_error
+
+    accepted_ids = set(outcome.accepted_ids)
+    duplicate_ids = set(outcome.duplicate_ids)
+
+    for playlist_id in unique_ids:
+        if playlist_id in accepted_ids:
+            accepted.append(
+                AcceptedPlaylist(
+                    playlist_id=playlist_id,
+                    url=_canonical_playlist_url(playlist_id),
+                )
+            )
+        else:
+            skipped.append(
+                SkippedPlaylist(
+                    url=origin_map.get(playlist_id, _canonical_playlist_url(playlist_id)),
+                    reason="duplicate",
+                )
+            )
+
+    extra_duplicates = duplicate_ids.difference(seen)
+    for playlist_id in extra_duplicates:
+        skipped.append(
+            SkippedPlaylist(
+                url=_canonical_playlist_url(playlist_id),
+                reason="duplicate",
+            )
+        )
+
+    response = FreeLinksResponse(accepted=accepted, skipped=skipped)
+    duration_ms = (perf_counter() - started) * 1000
+    _emit_api_event(
+        request,
+        status_code=status.HTTP_200_OK,
+        status_value="ok",
+        duration_ms=duration_ms,
+        meta={"accepted": len(response.accepted), "skipped": len(response.skipped)},
+    )
+    return response

--- a/app/schemas/spotify_free_links.py
+++ b/app/schemas/spotify_free_links.py
@@ -1,0 +1,42 @@
+"""Pydantic models for the Spotify FREE links endpoint."""
+
+from __future__ import annotations
+
+from typing import Iterable, List, Literal, Sequence
+
+from pydantic import BaseModel, Field
+
+
+class FreeLinksRequest(BaseModel):
+    """Input payload accepting a single URL or multiple URLs."""
+
+    url: str | None = Field(default=None, description="Single Spotify playlist link")
+    urls: Sequence[str] | None = Field(
+        default=None, description="Collection of Spotify playlist links"
+    )
+
+    def _collect_urls(self) -> List[str]:
+        values: List[str] = []
+        if self.url is not None:
+            values.append(self.url)
+        if self.urls is not None:
+            values.extend(self.urls)
+        return values
+
+    def iter_urls(self) -> Iterable[str]:
+        return list(self._collect_urls())
+
+
+class AcceptedPlaylist(BaseModel):
+    playlist_id: str = Field(..., description="Normalized Spotify playlist identifier")
+    url: str = Field(..., description="Canonical Spotify playlist URL")
+
+
+class SkippedPlaylist(BaseModel):
+    url: str = Field(..., description="Original URL submitted by the user")
+    reason: Literal["duplicate", "invalid", "non_playlist"] = Field(...)
+
+
+class FreeLinksResponse(BaseModel):
+    accepted: List[AcceptedPlaylist] = Field(default_factory=list)
+    skipped: List[SkippedPlaylist] = Field(default_factory=list)

--- a/app/utils/spotify_url.py
+++ b/app/utils/spotify_url.py
@@ -1,0 +1,46 @@
+"""Utilities for working with Spotify URLs and URIs."""
+
+from __future__ import annotations
+
+from typing import Final
+from urllib.parse import urlparse
+
+_PLAYLIST_URI_PREFIX: Final[str] = "spotify:playlist:"
+_ALLOWED_HOST: Final[str] = "open.spotify.com"
+
+
+def parse_playlist_id(url_or_uri: str | None) -> str | None:
+    """Extract a playlist identifier from a Spotify URL or URI.
+
+    Args:
+        url_or_uri: Raw input provided by the user. Supports Spotify playlist
+            share URLs (``https://open.spotify.com/playlist/{id}``) and Spotify
+            URIs (``spotify:playlist:{id}``). Query parameters and fragments are
+            ignored. Returns ``None`` when the input does not represent a
+            playlist link or when the identifier contains invalid characters.
+    """
+
+    if not url_or_uri:
+        return None
+    candidate = url_or_uri.strip()
+    if not candidate:
+        return None
+
+    if candidate.lower().startswith(_PLAYLIST_URI_PREFIX):
+        playlist_id = candidate[len(_PLAYLIST_URI_PREFIX) :]
+        return playlist_id if playlist_id.isalnum() else None
+
+    parsed = urlparse(candidate)
+    if parsed.scheme not in {"http", "https"}:
+        return None
+    if parsed.netloc.lower() != _ALLOWED_HOST:
+        return None
+
+    segments = [segment for segment in parsed.path.split("/") if segment]
+    if segments and segments[0].lower().startswith("intl-"):
+        segments = segments[1:]
+    if len(segments) < 2 or segments[0].lower() != "playlist":
+        return None
+
+    playlist_id = segments[1].split("?")[0].split("#")[0]
+    return playlist_id if playlist_id.isalnum() else None

--- a/tests/api/test_router_registry.py
+++ b/tests/api/test_router_registry.py
@@ -62,6 +62,7 @@ def test_full_registry_matches_expected_configuration() -> None:
         "system",
         "download",
         "activity",
+        "spotify_free_links",
         "integrations",
         "health",
         "watchlist",

--- a/tests/api/test_spotify_free_links.py
+++ b/tests/api/test_spotify_free_links.py
@@ -1,0 +1,214 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, Callable
+
+import pytest
+from fastapi import FastAPI, Request
+
+from app.api import spotify_free_links as free_links_module
+from app.api.spotify_free_links import get_free_ingest_service
+from app.errors import AppError
+from tests.simple_client import SimpleTestClient
+
+
+class StubFreeIngestService:
+    def __init__(self) -> None:
+        self.calls: list[list[str]] = []
+        self._result = SimpleNamespace(accepted_ids=[], duplicate_ids=[], error=None)
+
+    def set_result(
+        self,
+        *,
+        accepted_ids: list[str] | None = None,
+        duplicate_ids: list[str] | None = None,
+        error: str | None = None,
+    ) -> None:
+        self._result = SimpleNamespace(
+            accepted_ids=list(accepted_ids or []),
+            duplicate_ids=list(duplicate_ids or []),
+            error=error,
+        )
+
+    async def enqueue_playlists(self, playlist_ids: list[str]) -> SimpleNamespace:
+        self.calls.append(list(playlist_ids))
+        return SimpleNamespace(
+            accepted_ids=list(self._result.accepted_ids),
+            duplicate_ids=list(self._result.duplicate_ids),
+            error=self._result.error,
+        )
+
+
+@pytest.fixture
+def client() -> Callable[[StubFreeIngestService], SimpleTestClient]:
+    instances: list[SimpleTestClient] = []
+
+    def _factory(stub: StubFreeIngestService) -> SimpleTestClient:
+        test_app = FastAPI()
+        
+        @test_app.exception_handler(AppError)
+        async def _handle_app_error(request: Request, exc: AppError):
+            return exc.as_response(request_path=request.url.path, method=request.method)
+
+        test_app.include_router(free_links_module.router, prefix="/api/v1")
+        test_app.dependency_overrides[get_free_ingest_service] = lambda: stub
+        context = SimpleTestClient(test_app)
+        client_instance = context.__enter__()
+        instances.append(context)
+        return client_instance
+
+    yield _factory
+
+    while instances:
+        context = instances.pop()
+        context.__exit__(None, None, None)
+
+
+def test_accepts_single_and_multiple_urls(
+    client: Callable[[StubFreeIngestService], SimpleTestClient]
+) -> None:
+    stub = StubFreeIngestService()
+    stub.set_result(accepted_ids=["AAA"])
+    test_client = client(stub)
+
+    response = test_client.post(
+        "/api/v1/spotify/free/links",
+        json={"url": "https://open.spotify.com/playlist/AAA?si=123"},
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["accepted"] == [
+        {"playlist_id": "AAA", "url": "https://open.spotify.com/playlist/AAA"}
+    ]
+    assert body["skipped"] == []
+    assert stub.calls[0] == ["AAA"]
+
+    stub.set_result(accepted_ids=["BBB", "CCC"])
+    response = test_client.post(
+        "/api/v1/spotify/free/links",
+        json={"urls": ["https://open.spotify.com/playlist/BBB", "spotify:playlist:CCC"]},
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert {
+        (entry["playlist_id"], entry["url"]) for entry in body["accepted"]
+    } == {
+        ("BBB", "https://open.spotify.com/playlist/BBB"),
+        ("CCC", "https://open.spotify.com/playlist/CCC"),
+    }
+    assert body["skipped"] == []
+
+
+def test_rejects_non_playlist_urls_and_malformed_inputs(
+    client: Callable[[StubFreeIngestService], SimpleTestClient]
+) -> None:
+    stub = StubFreeIngestService()
+    test_client = client(stub)
+
+    response = test_client.post(
+        "/api/v1/spotify/free/links",
+        json={
+            "urls": [
+                "https://example.com/not-spotify",
+                "spotify:track:abc123",
+                "",
+            ]
+        },
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["accepted"] == []
+    skipped = {(entry["url"], entry["reason"]) for entry in body["skipped"]}
+    assert skipped == {
+        ("https://example.com/not-spotify", "invalid"),
+        ("spotify:track:abc123", "non_playlist"),
+        ("", "invalid"),
+    }
+    assert stub.calls == []
+
+    empty_response = test_client.post(
+        "/api/v1/spotify/free/links",
+        json={"urls": []},
+    )
+    assert empty_response.status_code == 400
+    assert empty_response.json()["error"]["code"] == "VALIDATION_ERROR"
+
+
+def test_deduplicates_by_playlist_id(
+    client: Callable[[StubFreeIngestService], SimpleTestClient]
+) -> None:
+    stub = StubFreeIngestService()
+    stub.set_result(accepted_ids=["AAA"])
+    test_client = client(stub)
+
+    response = test_client.post(
+        "/api/v1/spotify/free/links",
+        json={
+            "urls": [
+                "https://open.spotify.com/playlist/AAA?si=123",
+                "spotify:playlist:AAA",
+            ]
+        },
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["accepted"] == [
+        {"playlist_id": "AAA", "url": "https://open.spotify.com/playlist/AAA"}
+    ]
+    assert body["skipped"] == [
+        {"url": "spotify:playlist:AAA", "reason": "duplicate"}
+    ]
+    assert stub.calls[0] == ["AAA"]
+
+
+def test_enqueues_via_free_ingest_service(
+    client: Callable[[StubFreeIngestService], SimpleTestClient]
+) -> None:
+    stub = StubFreeIngestService()
+    stub.set_result(accepted_ids=["AAA"], duplicate_ids=["BBB"])
+    test_client = client(stub)
+
+    response = test_client.post(
+        "/api/v1/spotify/free/links",
+        json={
+            "urls": [
+                "https://open.spotify.com/playlist/AAA",
+                "https://open.spotify.com/playlist/BBB",
+            ]
+        },
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["accepted"] == [
+        {"playlist_id": "AAA", "url": "https://open.spotify.com/playlist/AAA"}
+    ]
+    assert body["skipped"] == [
+        {"url": "https://open.spotify.com/playlist/BBB", "reason": "duplicate"}
+    ]
+    assert stub.calls[0] == ["AAA", "BBB"]
+
+
+def test_logs_api_request_event(
+    client: Callable[[StubFreeIngestService], SimpleTestClient],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stub = StubFreeIngestService()
+    stub.set_result(accepted_ids=["AAA"])
+    captured: list[str] = []
+
+    original_log_event = free_links_module.log_event
+
+    def _capture(event_logger: Any, event_name: str, /, **fields: Any) -> None:
+        captured.append(event_name)
+        original_log_event(event_logger, event_name, **fields)
+
+    monkeypatch.setattr(free_links_module, "log_event", _capture)
+    test_client = client(stub)
+
+    response = test_client.post(
+        "/api/v1/spotify/free/links",
+        json={"url": "https://open.spotify.com/playlist/AAA"},
+    )
+
+    assert response.status_code == 200
+    assert "api.request" in captured


### PR DESCRIPTION
## Summary
- add a dedicated router that exposes POST /spotify/free/links for playlist URL ingestion with validation, logging, and enqueueing via the FreeIngestService
- provide schemas and playlist URL parsing utilities plus service support for deduplicated enqueueing and worker logging
- document the new API entry point and cover router registration alongside a focused test suite for the endpoint

## Testing
- pytest tests/api/test_spotify_free_links.py
- pytest tests/e2e/test_artist_flow.py::test_artist_flow_happy_path_persists_and_exposes_via_api
- pytest -q *(fails: numerous pre-existing orchestrator/watchlist assertions unrelated to the new endpoint)*
- mypy app
- ruff check . *(fails: repository-wide import-order violations predating this change)*
- black --check . *(fails: repository-wide formatting drift predating this change)*

------
https://chatgpt.com/codex/tasks/task_e_68e63a39cae08321b0addc78d8df6691