### PR TITLE
fix: allow user-scoped playlist URLs in free links ingestion

### DIFF
--- a/app/utils/spotify_url.py
+++ b/app/utils/spotify_url.py
@@ -6,18 +6,26 @@ from typing import Final
 from urllib.parse import urlparse
 
 _PLAYLIST_URI_PREFIX: Final[str] = "spotify:playlist:"
+_USER_URI_PREFIX: Final[str] = "spotify:user:"
 _ALLOWED_HOST: Final[str] = "open.spotify.com"
 
 
-def parse_playlist_id(url_or_uri: str | None) -> str | None:
+def parse_playlist_id(
+    url_or_uri: str | None,
+    *,
+    allow_user_urls: bool = False,
+) -> str | None:
     """Extract a playlist identifier from a Spotify URL or URI.
 
     Args:
         url_or_uri: Raw input provided by the user. Supports Spotify playlist
             share URLs (``https://open.spotify.com/playlist/{id}``) and Spotify
-            URIs (``spotify:playlist:{id}``). Query parameters and fragments are
-            ignored. Returns ``None`` when the input does not represent a
-            playlist link or when the identifier contains invalid characters.
+            URIs (``spotify:playlist:{id}``). When ``allow_user_urls`` is set to
+            ``True`` the legacy ``/user/{user_id}/playlist/{id}`` URL and
+            ``spotify:user:{user_id}:playlist:{id}`` URI formats are also
+            accepted. Query parameters and fragments are ignored. Returns
+            ``None`` when the input does not represent a playlist link or when
+            the identifier contains invalid characters.
     """
 
     if not url_or_uri:
@@ -26,8 +34,19 @@ def parse_playlist_id(url_or_uri: str | None) -> str | None:
     if not candidate:
         return None
 
-    if candidate.lower().startswith(_PLAYLIST_URI_PREFIX):
+    lowered = candidate.lower()
+
+    if lowered.startswith(_PLAYLIST_URI_PREFIX):
         playlist_id = candidate[len(_PLAYLIST_URI_PREFIX) :]
+        return playlist_id if playlist_id.isalnum() else None
+
+    if allow_user_urls and lowered.startswith(_USER_URI_PREFIX):
+        parts = candidate.split(":")
+        if len(parts) < 5:
+            return None
+        if parts[3].lower() != "playlist":
+            return None
+        playlist_id = parts[4]
         return playlist_id if playlist_id.isalnum() else None
 
     parsed = urlparse(candidate)
@@ -39,8 +58,14 @@ def parse_playlist_id(url_or_uri: str | None) -> str | None:
     segments = [segment for segment in parsed.path.split("/") if segment]
     if segments and segments[0].lower().startswith("intl-"):
         segments = segments[1:]
-    if len(segments) < 2 or segments[0].lower() != "playlist":
-        return None
+    if len(segments) >= 2 and segments[0].lower() == "playlist":
+        playlist_id = segments[1].split("?")[0].split("#")[0]
+        return playlist_id if playlist_id.isalnum() else None
 
-    playlist_id = segments[1].split("?")[0].split("#")[0]
-    return playlist_id if playlist_id.isalnum() else None
+    if allow_user_urls and len(segments) >= 4 and segments[0].lower() == "user":
+        if segments[2].lower() != "playlist":
+            return None
+        playlist_id = segments[3].split("?")[0].split("#")[0]
+        return playlist_id if playlist_id.isalnum() else None
+
+    return None


### PR DESCRIPTION
## Summary
- allow the Spotify URL parser to accept legacy user-scoped playlist URLs when enabled
- thread the configuration flag through the Spotify FREE links endpoint and adjust invalid classification
- cover acceptance of user playlist URLs with new API tests

## Testing
- pytest tests/api/test_spotify_free_links.py

------
https://chatgpt.com/codex/tasks/task_e_68e64bffbaac83218ed82dbccb7f7836